### PR TITLE
udev scan only cards (drm_minor), not connectors (drm_connector)

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -50,7 +50,8 @@ static udev_enumerate* enumDRMCards(udev* udev) {
         return nullptr;
 
     udev_enumerate_add_match_subsystem(enumerate, "drm");
-    udev_enumerate_add_match_sysname(enumerate, DRM_PRIMARY_MINOR_NAME "[0-9]");
+    udev_enumerate_add_match_property(enumerate, "DEVTYPE", "drm_minor");
+    udev_enumerate_add_match_sysname(enumerate, DRM_PRIMARY_MINOR_NAME "[0-9]*");
 
     if (udev_enumerate_scan_devices(enumerate)) {
         udev_enumerate_unref(enumerate);


### PR DESCRIPTION
might or might not fix #110, author hasn't responded
but i think this pr makes sense anyways

drm_minor => ex. card1 and render128
drm_connector => ex. card1-DP-1 or card1-HDMI-A-1