### PR TITLE
don't connect before crtcs are guaranteed

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -246,7 +246,7 @@ std::vector<SP<CDRMBackend>> Aquamarine::CDRMBackend::attempt(SP<CBackend> backe
 
         drmBackend->grabFormats();
 
-        drmBackend->scanConnectors();
+        drmBackend->scanConnectors(false);
 
         drmBackend->recheckCRTCs();
 
@@ -279,7 +279,7 @@ bool Aquamarine::CDRMBackend::sessionActive() {
 void Aquamarine::CDRMBackend::restoreAfterVT() {
     backend->log(AQ_LOG_DEBUG, "drm: Restoring after VT switch");
 
-    scanConnectors();
+    scanConnectors(false);
     recheckCRTCs();
 
     backend->log(AQ_LOG_DEBUG, "drm: Rescanned connectors");


### PR DESCRIPTION
### better "workflow"

scan connectors to get them
assign crtcs if they don't have them
then connect