### PR TITLE
output avoid crashing on no crtc

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1713,6 +1713,10 @@ size_t Aquamarine::CDRMOutput::getGammaSize() {
 }
 
 std::vector<SDRMFormat> Aquamarine::CDRMOutput::getRenderFormats() {
+    if (!connector->crtc || !connector->crtc->primary || connector->crtc->primary->formats.empty()) {
+        backend->log(AQ_LOG_ERROR, "Can't get formats: no crtc");
+        return {};
+    }
     return connector->crtc->primary->formats;
 }
 


### PR DESCRIPTION
dual gpus can init with no crtc and later rescan for them, however getRenderFormats might be called before that happends and null ptr deref, guard against it.