### PR TITLE
drm: fix crash for connectors without a fallback mode

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1122,7 +1122,7 @@ void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
                                           aqMode->preferred ? " (preferred)" : ""));
     }
 
-    if (!currentModeInfo) {
+    if (!currentModeInfo && fallbackMode) {
         output->state->setMode(fallbackMode);
         crtc->refresh = calculateRefresh(fallbackMode->modeInfo.value());
     }


### PR DESCRIPTION
Fixes crash with my VR headset plugged in