### PR TITLE
Support setting drm content type property

### DIFF
--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -78,6 +78,7 @@ namespace Aquamarine {
             Hyprutils::Math::Mat3x3                        ctm;
             bool                                           wideColorGamut = false;
             hdr_output_metadata                            hdrMetadata;
+            uint16_t                                       contentType = DRM_MODE_CONTENT_TYPE_GRAPHICS;
         };
 
         const SInternalState& state();
@@ -99,6 +100,7 @@ namespace Aquamarine {
         void                  setCTM(const Hyprutils::Math::Mat3x3& ctm);
         void                  setWideColorGamut(bool wcg);
         void                  setHDRMetadata(const hdr_output_metadata& metadata);
+        void                  setContentType(const uint16_t drmContentType);
 
       private:
         SInternalState internalState;

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -105,9 +105,8 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
 
     add(connector->id, connector->props.crtc_id, enable ? connector->crtc->id : 0);
 
-    // TODO: allow to send aq a content type, maybe? Wayland has a protocol for this.
     if (enable && connector->props.content_type)
-        add(connector->id, connector->props.content_type, DRM_MODE_CONTENT_TYPE_GRAPHICS);
+        add(connector->id, connector->props.content_type, STATE.contentType);
 
     add(connector->crtc->id, connector->crtc->props.active, enable);
 

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -138,6 +138,10 @@ void Aquamarine::COutputState::setHDRMetadata(const hdr_output_metadata& metadat
     internalState.committed |= AQ_OUTPUT_STATE_HDR;
 }
 
+void Aquamarine::COutputState::setContentType(const uint16_t drmContentType) {
+    internalState.contentType = drmContentType;
+}
+
 void Aquamarine::COutputState::onCommit() {
     internalState.committed = 0;
     internalState.damage.clear();


### PR DESCRIPTION
API to set drm content type property. https://drmdb.emersion.fr/properties/3233857728/content%20type
Nvidia doesn't support it. Untested. Probably needs monitor support to be useful.