### PR TITLE
Fix cursor swapchain buffer creation

### DIFF
--- a/src/allocator/GBM.cpp
+++ b/src/allocator/GBM.cpp
@@ -53,7 +53,8 @@ static SDRMFormat guessFormatFrom(std::vector<SDRMFormat> formats, bool cursor) 
 }
 
 Aquamarine::CGBMBuffer::CGBMBuffer(const SAllocatorBufferParams& params, Hyprutils::Memory::CWeakPointer<CGBMAllocator> allocator_,
-                                   Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain) : allocator(allocator_) {
+                                   Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain) :
+    allocator(allocator_) {
     if (!allocator)
         return;
 
@@ -104,17 +105,17 @@ Aquamarine::CGBMBuffer::CGBMBuffer(const SAllocatorBufferParams& params, Hypruti
 
     if (explicitModifiers.empty()) {
         allocator->backend->log(AQ_LOG_WARNING, "GBM: Using modifier-less allocation");
-        bo = gbm_bo_create(allocator->gbmDevice, params.size.x, params.size.y, params.format, flags);
+        bo = gbm_bo_create(allocator->gbmDevice, attrs.size.x, attrs.size.y, attrs.format, flags);
     } else {
         TRACE(allocator->backend->log(AQ_LOG_TRACE, std::format("GBM: Using modifier-based allocation, modifiers: {}", explicitModifiers.size())));
         for (auto& mod : explicitModifiers) {
             TRACE(allocator->backend->log(AQ_LOG_TRACE, std::format("GBM: | mod 0x{:x}", mod)));
         }
-        bo = gbm_bo_create_with_modifiers(allocator->gbmDevice, params.size.x, params.size.y, params.format, explicitModifiers.data(), explicitModifiers.size());
+        bo = gbm_bo_create_with_modifiers(allocator->gbmDevice, attrs.size.x, attrs.size.y, attrs.format, explicitModifiers.data(), explicitModifiers.size());
 
         if (!bo) {
             allocator->backend->log(AQ_LOG_ERROR, "GBM: Allocating with modifiers failed, falling back to implicit");
-            bo = gbm_bo_create(allocator->gbmDevice, params.size.x, params.size.y, params.format, flags);
+            bo = gbm_bo_create(allocator->gbmDevice, attrs.size.x, attrs.size.y, attrs.format, flags);
         }
     }
 


### PR DESCRIPTION
Use `attrs` instead of `params` since `guessFormatFrom` makes changes to `attrs` and other code also uses this var.
Fixes cursor buffer creation on nvidia.
Fixes `[ERR] [EGL] Command eglQueryDmaBufModifiersEXT errored out with EGL_BAD_PARAMETER (0x12300): EGL_BAD_PARAMETER error: In eglQueryDmaBufModifiersEXT: Invalid format` on hl side but rendering to this buffer still fails.