### PR TITLE
Expose bo buffer mapping

### DIFF
--- a/include/aquamarine/allocator/GBM.hpp
+++ b/include/aquamarine/allocator/GBM.hpp
@@ -21,6 +21,7 @@ namespace Aquamarine {
         virtual bool                                   good();
         virtual SDMABUFAttrs                           dmabuf();
         virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
+        virtual void                                   endDataPtr();
 
       private:
         CGBMBuffer(const SAllocatorBufferParams& params, Hyprutils::Memory::CWeakPointer<CGBMAllocator> allocator_, Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain);

--- a/include/aquamarine/allocator/GBM.hpp
+++ b/include/aquamarine/allocator/GBM.hpp
@@ -14,12 +14,13 @@ namespace Aquamarine {
       public:
         virtual ~CGBMBuffer();
 
-        virtual eBufferCapability caps();
-        virtual eBufferType       type();
-        virtual void              update(const Hyprutils::Math::CRegion& damage);
-        virtual bool              isSynchronous();
-        virtual bool              good();
-        virtual SDMABUFAttrs      dmabuf();
+        virtual eBufferCapability                      caps();
+        virtual eBufferType                            type();
+        virtual void                                   update(const Hyprutils::Math::CRegion& damage);
+        virtual bool                                   isSynchronous();
+        virtual bool                                   good();
+        virtual SDMABUFAttrs                           dmabuf();
+        virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
 
       private:
         CGBMBuffer(const SAllocatorBufferParams& params, Hyprutils::Memory::CWeakPointer<CGBMAllocator> allocator_, Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain);
@@ -27,7 +28,9 @@ namespace Aquamarine {
         Hyprutils::Memory::CWeakPointer<CGBMAllocator> allocator;
 
         // gbm stuff
-        gbm_bo*      bo = nullptr;
+        gbm_bo*      bo         = nullptr;
+        void*        boBuffer   = nullptr;
+        void*        gboMapping = nullptr;
         SDMABUFAttrs attrs{.success = false};
 
         friend class CGBMAllocator;

--- a/src/allocator/GBM.cpp
+++ b/src/allocator/GBM.cpp
@@ -196,7 +196,7 @@ std::tuple<uint8_t*, uint32_t, size_t> Aquamarine::CGBMBuffer::beginDataPtr(uint
     uint32_t dst_stride = 0;
     if (!boBuffer)
         boBuffer = gbm_bo_map(bo, 0, 0, attrs.size.x, attrs.size.y, flags, &dst_stride, &gboMapping);
-    // FIXME: assumes cursor with DRM_FORMAT_ARGB8888
+    // FIXME: assumes a 32-bit pixel format
     return {(uint8_t*)boBuffer, attrs.format, attrs.size.x * attrs.size.y * 4};
 }
 


### PR DESCRIPTION
Expose gbm buffer mapping through `beginDataPtr`. The mapping is created only once so only flags passed for the first time are used. Can be used to copy data to the gbm buffer if rendering fails (`flags = GBM_BO_TRANSFER_WRITE`). Assumes 4 bytes per pixel as the most common case for cursor buffers.