### PR TITLE
formatutils: ensure we dont leak name ptr

### DIFF
--- a/src/utils/FormatUtils.cpp
+++ b/src/utils/FormatUtils.cpp
@@ -3,6 +3,8 @@
 #include <xf86drm.h>
 
 std::string fourccToName(uint32_t drmFormat) {
-    auto fmt = drmGetFormatName(drmFormat);
-    return fmt ? fmt : "unknown";
+    auto        fmt  = drmGetFormatName(drmFormat);
+    std::string name = fmt ? fmt : "unknown";
+    free(fmt);
+    return name;
 }


### PR DESCRIPTION
store format name in a std::string and free the char ptr to ensure we dont leak on each call to drmGetFormatName.