### PR TITLE
GPU hotplug support

### DIFF
--- a/include/aquamarine/allocator/Allocator.hpp
+++ b/include/aquamarine/allocator/Allocator.hpp
@@ -26,6 +26,6 @@ namespace Aquamarine {
         virtual Hyprutils::Memory::CSharedPointer<CBackend> getBackend()                                                                                           = 0;
         virtual int                                         drmFD()                                                                                                = 0;
         virtual eAllocatorType                              type()                                                                                                 = 0;
-        virtual void                                        destroyBuffers() {};
+        virtual void                                        destroyBuffers();
     };
 };

--- a/include/aquamarine/allocator/Allocator.hpp
+++ b/include/aquamarine/allocator/Allocator.hpp
@@ -26,5 +26,6 @@ namespace Aquamarine {
         virtual Hyprutils::Memory::CSharedPointer<CBackend> getBackend()                                                                                           = 0;
         virtual int                                         drmFD()                                                                                                = 0;
         virtual eAllocatorType                              type()                                                                                                 = 0;
+        virtual void                                        destroyBuffers() {};
     };
 };

--- a/include/aquamarine/allocator/GBM.hpp
+++ b/include/aquamarine/allocator/GBM.hpp
@@ -46,6 +46,7 @@ namespace Aquamarine {
         virtual Hyprutils::Memory::CSharedPointer<CBackend>     getBackend();
         virtual int                                             drmFD();
         virtual eAllocatorType                                  type();
+        virtual void                                            destroyBuffers();
 
         //
         Hyprutils::Memory::CWeakPointer<CGBMAllocator> self;

--- a/include/aquamarine/backend/Backend.hpp
+++ b/include/aquamarine/backend/Backend.hpp
@@ -117,6 +117,9 @@ namespace Aquamarine {
         // utils
         int reopenDRMNode(int drmFD, bool allowRenderNode = true);
 
+        // called when a new DRM card is hotplugged
+        void onNewGpu(std::string path);
+
         struct {
             Hyprutils::Signal::CSignal newOutput;
             Hyprutils::Signal::CSignal newPointer;
@@ -126,6 +129,8 @@ namespace Aquamarine {
             Hyprutils::Signal::CSignal newTablet;
             Hyprutils::Signal::CSignal newTabletTool;
             Hyprutils::Signal::CSignal newTabletPad;
+
+            Hyprutils::Signal::CSignal pollFDsChanged;
         } events;
 
         Hyprutils::Memory::CSharedPointer<IAllocator> primaryAllocator;
@@ -159,5 +164,7 @@ namespace Aquamarine {
             std::mutex              loopRequestMutex;
             std::mutex              eventLock;
         } m_sEventLoopInternals;
+
+        friend class CDRMBackend;
     };
 };

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -389,6 +389,9 @@ namespace Aquamarine {
         CDRMBackend(Hyprutils::Memory::CSharedPointer<CBackend> backend);
 
         static std::vector<Hyprutils::Memory::CSharedPointer<CDRMBackend>> attempt(Hyprutils::Memory::CSharedPointer<CBackend> backend);
+        static Hyprutils::Memory::CSharedPointer<CDRMBackend>              fromGpu(std::string path, Hyprutils::Memory::CSharedPointer<CBackend> backend,
+                                                                                   Hyprutils::Memory::CSharedPointer<CDRMBackend> primary);
+
         bool registerGPU(Hyprutils::Memory::CSharedPointer<CSessionDevice> gpu_, Hyprutils::Memory::CSharedPointer<CDRMBackend> primary_ = {});
         bool checkFeatures();
         bool initResources();

--- a/src/allocator/Allocator.cpp
+++ b/src/allocator/Allocator.cpp
@@ -1,0 +1,3 @@
+#include <aquamarine/allocator/Allocator.hpp>
+
+void Aquamarine::IAllocator::destroyBuffers() {}

--- a/src/allocator/GBM.cpp
+++ b/src/allocator/GBM.cpp
@@ -284,7 +284,7 @@ void Aquamarine::CGBMBuffer::endDataPtr() {
 
 void CGBMAllocator::destroyBuffers() {
     for (auto& buf : buffers) {
-        buf.reset()
+        buf.reset();
     }
 }
 

--- a/src/allocator/GBM.cpp
+++ b/src/allocator/GBM.cpp
@@ -282,7 +282,7 @@ void Aquamarine::CGBMBuffer::endDataPtr() {
 }
 
 void CGBMAllocator::destroyBuffers() {
-    for (auto &buf : buffers) {
+    for (auto& buf : buffers) {
         buf.impl_->destroy();
     }
 }

--- a/src/allocator/GBM.cpp
+++ b/src/allocator/GBM.cpp
@@ -228,8 +228,9 @@ Aquamarine::CGBMBuffer::CGBMBuffer(const SAllocatorBufferParams& params, Hypruti
 }
 
 Aquamarine::CGBMBuffer::~CGBMBuffer() {
-    for (size_t i = 0; i < (size_t)attrs.planes; i++)
+    for (size_t i = 0; i < (size_t)attrs.planes; i++) {
         close(attrs.fds.at(i));
+    }
 
     events.destroy.emit();
     if (bo) {

--- a/src/allocator/GBM.cpp
+++ b/src/allocator/GBM.cpp
@@ -283,7 +283,7 @@ void Aquamarine::CGBMBuffer::endDataPtr() {
 
 void CGBMAllocator::destroyBuffers() {
     for (auto& buf : buffers) {
-        buf.impl_->destroy();
+        buf.reset()
     }
 }
 

--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -276,7 +276,7 @@ void Aquamarine::CBackend::onNewGpu(std::string path) {
     const auto primaryDrm = primary != implementations.end() ? ((Aquamarine::CDRMBackend*)(*primary).get())->self.lock() : nullptr;
 
     auto       ref = CDRMBackend::fromGpu(path, self.lock(), primaryDrm);
-    if (ref == nullptr) {
+    if (!ref) {
         log(AQ_LOG_ERROR, std::format("DRM Backend failed for device {}", path));
         return;
     }

--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -288,7 +288,7 @@ void Aquamarine::CBackend::onNewGpu(std::string path) {
     implementations.emplace_back(ref);
     events.pollFDsChanged.emit();
 
-    ref->onReady(); // Renderer created here
+    ref->onReady();        // Renderer created here
     ref->recheckOutputs(); // Now we can recheck outputs
 }
 

--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -271,6 +271,27 @@ void Aquamarine::CBackend::dispatchIdle() {
     updateIdleTimer();
 }
 
+void Aquamarine::CBackend::onNewGpu(std::string path) {
+    const auto primary    = std::ranges::find_if(implementations, [](SP<IBackendImplementation> value) { return value->type() == Aquamarine::AQ_BACKEND_DRM; });
+    const auto primaryDrm = primary != implementations.end() ? ((Aquamarine::CDRMBackend*)(*primary).get())->self.lock() : nullptr;
+
+    auto       ref = CDRMBackend::fromGpu(path, self.lock(), primaryDrm);
+    if (ref == nullptr) {
+        log(AQ_LOG_ERROR, std::format("DRM Backend failed for device {}", path));
+        return;
+    }
+    if (!ref->start()) {
+        log(AQ_LOG_ERROR, std::format("Couldn't start DRM Backend for device {}", path));
+        return;
+    }
+
+    implementations.emplace_back(ref);
+    events.pollFDsChanged.emit();
+
+    ref->onReady(); // Renderer created here
+    ref->recheckOutputs(); // Now we can recheck outputs
+}
+
 // Yoinked from wlroots, render/allocator/allocator.c
 // Ref-counting reasons, see https://gitlab.freedesktop.org/mesa/drm/-/merge_requests/110
 int Aquamarine::CBackend::reopenDRMNode(int drmFD, bool allowRenderNode) {

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -296,6 +296,12 @@ void Aquamarine::CSession::dispatchUdevEvents() {
         }
     }
 
+    if (!sessionDevice && action == std::string{"add"}) {
+        backend->onNewGpu(devnode);
+        udev_device_unref(device);
+        return;
+    }
+
     if (!sessionDevice) {
         udev_device_unref(device);
         return;
@@ -330,6 +336,7 @@ void Aquamarine::CSession::dispatchUdevEvents() {
     } else if (action == std::string{"remove"}) {
         backend->log(AQ_LOG_DEBUG, std::format("udev: DRM device {} removed", sysname ? sysname : "unknown"));
         sessionDevice->events.remove.emit();
+        std::erase_if(sessionDevices, [sessionDevice](const auto& sd) { return sd == sessionDevice; });
     }
 
     udev_device_unref(device);

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -307,15 +307,14 @@ std::vector<SP<CDRMBackend>> Aquamarine::CDRMBackend::attempt(SP<CBackend> backe
 
 Aquamarine::CDRMBackend::~CDRMBackend() {
     for (auto conn : connectors) {
-        if (conn && conn->output)
-            conn->output->events.destroy.emit();
-        conn.impl_->destroy();
+        conn->disconnect();
+        conn.reset();
     }
 
     rendererState.allocator->destroyBuffers();
 
-    rendererState.renderer.impl_->destroy();
-    rendererState.allocator.impl_->destroy();
+    rendererState.renderer.reset();
+    rendererState.allocator.reset();
 }
 
 void Aquamarine::CDRMBackend::log(eBackendLogLevel l, const std::string& s) {

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -181,6 +181,43 @@ static std::vector<SP<CSessionDevice>> scanGPUs(SP<CBackend> backend) {
     return vecDevices;
 }
 
+SP<CDRMBackend> Aquamarine::CDRMBackend::fromGpu(std::string path, SP<CBackend> backend, SP<CDRMBackend> primary) {
+    auto gpu = CSessionDevice::openIfKMS(backend->session, path);
+    if (!gpu) {
+        return nullptr;
+    }
+
+    auto drmBackend  = SP<CDRMBackend>(new CDRMBackend(backend));
+    drmBackend->self = drmBackend;
+
+    if (!drmBackend->registerGPU(gpu, primary)) {
+        backend->log(AQ_LOG_ERROR, std::format("drm: Failed to register gpu {}", gpu->path));
+        return nullptr;
+    } else
+        backend->log(AQ_LOG_DEBUG, std::format("drm: Registered gpu {}", gpu->path));
+
+    if (!drmBackend->checkFeatures()) {
+        backend->log(AQ_LOG_ERROR, "drm: Failed checking features");
+        return nullptr;
+    }
+
+    if (!drmBackend->initResources()) {
+        backend->log(AQ_LOG_ERROR, "drm: Failed initializing resources");
+        return nullptr;
+    }
+
+    backend->log(AQ_LOG_DEBUG, std::format("drm: Basic init pass for gpu {}", gpu->path));
+
+    drmBackend->grabFormats();
+
+    drmBackend->dumbAllocator = CDRMDumbAllocator::create(gpu->fd, backend);
+
+    // so that session can handle udev change/remove events for this gpu
+    backend->session->sessionDevices.push_back(gpu);
+
+    return drmBackend;
+}
+
 std::vector<SP<CDRMBackend>> Aquamarine::CDRMBackend::attempt(SP<CBackend> backend) {
     if (!backend->session)
         backend->session = CSession::attempt(backend);
@@ -269,7 +306,16 @@ std::vector<SP<CDRMBackend>> Aquamarine::CDRMBackend::attempt(SP<CBackend> backe
 }
 
 Aquamarine::CDRMBackend::~CDRMBackend() {
-    ;
+    for (auto conn : connectors) {
+        if (conn && conn->output)
+            conn->output->events.destroy.emit();
+        conn.impl_->destroy();
+    }
+
+    rendererState.allocator->destroyBuffers();
+
+    rendererState.renderer.impl_->destroy();
+    rendererState.allocator.impl_->destroy();
 }
 
 void Aquamarine::CDRMBackend::log(eBackendLogLevel l, const std::string& s) {
@@ -663,8 +709,10 @@ bool Aquamarine::CDRMBackend::registerGPU(SP<CSessionDevice> gpu_, SP<CDRMBacken
         }
     });
 
-    listeners.gpuRemove = gpu->events.remove.registerListener(
-        [this](std::any d) { backend->log(AQ_LOG_ERROR, std::format("drm: !!!!FIXME: Got a remove event for {}, this is not handled properly!!!!!", gpuName)); });
+    listeners.gpuRemove = gpu->events.remove.registerListener([this](std::any d) {
+        std::erase_if(backend->implementations, [this](const auto& impl) { return impl->drmFD() == this->drmFD(); });
+        backend->events.pollFDsChanged.emit();
+    });
 
     return true;
 }

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -197,6 +197,15 @@ bool CDRMRenderer::initDRMFormats() {
     return true;
 }
 
+Aquamarine::CDRMRenderer::~CDRMRenderer() {
+    eglMakeCurrent(egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    eglDestroyContext(egl.display, egl.context);
+
+    eglTerminate(egl.display);
+
+    eglReleaseThread();
+}
+
 SP<CDRMRenderer> CDRMRenderer::attempt(Hyprutils::Memory::CSharedPointer<CGBMAllocator> allocator_, SP<CBackend> backend_) {
     SP<CDRMRenderer> renderer = SP<CDRMRenderer>(new CDRMRenderer());
     renderer->drmFD           = allocator_->drmFD();

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -42,6 +42,7 @@ namespace Aquamarine {
 
     class CDRMRenderer {
       public:
+        ~CDRMRenderer();
         static Hyprutils::Memory::CSharedPointer<CDRMRenderer> attempt(Hyprutils::Memory::CSharedPointer<CGBMAllocator> allocator_,
                                                                        Hyprutils::Memory::CSharedPointer<CBackend>      backend_);
 


### PR DESCRIPTION
### Use Case

I have a Lenovo Legion 5 Pro (16ACH6H) laptop with an AMD iGPU and an NVIDIA dGPU. I want the flexibility to use different modules for the dGPU depending on my needs:

1. **No module**: startup and power-saving.
2. **`vfio-pci`**: For passthrough to a vm.
3. **`nouveau`**: To use the connectors connected to the dGPU exclusively for driving additional monitors.
4. **`nvidia` (without modesetting)**: For CUDA workloads, offloaded rendering, etc.

---

### Workflow involving Hyprland
1. **Load nouveau**:  
  I can now use the outputs connected to my dGPU only.
2. **Signal Aquamarine to release the dGPU**:
  ```bash
  udevadm trigger --type=devices --action=remove --subsystem-match=drm --property-match="MINOR=0"
  ```
3. **Unload nouveau and load something else.**

---

I'm happy to take this to the finish line in case any changes are required.