### PR TITLE
drm: only allow multigpu blit to implcit, not all external formats

### DIFF
--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -1030,6 +1030,11 @@ bool CDRMRenderer::verifyDestinationDMABUF(const SDMABUFAttrs& attrs) {
         if (fmt.modifier != attrs.modifier)
             continue;
 
+        if (fmt.modifier != DRM_FORMAT_INVALID && fmt.external) {
+            backend->log(AQ_LOG_ERROR, "EGL (verifyDestinationDMABUF): FAIL, format is external-only");
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
realized while looking back at #114, oops