### PR TITLE
Update switch state in libinput event

### DIFF
--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -640,6 +640,7 @@ void Aquamarine::CSession::handleLibinputEvent(libinput_event* e) {
 
             if (ENABLED == hlDevice->switchy->state)
                 return;
+            hlDevice->switchy->state = ENABLED;
 
             switch (libinput_event_switch_get_switch(se)) {
                 case LIBINPUT_SWITCH_LID: hlDevice->switchy->type = ISwitch::AQ_SWITCH_TYPE_LID; break;


### PR DESCRIPTION
This fixes a bug, where the aquamarine switch state is never updated, thus the check `if (ENABLED == hlDevice->switchy->state)` blocks all "disabled" events (the default state) and only switch "enabled" events are fired.