### PR TITLE
fix destroying headless outputs

### DIFF
--- a/src/backend/Headless.cpp
+++ b/src/backend/Headless.cpp
@@ -73,6 +73,7 @@ void Aquamarine::CHeadlessOutput::scheduleFrame(const scheduleFrameReason reason
 }
 
 bool Aquamarine::CHeadlessOutput::destroy() {
+    events.destroy.emit();
     std::erase(backend->outputs, self.lock());
     return true;
 }

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -496,6 +496,7 @@ Aquamarine::CWaylandOutput::CWaylandOutput(const std::string& name_, Hyprutils::
 
 Aquamarine::CWaylandOutput::~CWaylandOutput() {
     backend->idleCallbacks.clear(); // FIXME: mega hack to avoid a UAF in frame events
+    events.destroy.emit();
     if (waylandState.xdgToplevel)
         waylandState.xdgToplevel->sendDestroy();
     if (waylandState.xdgSurface)


### PR DESCRIPTION
fixes hyprwm/Hyprland#6995

Hyprland still holds ref to output so it isn't destroyed by std::erase, and destroy event isnt sent