### PR TITLE
nix: libseat renamed to seatd

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,10 +10,10 @@
   libffi,
   libGL,
   libinput,
-  libseat,
   mesa,
   pixman,
   pkg-config,
+  seatd,
   udev,
   wayland,
   wayland-protocols,
@@ -46,9 +46,9 @@ stdenv.mkDerivation {
     libffi
     libGL
     libinput
-    libseat
     mesa
     pixman
+    seatd
     udev
     wayland
     wayland-protocols


### PR DESCRIPTION
libseat was renamed to seatd in 2021 and was recently made to throw (see https://github.com/NixOS/nixpkgs/pull/349431/files#diff-29ed0f5fda84c91253503c1664d60a194a324e29518d472adf846f30b8db52e3R872).