### PR TITLE
drm: Validate conn before dereference in CDRMAtomicRequest::commit()

### DIFF
--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -162,6 +162,9 @@ bool Aquamarine::CDRMAtomicRequest::commit(uint32_t flagssss) {
         return false;
     }
 
+    if (!conn)
+        return false;
+
     if (auto ret = drmModeAtomicCommit(backend->gpu->fd, req, flagssss, &conn->pendingPageFlip); ret) {
         backend->log((flagssss & DRM_MODE_ATOMIC_TEST_ONLY) ? AQ_LOG_DEBUG : AQ_LOG_ERROR,
                      std::format("atomic drm request: failed to commit: {}, flags: {}", strerror(-ret), flagsToStr(flagssss)));


### PR DESCRIPTION
During startup, CDRMAtomicImpl::reset() may emit a call to method commit of a CDRMAtomicRequest instance with member "conn" uninitialized, leading to a segfault. Validate the the pointer before dereference it as a workaround.

Fixes: 55ac962 ("DRM: preliminary atomic support")
Closes: https://github.com/hyprwm/aquamarine/issues/107