### PR TITLE
backends dont overflow on 32bit builds

### DIFF
--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -17,7 +17,7 @@ using namespace Hyprutils::Memory;
 using namespace Aquamarine;
 #define SP CSharedPointer
 
-#define TIMESPEC_NSEC_PER_SEC 1000000000L
+#define TIMESPEC_NSEC_PER_SEC 1000000000LL
 
 static void timespecAddNs(timespec* pTimespec, int64_t delta) {
     int delta_ns_low = delta % TIMESPEC_NSEC_PER_SEC;

--- a/src/backend/Headless.cpp
+++ b/src/backend/Headless.cpp
@@ -10,7 +10,7 @@ using namespace Hyprutils::Memory;
 using namespace Hyprutils::Math;
 #define SP CSharedPointer
 
-#define TIMESPEC_NSEC_PER_SEC 1000000000L
+#define TIMESPEC_NSEC_PER_SEC 1000000000LL
 
 static void timespecAddNs(timespec* pTimespec, int64_t delta) {
     int delta_ns_low = delta % TIMESPEC_NSEC_PER_SEC;


### PR DESCRIPTION
make the definition long long as its used as long long later, only the value was being calculated TIMESPEC_NSEC_PER_SEC * 240 and rolls over before assigning to the variable.

```
long long  lowestNs = TIMESPEC_NSEC_PER_SEC * 240 /* 240s, 4 mins */;
```