### PR TITLE
allow multigpu blit from explicit to implicit

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -527,7 +527,7 @@ void Aquamarine::CDRMBackend::buildGlFormats(const std::vector<SGLFormat>& fmts)
     std::vector<SDRMFormat> result;
 
     for (auto const& fmt : fmts) {
-        if (fmt.external)
+        if (fmt.external && fmt.modifier != DRM_FORMAT_MOD_INVALID)
             continue;
 
         if (auto it = std::find_if(result.begin(), result.end(), [fmt](const auto& e) { return fmt.drmFormat == e.drmFormat; }); it != result.end()) {

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -809,11 +809,6 @@ bool CDRMRenderer::verifyDestinationDMABUF(const SDMABUFAttrs& attrs) {
         if (fmt.modifier != attrs.modifier)
             continue;
 
-        if (fmt.external) {
-            backend->log(AQ_LOG_ERROR, "EGL (verifyDestinationDMABUF): FAIL, format is external-only");
-            return false;
-        }
-
         return true;
     }
 


### PR DESCRIPTION
fixes hyprwm/Hyprland#8354

this does
* errors before alloc when plane or backend doesn't support requested format in gbm
* allow implicit modifier buffers to be allocated by not forcing linear in gbm
* allow implicit modifiers to be added to glFormats
* allow the blit to_buffer to use external formats (cause implicit is external)