### PR TITLE
DRM/Output/Core: Add HW plane infrastructure

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -166,10 +166,11 @@ namespace Aquamarine {
             uint32_t ctm       = 0;
         } atomic;
 
-        Hyprutils::Memory::CSharedPointer<SDRMPlane> primary;
-        Hyprutils::Memory::CSharedPointer<SDRMPlane> cursor;
-        Hyprutils::Memory::CWeakPointer<CDRMBackend> backend;
-        Hyprutils::Memory::CSharedPointer<CDRMFB>    pendingCursor;
+        Hyprutils::Memory::CSharedPointer<SDRMPlane>              primary;
+        Hyprutils::Memory::CSharedPointer<SDRMPlane>              cursor;
+        std::vector<Hyprutils::Memory::CSharedPointer<SDRMPlane>> planes; // other planes go here
+        Hyprutils::Memory::CWeakPointer<CDRMBackend>              backend;
+        Hyprutils::Memory::CSharedPointer<CDRMFB>                 pendingCursor;
 
         union UDRMCRTCProps {
             struct {

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1023,11 +1023,19 @@ bool Aquamarine::SDRMPlane::init(drmModePlane* plane) {
         auto CRTC = backend->crtcs.at(i);
         if (type == DRM_PLANE_TYPE_PRIMARY && !CRTC->primary) {
             CRTC->primary = self.lock();
+            TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("drm: CRTC {} gets assigned plane {} as primary", CRTC->id, id)));
             break;
         }
 
         if (type == DRM_PLANE_TYPE_CURSOR && !CRTC->cursor) {
             CRTC->cursor = self.lock();
+            TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("drm: CRTC {} gets assigned plane {} as cursor", CRTC->id, id)));
+            break;
+        }
+
+        if (std::find(CRTC->planes.begin(), CRTC->planes.end(), self) == CRTC->planes.end()) {
+            CRTC->planes.emplace_back(self.lock());
+            TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("drm: CRTC {} gets added plane {} as general-purpose misc", CRTC->id, id)));
             break;
         }
     }

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -43,6 +43,10 @@ bool Aquamarine::IOutput::destroy() {
     return false;
 }
 
+std::vector<Aquamarine::IOutput::SPlaneData> Aquamarine::IOutput::getPlanes() {
+    return {{.renderFormats = {}, .type = AQ_PLANE_PRIMARY}};
+}
+
 const Aquamarine::COutputState::SInternalState& Aquamarine::COutputState::state() {
     return internalState;
 }
@@ -120,7 +124,52 @@ void Aquamarine::COutputState::setCTM(const Hyprutils::Math::Mat3x3& ctm) {
     internalState.committed |= AQ_OUTPUT_STATE_CTM;
 }
 
+void Aquamarine::COutputState::setPlaneEnabled(uint32_t planeIdx, bool enabled) {
+    if (planeIdx >= internalState.planeStates.size())
+        return;
+
+    internalState.planeStates.at(planeIdx).enabled = enabled;
+    internalState.planeStates.at(planeIdx).updated = true;
+
+    internalState.committed |= AQ_OUTPUT_STATE_PLANE_STATE;
+}
+
+void Aquamarine::COutputState::setPlaneBuffer(uint32_t planeIdx, Hyprutils::Memory::CSharedPointer<IBuffer> buffer) {
+    if (planeIdx >= internalState.planeStates.size())
+        return;
+
+    internalState.planeStates.at(planeIdx).buffer  = buffer;
+    internalState.planeStates.at(planeIdx).updated = true;
+
+    internalState.committed |= AQ_OUTPUT_STATE_PLANE_STATE;
+}
+
+void Aquamarine::COutputState::setPlaneGeometry(uint32_t planeIdx, const Hyprutils::Math::CBox& box) {
+    if (planeIdx >= internalState.planeStates.size())
+        return;
+
+    internalState.planeStates.at(planeIdx).geometry = box;
+    internalState.planeStates.at(planeIdx).updated  = true;
+
+    internalState.committed |= AQ_OUTPUT_STATE_PLANE_STATE;
+}
+
+void Aquamarine::COutputState::addPlaneDamage(uint32_t planeIdx, const Hyprutils::Math::CRegion& region) {
+    if (planeIdx >= internalState.planeStates.size())
+        return;
+
+    internalState.planeStates.at(planeIdx).damage.add(region);
+    internalState.planeStates.at(planeIdx).updated = true;
+
+    internalState.committed |= AQ_OUTPUT_STATE_PLANE_STATE;
+}
+
 void Aquamarine::COutputState::onCommit() {
     internalState.committed = 0;
     internalState.damage.clear();
+
+    for (auto& p : internalState.planeStates) {
+        p.damage.clear();
+        p.updated = false;
+    }
 }


### PR DESCRIPTION
This is required for a better fix to nvidia hw cursors, and generally enables powerful optimizations in the future.

Very wip, not done yet