### PR TITLE
buffer: add a NONE flag to eBufferCapability

### DIFF
--- a/include/aquamarine/buffer/Buffer.hpp
+++ b/include/aquamarine/buffer/Buffer.hpp
@@ -8,6 +8,7 @@
 
 namespace Aquamarine {
     enum eBufferCapability : uint32_t {
+        BUFFER_CAPABILITY_NONE    = 0,
         BUFFER_CAPABILITY_DATAPTR = (1 << 0),
     };
 
@@ -63,7 +64,7 @@ namespace Aquamarine {
         Hyprutils::Math::Vector2D                      size;
         bool                                           opaque = false;
 
-        CAttachmentManager attachments;
+        CAttachmentManager                             attachments;
 
         struct {
             Hyprutils::Signal::CSignal destroy;


### PR DESCRIPTION
ensure we dont cast out of range in caps(),
return (Aquamarine::eBufferCapability)0; in GBM.cpp

one less out of range cast from #4 