### PR TITLE
Revert #108

### DIFF
--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -162,9 +162,6 @@ bool Aquamarine::CDRMAtomicRequest::commit(uint32_t flagssss) {
         return false;
     }
 
-    if (!conn)
-        return false;
-
     if (auto ret = drmModeAtomicCommit(backend->gpu->fd, req, flagssss, &conn->pendingPageFlip); ret) {
         backend->log((flagssss & DRM_MODE_ATOMIC_TEST_ONLY) ? AQ_LOG_DEBUG : AQ_LOG_ERROR,
                      std::format("atomic drm request: failed to commit: {}, flags: {}", strerror(ret == -1 ? errno : -ret), flagsToStr(flagssss)));


### PR DESCRIPTION
This is causing a major regression on some Nvidia laptops that leads to the system becoming frozen after returning from suspend. Fixes #125.

This reverts commit 4468981c1c50999f315baa1508f0e53c4ee70c52 for the time being.
