### PR TITLE
Remove redundant needsFrame & allow frame schedule skipping on mouse move

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -194,7 +194,7 @@ namespace Aquamarine {
         virtual bool                                                      test();
         virtual Hyprutils::Memory::CSharedPointer<IBackendImplementation> getBackend();
         virtual bool                                                      setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot);
-        virtual void                                                      moveCursor(const Hyprutils::Math::Vector2D& coord);
+        virtual void                                                      moveCursor(const Hyprutils::Math::Vector2D& coord, bool skipShedule = false);
         virtual void                                                      scheduleFrame(const scheduleFrameReason reason = AQ_SCHEDULE_UNKNOWN);
         virtual void                                                      setCursorVisible(bool visible);
         virtual Hyprutils::Math::Vector2D                                 cursorPlaneSize();
@@ -324,7 +324,7 @@ namespace Aquamarine {
         virtual bool reset()                                                                                           = 0;
 
         // moving a cursor IIRC is almost instant on most hardware so we don't have to wait for a commit.
-        virtual bool moveCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector) = 0;
+        virtual bool moveCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, bool skipShedule = false) = 0;
     };
 
     class CDRMBackend : public IBackendImplementation {

--- a/include/aquamarine/backend/Wayland.hpp
+++ b/include/aquamarine/backend/Wayland.hpp
@@ -45,7 +45,7 @@ namespace Aquamarine {
         virtual bool                                                      test();
         virtual Hyprutils::Memory::CSharedPointer<IBackendImplementation> getBackend();
         virtual bool                                                      setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot);
-        virtual void                                                      moveCursor(const Hyprutils::Math::Vector2D& coord);
+        virtual void                                                      moveCursor(const Hyprutils::Math::Vector2D& coord, bool skipShedule = false);
         virtual void                                                      scheduleFrame(const scheduleFrameReason reason = AQ_SCHEDULE_UNKNOWN);
         virtual Hyprutils::Math::Vector2D                                 cursorPlaneSize();
         virtual bool                                                      destroy();

--- a/include/aquamarine/backend/drm/Atomic.hpp
+++ b/include/aquamarine/backend/drm/Atomic.hpp
@@ -8,7 +8,7 @@ namespace Aquamarine {
         CDRMAtomicImpl(Hyprutils::Memory::CSharedPointer<CDRMBackend> backend_);
         virtual bool commit(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
         virtual bool reset();
-        virtual bool moveCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector);
+        virtual bool moveCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, bool skipShedule = false);
 
       private:
         bool                                         prepareConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);

--- a/include/aquamarine/backend/drm/Legacy.hpp
+++ b/include/aquamarine/backend/drm/Legacy.hpp
@@ -8,12 +8,11 @@ namespace Aquamarine {
         CDRMLegacyImpl(Hyprutils::Memory::CSharedPointer<CDRMBackend> backend_);
         virtual bool commit(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
         virtual bool reset();
-        virtual bool moveCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector);
+        virtual bool moveCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, bool skipShedule = false);
 
       private:
-
-        bool commitInternal(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
-        bool testInternal(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
+        bool                                         commitInternal(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
+        bool                                         testInternal(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
 
         Hyprutils::Memory::CWeakPointer<CDRMBackend> backend;
     };

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -113,6 +113,8 @@ namespace Aquamarine {
             AQ_SCHEDULE_NEW_MONITOR,
             AQ_SCHEDULE_RENDER_MONITOR,
             AQ_SCHEDULE_NEEDS_FRAME,
+            AQ_SCHEDULE_ANIMATION,
+            AQ_SCHEDULE_ANIMATION_DAMAGE,
         };
 
         virtual bool                                                      commit()           = 0;
@@ -121,7 +123,7 @@ namespace Aquamarine {
         virtual std::vector<SDRMFormat>                                   getRenderFormats() = 0;
         virtual Hyprutils::Memory::CSharedPointer<SOutputMode>            preferredMode();
         virtual bool                                                      setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot);
-        virtual void                                                      moveCursor(const Hyprutils::Math::Vector2D& coord); // includes the hotspot
+        virtual void                                                      moveCursor(const Hyprutils::Math::Vector2D& coord, bool skipShedule = false); // includes the hotspot
         virtual void                                                      setCursorVisible(bool visible); // moving the cursor will make it visible again without this util
         virtual Hyprutils::Math::Vector2D                                 cursorPlaneSize();              // -1, -1 means no set size, 0, 0 means error
         virtual void                                                      scheduleFrame(const scheduleFrameReason reason = AQ_SCHEDULE_UNKNOWN);

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -724,7 +724,7 @@ bool Aquamarine::CWaylandOutput::setCursor(Hyprutils::Memory::CSharedPointer<IBu
     return true;
 }
 
-void Aquamarine::CWaylandOutput::moveCursor(const Hyprutils::Math::Vector2D& coord) {
+void Aquamarine::CWaylandOutput::moveCursor(const Hyprutils::Math::Vector2D& coord, bool skipShedule) {
     return;
 }
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1289,7 +1289,6 @@ bool Aquamarine::CDRMOutput::test() {
 
 void Aquamarine::CDRMOutput::setCursorVisible(bool visible) {
     cursorVisible = visible;
-    needsFrame    = true;
     scheduleFrame(AQ_SCHEDULE_CURSOR_VISIBLE);
 }
 
@@ -1549,15 +1548,14 @@ bool Aquamarine::CDRMOutput::setCursor(SP<IBuffer> buffer, const Vector2D& hotsp
         cursorVisible = true;
     }
 
-    needsFrame = true;
     scheduleFrame(AQ_SCHEDULE_CURSOR_SHAPE);
     return true;
 }
 
-void Aquamarine::CDRMOutput::moveCursor(const Vector2D& coord) {
-    cursorPos     = coord;
-    cursorVisible = true;
-    backend->impl->moveCursor(connector);
+void Aquamarine::CDRMOutput::moveCursor(const Vector2D& coord, bool skipShedule) {
+    cursorPos = coord;
+    // cursorVisible = true;
+    backend->impl->moveCursor(connector, skipShedule);
 }
 
 void Aquamarine::CDRMOutput::scheduleFrame(const scheduleFrameReason reason) {

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -324,12 +324,14 @@ bool Aquamarine::CDRMAtomicImpl::reset() {
     return request.commit(DRM_MODE_ATOMIC_ALLOW_MODESET);
 }
 
-bool Aquamarine::CDRMAtomicImpl::moveCursor(SP<SDRMConnector> connector) {
+bool Aquamarine::CDRMAtomicImpl::moveCursor(SP<SDRMConnector> connector, bool skipShedule) {
     if (!connector->output->cursorVisible || !connector->output->state->state().enabled || !connector->crtc || !connector->crtc->cursor)
         return true;
 
-    connector->output->needsFrame = true;
-    connector->output->scheduleFrame(IOutput::AQ_SCHEDULE_CURSOR_MOVE);
+    if (!skipShedule) {
+        TRACE(connector->backend->log(AQ_LOG_TRACE, "atomic moveCursor"));
+        connector->output->scheduleFrame(IOutput::AQ_SCHEDULE_CURSOR_MOVE);
+    }
 
     return true;
 }

--- a/src/backend/drm/impl/Legacy.cpp
+++ b/src/backend/drm/impl/Legacy.cpp
@@ -14,12 +14,12 @@ Aquamarine::CDRMLegacyImpl::CDRMLegacyImpl(Hyprutils::Memory::CSharedPointer<CDR
     ;
 }
 
-bool Aquamarine::CDRMLegacyImpl::moveCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector) {
+bool Aquamarine::CDRMLegacyImpl::moveCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, bool skipShedule) {
     if (!connector->output->cursorVisible || !connector->output->state->state().enabled || !connector->crtc || !connector->crtc->cursor)
         return true;
 
-    connector->output->needsFrame = true;
-    connector->output->scheduleFrame(IOutput::AQ_SCHEDULE_CURSOR_MOVE);
+    if (!skipShedule)
+        connector->output->scheduleFrame(IOutput::AQ_SCHEDULE_CURSOR_MOVE);
 
     return true;
 }

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -11,7 +11,7 @@ Hyprutils::Memory::CSharedPointer<SOutputMode> Aquamarine::IOutput::preferredMod
     return nullptr;
 }
 
-void Aquamarine::IOutput::moveCursor(const Hyprutils::Math::Vector2D& coord) {
+void Aquamarine::IOutput::moveCursor(const Hyprutils::Math::Vector2D& coord, bool skipShedule) {
     ;
 }
 


### PR DESCRIPTION
- Removes `needsFrame = true` before `scheduleFrame` since it is set inside. Useful for logging `needsFrame` changes.
- Adds optional `skipShedule` argument to `moveCursor` to allow `cursor:no_break_fs_vrr` with hw cursors

`skipShedule` requires HL updates to be useful. Just passing `true` to `moveCursor` is not enough to fix VRR. Probably needs something like https://github.com/hyprwm/Hyprland/pull/6877 for hw cursors.