### PR TITLE
tearing fix

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1449,10 +1449,8 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
 
         if (STATE.enabled && (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER))
             flags |= DRM_MODE_PAGE_FLIP_EVENT;
-        if (STATE.presentationMode == AQ_OUTPUT_PRESENTATION_IMMEDIATE && (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER)) {
+        if (STATE.presentationMode == AQ_OUTPUT_PRESENTATION_IMMEDIATE && (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER))
             flags |= DRM_MODE_PAGE_FLIP_ASYNC;
-            flags &= ~DRM_MODE_PAGE_FLIP_EVENT; // Do not request an event for immediate page flips, as it makes no sense.
-        }
     }
 
     // we can't go further without a blit


### PR DESCRIPTION
related commit hyprwm/aquamarine@18c6a8c
fix for `[ERR] [AQ] atomic drm request: failed to commit: Device or resource busy, flags: ATOMIC_NONBLOCK PAGE_FLIP_ASYNC` hyprwm/Hyprland#7215