### PR TITLE
fix drm lease crash

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -2056,6 +2056,7 @@ SP<CDRMLease> Aquamarine::CDRMLease::create(std::vector<SP<IOutput>> outputs) {
     }
 
     lease->leaseFD = leaseFD;
+    lease->backend = backend;
 
     backend->log(AQ_LOG_DEBUG, std::format("drm lease: lease granted with lessee id {}", lease->lesseeID));
 


### PR DESCRIPTION
fixes a crash because backend was null in DRMLease dtor lol
for hyprwm/Hyprland#8116