### PR TITLE
displaylink fix: ignore primary argument when using evdi drivers

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -599,8 +599,13 @@ bool Aquamarine::CDRMBackend::registerGPU(SP<CSessionDevice> gpu_, SP<CDRMBacken
 
     gpuName = drmName;
 
+    auto drmVerName = drmVer->name ? drmVer->name : "unknown";
+    if (std::string_view(drmVerName) == "evdi") {
+        primary = {};
+    }
+
     backend->log(AQ_LOG_DEBUG,
-                 std::format("drm: Starting backend for {}, with driver {}{}", drmName ? drmName : "unknown", drmVer->name ? drmVer->name : "unknown",
+                 std::format("drm: Starting backend for {}, with driver {}{}", drmName ? drmName : "unknown", drmVerName,
                              (primary ? std::format(" with primary {}", primary->gpu->path) : "")));
 
     drmFreeVersion(drmVer);
@@ -1346,7 +1351,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
     if (!MODE) // modeless commits are invalid
         return false;
 
-    uint32_t   flags = 0;
+    uint32_t flags = 0;
 
     if (!onlyTest) {
         if (NEEDS_RECONFIG) {

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -600,9 +600,8 @@ bool Aquamarine::CDRMBackend::registerGPU(SP<CSessionDevice> gpu_, SP<CDRMBacken
     gpuName = drmName;
 
     auto drmVerName = drmVer->name ? drmVer->name : "unknown";
-    if (std::string_view(drmVerName) == "evdi") {
+    if (std::string_view(drmVerName) == "evdi")
         primary = {};
-    }
 
     backend->log(AQ_LOG_DEBUG,
                  std::format("drm: Starting backend for {}, with driver {}{}", drmName ? drmName : "unknown", drmVerName,


### PR DESCRIPTION
Fixes #22.

A slightly more robust way to address the issue than the hack provided in #22 - done by checking if the driver being used for the given GPU is `evdi`. If so, set `primary` to `{}`.

Unsure of the following:
- whether this still falls under "hacky code" mentioned in Hyprland's [PR Guidelines](https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/#pr-requirements)
- variables like `drmName` and `drmVer` are `auto` instead of `auto const` - have followed the same convention for the newly introduced `drmVerName` variable
- whether there exist use cases with `evdi` drivers and using the passed-in `primary_` argument (I assume no)