### PR TITLE
fix headless supported formats

### DIFF
--- a/src/backend/Headless.cpp
+++ b/src/backend/Headless.cpp
@@ -51,7 +51,6 @@ bool Aquamarine::CHeadlessOutput::test() {
 }
 
 std::vector<SDRMFormat> Aquamarine::CHeadlessOutput::getRenderFormats() {
-    // not sure if this is right but prob doest matter
     return backend->getRenderFormats();
 }
 
@@ -119,9 +118,29 @@ void Aquamarine::CHeadlessBackend::onReady() {
 }
 
 std::vector<SDRMFormat> Aquamarine::CHeadlessBackend::getRenderFormats() {
-    // FIXME: allow any modifier. Maybe set INVALID to mean that? or a special value?
-    return {SDRMFormat{.drmFormat = DRM_FORMAT_RGBA8888, .modifiers = {DRM_FORMAT_MOD_LINEAR}},
-            SDRMFormat{.drmFormat = DRM_FORMAT_RGBA1010102, .modifiers = {DRM_FORMAT_MOD_LINEAR}}};
+    for (const auto& impl : backend->getImplementations()) {
+        if (impl->type() != AQ_BACKEND_DRM || impl->getRenderableFormats().empty())
+            continue;
+        return impl->getRenderableFormats();
+    }
+
+    // formats probably supported by EGL
+    return {SDRMFormat{.drmFormat = DRM_FORMAT_XRGB8888, .modifiers = {DRM_FORMAT_INVALID}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_XBGR8888, .modifiers = {DRM_FORMAT_INVALID}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_RGBX8888, .modifiers = {DRM_FORMAT_INVALID}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_BGRX8888, .modifiers = {DRM_FORMAT_INVALID}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_ARGB8888, .modifiers = {DRM_FORMAT_INVALID}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_ABGR8888, .modifiers = {DRM_FORMAT_INVALID}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_RGBA8888, .modifiers = {DRM_FORMAT_INVALID}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_BGRA8888, .modifiers = {DRM_FORMAT_INVALID}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_XRGB2101010, .modifiers = {DRM_FORMAT_MOD_LINEAR}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_XBGR2101010, .modifiers = {DRM_FORMAT_MOD_LINEAR}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_RGBX1010102, .modifiers = {DRM_FORMAT_MOD_LINEAR}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_BGRX1010102, .modifiers = {DRM_FORMAT_MOD_LINEAR}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_ARGB2101010, .modifiers = {DRM_FORMAT_MOD_LINEAR}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_ABGR2101010, .modifiers = {DRM_FORMAT_MOD_LINEAR}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_RGBA1010102, .modifiers = {DRM_FORMAT_MOD_LINEAR}},
+            SDRMFormat{.drmFormat = DRM_FORMAT_BGRA1010102, .modifiers = {DRM_FORMAT_MOD_LINEAR}}};
 }
 
 std::vector<SDRMFormat> Aquamarine::CHeadlessBackend::getCursorFormats() {


### PR DESCRIPTION
fix hyprwm/Hyprland#8806
grabs EGL formats from DRM backend or uses a set of usually supported formats