### PR TITLE
log errno set by drmModeAtomicCommit

### DIFF
--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -167,7 +167,7 @@ bool Aquamarine::CDRMAtomicRequest::commit(uint32_t flagssss) {
 
     if (auto ret = drmModeAtomicCommit(backend->gpu->fd, req, flagssss, &conn->pendingPageFlip); ret) {
         backend->log((flagssss & DRM_MODE_ATOMIC_TEST_ONLY) ? AQ_LOG_DEBUG : AQ_LOG_ERROR,
-                     std::format("atomic drm request: failed to commit: {}, flags: {}", strerror(-ret), flagsToStr(flagssss)));
+                     std::format("atomic drm request: failed to commit: {}, flags: {}", strerror(ret == -1 ? errno : -ret), flagsToStr(flagssss)));
         return false;
     }
 


### PR DESCRIPTION
drmModeAtomicCommit sets errno sometimes instead of returning it...

ex. returns -1 but errno = ENOMEM