### PR TITLE
drm: don't schedule new frame events on disabled outputs

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -209,6 +209,8 @@ namespace Aquamarine {
         Hyprutils::Math::Vector2D                                         cursorPos; // without hotspot
         Hyprutils::Math::Vector2D                                         cursorHotspot;
 
+        bool enabledState = true; // actual enabled state. Should be synced with state->state().enabled after a new frame
+
       private:
         CDRMOutput(const std::string& name_, Hyprutils::Memory::CWeakPointer<CDRMBackend> backend_, Hyprutils::Memory::CSharedPointer<SDRMConnector> connector_);
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -818,7 +818,7 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
         .flags     = flags,
     });
 
-    if (BACKEND->sessionActive() && !pageFlip->connector->frameEventScheduled && pageFlip->connector->output->state->state().enabled)
+    if (BACKEND->sessionActive() && !pageFlip->connector->frameEventScheduled && pageFlip->connector->output->enabledState)
         pageFlip->connector->output->events.frame.emit();
 }
 
@@ -1318,6 +1318,8 @@ void Aquamarine::SDRMConnector::applyCommit(const SDRMConnectorCommitData& data)
 
     if (output->state->state().committed & COutputState::AQ_OUTPUT_STATE_MODE)
         refresh = calculateRefresh(data.modeInfo);
+
+    output->enabledState = output->state->state().enabled;
 }
 
 void Aquamarine::SDRMConnector::rollbackCommit(const SDRMConnectorCommitData& data) {
@@ -1679,7 +1681,7 @@ void Aquamarine::CDRMOutput::scheduleFrame(const scheduleFrameReason reason) {
                                             connector->isPageFlipPending, connector->frameEventScheduled)));
     needsFrame = true;
 
-    if (connector->isPageFlipPending || connector->frameEventScheduled || !state->state().enabled)
+    if (connector->isPageFlipPending || connector->frameEventScheduled || !enabledState)
         return;
 
     connector->frameEventScheduled = true;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1679,7 +1679,7 @@ void Aquamarine::CDRMOutput::scheduleFrame(const scheduleFrameReason reason) {
                                             connector->isPageFlipPending, connector->frameEventScheduled)));
     needsFrame = true;
 
-    if (connector->isPageFlipPending || connector->frameEventScheduled)
+    if (connector->isPageFlipPending || connector->frameEventScheduled || !state->state().enabled)
         return;
 
     connector->frameEventScheduled = true;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -818,7 +818,7 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
         .flags     = flags,
     });
 
-    if (BACKEND->sessionActive() && !pageFlip->connector->frameEventScheduled)
+    if (BACKEND->sessionActive() && !pageFlip->connector->frameEventScheduled && pageFlip->connector->output->state->state().enabled)
         pageFlip->connector->output->events.frame.emit();
 }
 


### PR DESCRIPTION
Fixes https://github.com/hyprwm/Hyprland/issues/6459

Needs a test run