### PR TITLE
Compiler fixes and options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,12 @@ pkg_check_modules(
 configure_file(aquamarine.pc.in aquamarine.pc @ONLY)
 
 set(CMAKE_CXX_STANDARD 23)
+add_compile_options(
+  -Wall
+  -Wextra
+  -Wno-unused-parameter
+  -Wno-unused-value
+  -Wno-missing-field-initializers)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)

--- a/src/allocator/DRMDumb.cpp
+++ b/src/allocator/DRMDumb.cpp
@@ -154,6 +154,6 @@ eAllocatorType Aquamarine::CDRMDumbAllocator::type() {
     return eAllocatorType::AQ_ALLOCATOR_TYPE_DRM_DUMB;
 }
 
-Aquamarine::CDRMDumbAllocator::CDRMDumbAllocator(int fd_, Hyprutils::Memory::CWeakPointer<CBackend> backend_) : drmfd(fd_), backend(backend_) {
+Aquamarine::CDRMDumbAllocator::CDRMDumbAllocator(int fd_, Hyprutils::Memory::CWeakPointer<CBackend> backend_) : backend(backend_), drmfd(fd_) {
     ; // nothing to do
 }

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -118,7 +118,7 @@ static const libinput_interface libinputListener = {
 
 // ------------
 
-Aquamarine::CSessionDevice::CSessionDevice(Hyprutils::Memory::CSharedPointer<CSession> session_, const std::string& path_) : session(session_), path(path_) {
+Aquamarine::CSessionDevice::CSessionDevice(Hyprutils::Memory::CSharedPointer<CSession> session_, const std::string& path_) : path(path_), session(session_) {
     deviceID = libseat_open_device(session->libseatHandle, path.c_str(), &fd);
     if (deviceID < 0) {
         session->backend->log(AQ_LOG_ERROR, std::format("libseat: Couldn't open device at {}", path_));

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -1025,7 +1025,7 @@ Aquamarine::CLibinputTabletPad::CLibinputTabletPad(Hyprutils::Memory::CSharedPoi
     paths.emplace_back(udev_device_get_syspath(udevice));
 
     int groupsno = libinput_device_tablet_pad_get_num_mode_groups(device->device);
-    for (size_t i = 0; i < groupsno; ++i) {
+    for (int i = 0; i < groupsno; ++i) {
         auto g = createGroupFromID(i);
         if (g)
             groups.emplace_back(g);

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -783,7 +783,7 @@ Aquamarine::CWaylandBuffer::CWaylandBuffer(SP<IBuffer> buffer_, Hyprutils::Memor
 
     auto attrs = buffer->dmabuf();
 
-    for (size_t i = 0; i < attrs.planes; ++i) {
+    for (int i = 0; i < attrs.planes; ++i) {
         params->sendAdd(attrs.fds.at(i), i, attrs.offsets.at(i), attrs.strides.at(i), attrs.modifier >> 32, attrs.modifier & 0xFFFFFFFF);
     }
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -470,7 +470,7 @@ bool Aquamarine::CDRMBackend::initResources() {
 
     backend->log(AQ_LOG_DEBUG, std::format("drm: found {} CRTCs", resources->count_crtcs));
 
-    for (size_t i = 0; i < resources->count_crtcs; ++i) {
+    for (int i = 0; i < resources->count_crtcs; ++i) {
         auto CRTC     = makeShared<SDRMCRTC>();
         CRTC->id      = resources->crtcs[i];
         CRTC->backend = self;
@@ -762,7 +762,7 @@ void Aquamarine::CDRMBackend::scanConnectors() {
         return;
     }
 
-    for (size_t i = 0; i < resources->count_connectors; ++i) {
+    for (int i = 0; i < resources->count_connectors; ++i) {
         uint32_t          connectorID = resources->connectors[i];
 
         SP<SDRMConnector> conn;
@@ -804,7 +804,7 @@ void Aquamarine::CDRMBackend::scanConnectors() {
 
     // cleanup hot unplugged connectors
     std::erase_if(connectors, [resources](const auto& conn) {
-        for (size_t i = 0; i < resources->count_connectors; ++i) {
+        for (int i = 0; i < resources->count_connectors; ++i) {
             if (resources->connectors[i] == conn->id)
                 return false;
         }
@@ -2103,7 +2103,7 @@ uint32_t Aquamarine::CDRMFB::submitBuffer() {
 
     auto                    attrs = buffer->dmabuf();
     std::array<uint64_t, 4> mods  = {0, 0, 0, 0};
-    for (size_t i = 0; i < attrs.planes; ++i) {
+    for (int i = 0; i < attrs.planes; ++i) {
         mods[i] = attrs.modifier;
     }
 

--- a/src/backend/drm/Props.cpp
+++ b/src/backend/drm/Props.cpp
@@ -111,7 +111,7 @@ namespace Aquamarine {
         if (!prop)
             return false;
 
-        for (uint32_t i = 0; i < prop->count_enums; ++i) {
+        for (int i = 0; i < prop->count_enums; ++i) {
             const prop_info* p = (prop_info*)bsearch(prop->enums[i].name, info, info_len, sizeof(info[0]), comparePropInfo);
             if (p)
                 result[p->index] = prop->enums[i].value;

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -1039,6 +1039,6 @@ bool CDRMRenderer::verifyDestinationDMABUF(const SDMABUFAttrs& attrs) {
 
 CDRMRendererBufferAttachment::CDRMRendererBufferAttachment(Hyprutils::Memory::CWeakPointer<CDRMRenderer> renderer_, Hyprutils::Memory::CSharedPointer<IBuffer> buffer,
                                                            EGLImageKHR image, GLuint fbo_, GLuint rbo_, SGLTex tex_) :
-    eglImage(image), fbo(fbo_), rbo(rbo_), renderer(renderer_), tex(tex_) {
+    eglImage(image), fbo(fbo_), rbo(rbo_), tex(tex_), renderer(renderer_) {
     bufferDestroy = buffer->events.destroy.registerListener([this](std::any d) { renderer->onBufferAttachmentDrop(this); });
 }


### PR DESCRIPTION
As i said in the title
There's only 5 warnings left
3 of them is unused variable, 1 unused, but set variable and a implicit fallthrough