### PR TITLE
pass explicitOutFence pointer and do not touch the value

### DIFF
--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -82,6 +82,7 @@ namespace Aquamarine {
         void                  setBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buffer);
         void                  setExplicitInFence(int64_t fenceFD);  // -1 removes
         void                  setExplicitOutFence(int64_t fenceFD); // -1 removes
+        void                  resetExplicitFences();
 
       private:
         SInternalState internalState;

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -101,8 +101,8 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
     add(connector->crtc->id, connector->crtc->props.active, enable);
 
     if (enable) {
-        if (connector->output->supportsExplicit && STATE.explicitOutFence >= 0)
-            add(connector->crtc->id, connector->crtc->props.out_fence_ptr, STATE.explicitOutFence);
+        if (connector->output->supportsExplicit && STATE.committed & COutputState::AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE)
+            add(connector->crtc->id, connector->crtc->props.out_fence_ptr, (uintptr_t)&STATE.explicitOutFence);
 
         if (connector->crtc->props.gamma_lut && data.atomic.gammad)
             add(connector->crtc->id, connector->crtc->props.gamma_lut, data.atomic.gammaLut);

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -105,11 +105,13 @@ void Aquamarine::COutputState::setExplicitOutFence(int64_t fenceFD) {
     internalState.committed |= AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE;
 }
 
-void Aquamarine::COutputState::onCommit() {
-    internalState.committed = 0;
-    internalState.damage.clear();
-
+void Aquamarine::COutputState::resetExplicitFences() {
     // fences are now used, let's reset them to not confuse ourselves later.
     internalState.explicitInFence  = -1;
     internalState.explicitOutFence = -1;
+}
+
+void Aquamarine::COutputState::onCommit() {
+    internalState.committed = 0;
+    internalState.damage.clear();
 }

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -101,7 +101,7 @@ void Aquamarine::COutputState::setExplicitInFence(int64_t fenceFD) {
 }
 
 void Aquamarine::COutputState::setExplicitOutFence(int64_t fenceFD) {
-    internalState.explicitOutFence = fenceFD;
+    // internalState.explicitOutFence = fenceFD;
     internalState.committed |= AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE;
 }
 


### PR DESCRIPTION
Handle `explicit*Fence` as wlroots does. `setExplicitOutFence` doesn't need an argument but I kept it for a while. It should be called when there is some active `wait_timeline`... whatever this might be.