### PR TITLE
Session: only dispatch udev in dispatchPendingEventsAsync if on linux

### DIFF
--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -166,6 +166,9 @@ bool Aquamarine::CBackend::start() {
         b->onReady();
     }
 
+    if (session)
+        session->onReady();
+
     sessionFDs = session ? session->pollFDs() : std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>>{};
 
     return true;

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -264,6 +264,9 @@ static bool isDRMCard(const char* sysname) {
 }
 
 void Aquamarine::CSession::onReady() {
+    dispatchLibseatEvents();
+    dispatchLibinputEvents();
+
     for (auto const& d : libinputDevices) {
         if (d->keyboard)
             backend->events.newKeyboard.emit(SP<IKeyboard>(d->keyboard));

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -264,8 +264,7 @@ static bool isDRMCard(const char* sysname) {
 }
 
 void Aquamarine::CSession::onReady() {
-    dispatchLibseatEvents();
-    dispatchLibinputEvents();
+    ;
 }
 
 void Aquamarine::CSession::dispatchUdevEvents() {
@@ -361,7 +360,12 @@ void Aquamarine::CSession::dispatchLibseatEvents() {
 
 void Aquamarine::CSession::dispatchPendingEventsAsync() {
     dispatchLibseatEvents();
+
+    // only linux libudev allows us to asynchronously dispatch outstanding without blocking
+#if defined(__linux__)
     dispatchUdevEvents();
+#endif
+
     dispatchLibinputEvents();
 }
 

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -266,25 +266,6 @@ static bool isDRMCard(const char* sysname) {
 void Aquamarine::CSession::onReady() {
     dispatchLibseatEvents();
     dispatchLibinputEvents();
-
-    for (auto const& d : libinputDevices) {
-        if (d->keyboard)
-            backend->events.newKeyboard.emit(SP<IKeyboard>(d->keyboard));
-        if (d->mouse)
-            backend->events.newPointer.emit(SP<IPointer>(d->mouse));
-        if (d->touch)
-            backend->events.newTouch.emit(SP<ITouch>(d->touch));
-        if (d->switchy)
-            backend->events.newSwitch.emit(SP<ITouch>(d->touch));
-        if (d->tablet)
-            backend->events.newTablet.emit(SP<ITablet>(d->tablet));
-        if (d->tabletPad)
-            backend->events.newTabletPad.emit(SP<ITabletPad>(d->tabletPad));
-
-        for (auto const& t : d->tabletTools) {
-            backend->events.newTabletTool.emit(SP<ITabletTool>(t));
-        }
-    }
 }
 
 void Aquamarine::CSession::dispatchUdevEvents() {


### PR DESCRIPTION
Dispatches libinput events when onReady is called. Prevents unread events on start

fixes https://github.com/hyprwm/Hyprland/issues/7855 https://github.com/hyprwm/Hyprland/issues/7391