### PR TITLE
scan only cards and not outputs, safeguard against null renderer

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -50,7 +50,7 @@ static udev_enumerate* enumDRMCards(udev* udev) {
         return nullptr;
 
     udev_enumerate_add_match_subsystem(enumerate, "drm");
-    udev_enumerate_add_match_sysname(enumerate, DRM_PRIMARY_MINOR_NAME "[0-9]*");
+    udev_enumerate_add_match_sysname(enumerate, DRM_PRIMARY_MINOR_NAME "[0-9]");
 
     if (udev_enumerate_scan_devices(enumerate)) {
         udev_enumerate_unref(enumerate);
@@ -75,8 +75,6 @@ static std::vector<SP<CSessionDevice>> scanGPUs(SP<CBackend> backend) {
     }
 
     udev_list_entry*               entry = nullptr;
-    size_t                         i     = 0;
-
     std::deque<SP<CSessionDevice>> devices;
 
     udev_list_entry_foreach(entry, udev_enumerate_get_list_entry(enumerate)) {
@@ -125,8 +123,6 @@ static std::vector<SP<CSessionDevice>> scanGPUs(SP<CBackend> backend) {
             devices.push_front(sessionDevice);
         else
             devices.push_back(sessionDevice);
-
-        ++i;
     }
 
     udev_enumerate_unref(enumerate);

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1400,6 +1400,11 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
         return false;
     }
 
+    if (!backend->rendererState.renderer) {
+        backend->backend->log(AQ_LOG_ERROR, "drm: No renderer attached to backend");
+        return false;
+    }
+
     const auto&    STATE     = state->state();
     const uint32_t COMMITTED = STATE.committed;
 


### PR DESCRIPTION
seems pointless scanning the card[0-9]-eDP etc outputs for kms/bootvga/rendernodes just use the [0-9] cards, also safegaurd in commitstate for missing renderer prevents a coredump if __EGL_VENDOR_LIBRARY_FILENAMES is set to mesa on a laptop with dual gpus and a monitor attached to the nvidia dgpu. it might be a way to make this handled better but now it doesnt segfault atleast with a null dereference to renderer.