### PR TITLE
Add  scheduleFrame reasons

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -187,7 +187,7 @@ namespace Aquamarine {
         virtual Hyprutils::Memory::CSharedPointer<IBackendImplementation> getBackend();
         virtual bool                                                      setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot);
         virtual void                                                      moveCursor(const Hyprutils::Math::Vector2D& coord);
-        virtual void                                                      scheduleFrame();
+        virtual void                                                      scheduleFrame(const scheduleFrameReason reason = AQ_SCHEDULE_UNKNOWN);
         virtual void                                                      setCursorVisible(bool visible);
         virtual Hyprutils::Math::Vector2D                                 cursorPlaneSize();
         virtual size_t                                                    getGammaSize();

--- a/include/aquamarine/backend/Headless.hpp
+++ b/include/aquamarine/backend/Headless.hpp
@@ -15,7 +15,7 @@ namespace Aquamarine {
         virtual bool                                                      commit();
         virtual bool                                                      test();
         virtual Hyprutils::Memory::CSharedPointer<IBackendImplementation> getBackend();
-        virtual void                                                      scheduleFrame();
+        virtual void                                                      scheduleFrame(const scheduleFrameReason reason = AQ_SCHEDULE_UNKNOWN);
         virtual bool                                                      destroy();
 
         Hyprutils::Memory::CWeakPointer<CHeadlessOutput>                  self;

--- a/include/aquamarine/backend/Wayland.hpp
+++ b/include/aquamarine/backend/Wayland.hpp
@@ -46,7 +46,7 @@ namespace Aquamarine {
         virtual Hyprutils::Memory::CSharedPointer<IBackendImplementation> getBackend();
         virtual bool                                                      setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot);
         virtual void                                                      moveCursor(const Hyprutils::Math::Vector2D& coord);
-        virtual void                                                      scheduleFrame();
+        virtual void                                                      scheduleFrame(const scheduleFrameReason reason = AQ_SCHEDULE_UNKNOWN);
         virtual Hyprutils::Math::Vector2D                                 cursorPlaneSize();
         virtual bool                                                      destroy();
 

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -100,6 +100,19 @@ namespace Aquamarine {
             ;
         }
 
+        enum scheduleFrameReason : uint32_t {
+            AQ_SCHEDULE_UNKNOWN = 0,
+            AQ_SCHEDULE_NEW_CONNECTOR,
+            AQ_SCHEDULE_CURSOR_VISIBLE,
+            AQ_SCHEDULE_CURSOR_SHAPE,
+            AQ_SCHEDULE_CURSOR_MOVE,
+            AQ_SCHEDULE_CLIENT_UNKNOWN,
+            AQ_SCHEDULE_DAMAGE,
+            AQ_SCHEDULE_NEW_MONITOR,
+            AQ_SCHEDULE_RENDER_MONITOR,
+            AQ_SCHEDULE_NEEDS_FRAME,
+        };
+
         virtual bool                                                      commit()     = 0;
         virtual bool                                                      test()       = 0;
         virtual Hyprutils::Memory::CSharedPointer<IBackendImplementation> getBackend() = 0;
@@ -108,7 +121,7 @@ namespace Aquamarine {
         virtual void                                                      moveCursor(const Hyprutils::Math::Vector2D& coord); // includes the hotspot
         virtual void                                                      setCursorVisible(bool visible); // moving the cursor will make it visible again without this util
         virtual Hyprutils::Math::Vector2D                                 cursorPlaneSize();              // -1, -1 means no set size, 0, 0 means error
-        virtual void                                                      scheduleFrame();
+        virtual void                                                      scheduleFrame(const scheduleFrameReason reason = AQ_SCHEDULE_UNKNOWN);
         virtual size_t                                                    getGammaSize();
         virtual bool                                                      destroy(); // not all backends allow this!!!
 

--- a/src/backend/Headless.cpp
+++ b/src/backend/Headless.cpp
@@ -3,6 +3,7 @@
 #include <time.h>
 #include <sys/timerfd.h>
 #include <string.h>
+#include "Shared.hpp"
 
 using namespace Aquamarine;
 using namespace Hyprutils::Memory;
@@ -53,7 +54,9 @@ Hyprutils::Memory::CSharedPointer<IBackendImplementation> Aquamarine::CHeadlessO
     return backend.lock();
 }
 
-void Aquamarine::CHeadlessOutput::scheduleFrame() {
+void Aquamarine::CHeadlessOutput::scheduleFrame(const scheduleFrameReason reason) {
+    TRACE(backend->backend->log(AQ_LOG_TRACE,
+                                std::format("CHeadlessOutput::scheduleFrame: reason {}, needsFrame {}, frameScheduled {}", (uint32_t)reason, needsFrame, frameScheduled)));
     // FIXME: limit fps to the committed framerate.
     needsFrame = true;
 

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -722,7 +722,9 @@ Hyprutils::Math::Vector2D Aquamarine::CWaylandOutput::cursorPlaneSize() {
     return {-1, -1}; // no limit
 }
 
-void Aquamarine::CWaylandOutput::scheduleFrame() {
+void Aquamarine::CWaylandOutput::scheduleFrame(const scheduleFrameReason reason) {
+    TRACE(backend->backend->log(AQ_LOG_TRACE,
+                                std::format("CWaylandOutput::scheduleFrame: reason {}, needsFrame {}, frameScheduled {}", (uint32_t)reason, needsFrame, frameScheduled)));
     needsFrame = true;
 
     if (frameScheduled)

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -4,6 +4,7 @@
 #include <xf86drmMode.h>
 #include <sys/mman.h>
 #include "Shared.hpp"
+#include "aquamarine/output/Output.hpp"
 
 using namespace Aquamarine;
 using namespace Hyprutils::Memory;
@@ -323,7 +324,7 @@ bool Aquamarine::CDRMAtomicImpl::moveCursor(SP<SDRMConnector> connector) {
         return true;
 
     connector->output->needsFrame = true;
-    connector->output->scheduleFrame();
+    connector->output->scheduleFrame(IOutput::AQ_SCHEDULE_CURSOR_MOVE);
 
     return true;
 }

--- a/src/backend/drm/impl/Legacy.cpp
+++ b/src/backend/drm/impl/Legacy.cpp
@@ -1,3 +1,4 @@
+#include "aquamarine/output/Output.hpp"
 #include <aquamarine/backend/drm/Legacy.hpp>
 #include <cstring>
 #include <xf86drm.h>
@@ -18,7 +19,7 @@ bool Aquamarine::CDRMLegacyImpl::moveCursor(Hyprutils::Memory::CSharedPointer<SD
         return true;
 
     connector->output->needsFrame = true;
-    connector->output->scheduleFrame();
+    connector->output->scheduleFrame(IOutput::AQ_SCHEDULE_CURSOR_MOVE);
 
     return true;
 }

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -23,7 +23,7 @@ void Aquamarine::IOutput::setCursorVisible(bool visible) {
     ;
 }
 
-void Aquamarine::IOutput::scheduleFrame() {
+void Aquamarine::IOutput::scheduleFrame(const scheduleFrameReason reason) {
     ;
 }
 


### PR DESCRIPTION
Adds an optional `scheduleFrameReason` argument to `scheduleFrame`. Now it is used for tracing only. Later it can be used for stuff like `cursor:no_break_fs_vrr`