### PR TITLE
Fix fences according to spec

### DIFF
--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -68,7 +68,7 @@ namespace Aquamarine {
             Hyprutils::Memory::CSharedPointer<SOutputMode> customMode;
             uint32_t                                       drmFormat = DRM_FORMAT_INVALID;
             Hyprutils::Memory::CSharedPointer<IBuffer>     buffer;
-            int64_t                                        explicitInFence = -1, explicitOutFence = -1;
+            int32_t                                        explicitInFence = -1, explicitOutFence = -1;
             Hyprutils::Math::Mat3x3                        ctm;
         };
 
@@ -84,8 +84,8 @@ namespace Aquamarine {
         void                  setCustomMode(Hyprutils::Memory::CSharedPointer<SOutputMode> mode);
         void                  setFormat(uint32_t drmFormat);
         void                  setBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buffer);
-        void                  setExplicitInFence(int64_t fenceFD);  // -1 removes
-        void                  setExplicitOutFence(int64_t fenceFD); // -1 removes
+        void                  setExplicitInFence(int32_t fenceFD); // -1 removes
+        void                  enableExplicitOutFenceForNextCommit();
         void                  resetExplicitFences();
         void                  setCTM(const Hyprutils::Math::Mat3x3& ctm);
 

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -99,13 +99,12 @@ void Aquamarine::COutputState::setBuffer(Hyprutils::Memory::CSharedPointer<IBuff
     internalState.committed |= AQ_OUTPUT_STATE_BUFFER;
 }
 
-void Aquamarine::COutputState::setExplicitInFence(int64_t fenceFD) {
+void Aquamarine::COutputState::setExplicitInFence(int32_t fenceFD) {
     internalState.explicitInFence = fenceFD;
     internalState.committed |= AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE;
 }
 
-void Aquamarine::COutputState::setExplicitOutFence(int64_t fenceFD) {
-    // internalState.explicitOutFence = fenceFD;
+void Aquamarine::COutputState::enableExplicitOutFenceForNextCommit() {
     internalState.committed |= AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE;
 }
 


### PR DESCRIPTION
* `setExplicitOutFence` is never called and doesn't really set the fence. Renamed it to reflect the real purpose
* changed fence type to int32_t

> prop_out_fence_ptr
> 
>  Sync File fd pointer representing the outgoing fences for a CRTC. Userspace should provide a pointer to a value of type s32, and then cast that pointer to u64.
https://www.kernel.org/doc/html/v6.11/gpu/drm-kms.html
https://drmdb.emersion.fr/properties/3435973836/OUT_FENCE_PTR
https://drmdb.emersion.fr/properties/4008636142/IN_FENCE_FD
