### PR TITLE
drm: guard cursorFB buffer in restoreAfterVT

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -331,7 +331,7 @@ void Aquamarine::CDRMBackend::restoreAfterVT() {
         if (c->crtc->pendingCursor)
             data.cursorFB = c->crtc->pendingCursor;
 
-        if (data.cursorFB && data.cursorFB->buffer->dmabuf().modifier == DRM_FORMAT_MOD_INVALID)
+        if (data.cursorFB && (data.cursorFB->dead || data.cursorFB->buffer->dmabuf().modifier == DRM_FORMAT_MOD_INVALID))
             data.cursorFB = nullptr;
 
         backend->log(AQ_LOG_DEBUG,


### PR DESCRIPTION
Fixes this crash I got twice randomly when switching vts. Don't know how to reproduce the underlying buffer getting destroyed, but this probably fixes it.

```
#0  0x00007f7cef1b57dc in __pthread_kill_implementation ()
   from /nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52/lib/libc.so.6
#1  0x00007f7cef163516 in raise ()
   from /nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52/lib/libc.so.6
#2  0x00007f7cef14b935 in abort ()
   from /nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52/lib/libc.so.6
#3  0x0000000000511b54 in handleUnrecoverableSignal(int) ()
#4  <signal handler called>
#5  0x00007f7cf02e6e26 in Aquamarine::CDRMBackend::restoreAfterVT (this=0x39d530e0)
    at /build/5zx5awmf2jcg95wcmcnmpycz47xsl1ix-source/src/backend/drm/DRM.cpp:334
#6  0x00007f7cf02e74d8 in operator() (d=..., __closure=0x39ba7560)
    at /build/5zx5awmf2jcg95wcmcnmpycz47xsl1ix-source/src/backend/drm/DRM.cpp:41
#7  std::__invoke_impl<void, Aquamarine::CDRMBackend::CDRMBackend(Hyprutils::Memory::CSharedPointer<Aquamarine::CBackend>)::<lambda(std::any)>&, std::any> (__f=...)
    at /nix/store/6mmwy4jcnqnhms3i56r1hbdn656akg1d-gcc-13.3.0/include/c++/13.3.0/bits/invoke.h:61
#8  std::__invoke_r<void, Aquamarine::CDRMBackend::CDRMBackend(Hyprutils::Memory::CSharedPointer<Aquamarine::CBackend>)::<lambda(std::any)>&, std::any> (__fn=...)
    at /nix/store/6mmwy4jcnqnhms3i56r1hbdn656akg1d-gcc-13.3.0/include/c++/13.3.0/bits/invoke.h:111
#9  std::_Function_handler<void(std::any), Aquamarine::CDRMBackend::CDRMBackend(Hyprutils::Memory::CSharedPointer<Aquamarine::CBackend>)::<lambda(std::any)> >::_M_invoke(const std::_Any_data &, std::any &&)
    (__functor=..., __args#0=...)
    at /nix/store/6mmwy4jcnqnhms3i56r1hbdn656akg1d-gcc-13.3.0/include/c++/13.3.0/bits/std_function.h:290
#10 0x00007f7ceffd2357 in std::function<void(std::any)>::operator() (__args#0=..., this=0x39ba7560)
    at /nix/store/6mmwy4jcnqnhms3i56r1hbdn656akg1d-gcc-13.3.0/include/c++/13.3.0/bits/std_function.h:591
#11 Hyprutils::Signal::CSignalListener::emit (this=this@entry=0x39ba7560, data=...)
    at /build/1p8zbhb9lpzb4mknsi9m0dxq05av2lsv-source/src/signal/Listener.cpp:13
#12 0x00007f7ceffd29d3 in Hyprutils::Signal::CSignal::emit (this=<optimized out>, data=...)
    at /build/1p8zbhb9lpzb4mknsi9m0dxq05av2lsv-source/src/signal/Signal.cpp:31
#13 0x00007f7cf02ac0ad in libseatEnableSeat (seat=<optimized out>, data=0x39c433f0)
    at /build/5zx5awmf2jcg95wcmcnmpycz47xsl1ix-source/src/backend/Session.cpp:73
#14 0x00007f7cef0e8cea in resume_device ()
   from /nix/store/bbda7dz6sf6370k8p1w2clvxdhyx3c8s-seatd-0.8.0/lib/libseat.so.1
#15 0x00007f7cebb2ff8d in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#16 0x00007f7cebb2fd68 in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#17 0x00007f7cebb2fd43 in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#18 0x00007f7cebb2fd68 in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#19 0x00007f7cebb2fd43 in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#20 0x00007f7cebb2fd68 in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#21 0x00007f7cebb2fd43 in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#22 0x00007f7cebb2fd68 in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#23 0x00007f7cebb2fd43 in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#24 0x00007f7cebb2fd68 in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#25 0x00007f7cebb2fe29 in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#26 0x00007f7cebb30017 in bus_match_run[localalias] ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#27 0x00007f7cebb55ac8 in bus_process_internal ()
   from /nix/store/1lbc6v5p1a3rn4rjaqnz0694xfbq8dxq-systemd-256.4/lib/libsystemd.so.0
#28 0x00007f7cef0ea38d in dispatch_and_execute ()
   from /nix/store/bbda7dz6sf6370k8p1w2clvxdhyx3c8s-seatd-0.8.0/lib/libseat.so.1
#29 0x00007f7cf02ad5d6 in Aquamarine::CSession::dispatchLibseatEvents (this=0x39c433f0)
    at /build/5zx5awmf2jcg95wcmcnmpycz47xsl1ix-source/src/backend/Session.cpp:357
#30 0x0000000000775a56 in aquamarineFDWrite(int, unsigned int, void*) ()
#31 0x00007f7cf01dded2 in wl_event_loop_dispatch ()
   from /nix/store/cdnwvy5zyh6la8x1cal00xmvsj8x3dai-wayland-1.23.1/lib/libwayland-server.so.0
#32 0x00007f7cf01db5d5 in wl_display_run ()
   from /nix/store/cdnwvy5zyh6la8x1cal00xmvsj8x3dai-wayland-1.23.1/lib/libwayland-server.so.0
#33 0x000000000077715f in CEventLoopManager::enterLoop() ()
#34 0x00000000006ec1e6 in main ()
#35 0x00007f7cef14d14e in __libc_start_call_main ()
   from /nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52/lib/libc.so.6
#36 0x00007f7cef14d209 in __libc_start_main_impl ()
   from /nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52/lib/libc.so.6
#37 0x00000000004d2e25 in _start ()
```