### PR TITLE
DRM: Allow checking no-crtc outputs

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -152,7 +152,6 @@ namespace Aquamarine {
     struct SDRMCRTC {
         uint32_t               id = 0;
         std::vector<SDRMLayer> layers;
-        int32_t                refresh = 0;
 
         struct {
             int gammaSize = 0;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -713,10 +713,10 @@ void Aquamarine::CDRMBackend::scanConnectors() {
 
         conn->status = drmConn->connection;
 
-        if (!conn->crtc) {
-            backend->log(AQ_LOG_DEBUG, std::format("drm: Ignoring connector {} because it has no CRTC", connectorID));
-            continue;
-        }
+        // if (!conn->crtc) {
+        //     backend->log(AQ_LOG_DEBUG, std::format("drm: Ignoring connector {} because it has no CRTC", connectorID));
+        //     continue;
+        // }
 
         backend->log(AQ_LOG_DEBUG, std::format("drm: Connector {} connection state: {}", connectorID, (int)drmConn->connection));
 
@@ -1198,7 +1198,8 @@ void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
             //uint64_t modeID = 0;
             // getDRMProp(backend->gpu->fd, crtc->id, crtc->props.mode_id, &modeID);
 
-            crtc->refresh = calculateRefresh(drmMode);
+            //if (crtc)
+            //    crtc->refresh = calculateRefresh(drmMode);
         }
 
         backend->backend->log(AQ_LOG_DEBUG,
@@ -1208,7 +1209,8 @@ void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
 
     if (!currentModeInfo && fallbackMode) {
         output->state->setMode(fallbackMode);
-        crtc->refresh = calculateRefresh(fallbackMode->modeInfo.value());
+        //if (crtc)
+        //    crtc->refresh = calculateRefresh(fallbackMode->modeInfo.value());
     }
 
     output->physicalSize = {(double)connector->mmWidth, (double)connector->mmHeight};


### PR DESCRIPTION
Some connectors might not have a CRTC at initialization, but these can receive them later via rescanCRTCs. However, if we nope out early, they will never be marked as "connected" thus will be ignored forever.

ref: https://github.com/hyprwm/Hyprland/issues/7292 https://github.com/hyprwm/aquamarine/issues/40 https://github.com/hyprwm/Hyprland/issues/7238 possibly more