### PR TITLE
Fix multi-GPU support for Nvidia

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1700,8 +1700,12 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
             }
 
             auto NEWAQBUF   = mgpu.swapchain->next(nullptr);
+            SP<Aquamarine::CDRMRenderer> primaryRenderer;
+            if (backend->primary) {
+                primaryRenderer = backend->primary->rendererState.renderer;
+            }
             auto blitResult = backend->rendererState.renderer->blit(
-                STATE.buffer, NEWAQBUF, (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE) ? STATE.explicitInFence : -1);
+                STATE.buffer, NEWAQBUF, primaryRenderer, (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE) ? STATE.explicitInFence : -1);
             if (!blitResult.success) {
                 backend->backend->log(AQ_LOG_ERROR, "drm: Backend requires blit, but blit failed");
                 return false;
@@ -1882,7 +1886,11 @@ bool Aquamarine::CDRMOutput::setCursor(SP<IBuffer> buffer, const Vector2D& hotsp
             }
 
             auto NEWAQBUF = mgpu.cursorSwapchain->next(nullptr);
-            if (!backend->rendererState.renderer->blit(buffer, NEWAQBUF).success) {
+            SP<Aquamarine::CDRMRenderer> primaryRenderer;
+            if (backend->primary) {
+                primaryRenderer = backend->primary->rendererState.renderer;
+            }
+            if (!backend->rendererState.renderer->blit(buffer, NEWAQBUF, primaryRenderer).success) {
                 backend->backend->log(AQ_LOG_ERROR, "drm: Backend requires blit, but cursor blit failed");
                 return false;
             }

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1699,11 +1699,10 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
                 return false;
             }
 
-            auto NEWAQBUF   = mgpu.swapchain->next(nullptr);
+            auto                         NEWAQBUF = mgpu.swapchain->next(nullptr);
             SP<Aquamarine::CDRMRenderer> primaryRenderer;
-            if (backend->primary) {
+            if (backend->primary)
                 primaryRenderer = backend->primary->rendererState.renderer;
-            }
             auto blitResult = backend->rendererState.renderer->blit(
                 STATE.buffer, NEWAQBUF, primaryRenderer, (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE) ? STATE.explicitInFence : -1);
             if (!blitResult.success) {
@@ -1885,11 +1884,10 @@ bool Aquamarine::CDRMOutput::setCursor(SP<IBuffer> buffer, const Vector2D& hotsp
                 return false;
             }
 
-            auto NEWAQBUF = mgpu.cursorSwapchain->next(nullptr);
+            auto                         NEWAQBUF = mgpu.cursorSwapchain->next(nullptr);
             SP<Aquamarine::CDRMRenderer> primaryRenderer;
-            if (backend->primary) {
+            if (backend->primary)
                 primaryRenderer = backend->primary->rendererState.renderer;
-            }
             if (!backend->rendererState.renderer->blit(buffer, NEWAQBUF, primaryRenderer).success) {
                 backend->backend->log(AQ_LOG_ERROR, "drm: Backend requires blit, but cursor blit failed");
                 return false;

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -698,7 +698,6 @@ SGLTex CDRMRenderer::glTex(Hyprutils::Memory::CSharedPointer<IBuffer> buffa) {
     return tex;
 }
 
-// TODO: Would another format be more efficient than GL_RGBA?
 constexpr GLenum PIXEL_BUFFER_FORMAT = GL_RGBA;
 
 void             CDRMRenderer::readBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buf, std::span<uint8_t> out) {

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -9,7 +9,6 @@
 #include "Shared.hpp"
 #include "FormatUtils.hpp"
 #include <aquamarine/allocator/GBM.hpp>
-#include <span>
 
 using namespace Aquamarine;
 using namespace Hyprutils::Memory;
@@ -924,7 +923,7 @@ CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, S
             from->attachments.add(newAttachment);
         }
 
-        if (!intermediateBuf.empty()) {
+        if (!intermediateBuf.empty() && primaryRenderer) {
             // Note: this might modify from's attachments
             primaryRenderer->readBuffer(from, intermediateBuf);
         }

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -1033,9 +1033,8 @@ CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, S
     GLCALL(glTexParameteri(fromTex.target, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
     GLCALL(glTexParameteri(fromTex.target, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
 
-    if (intermediateBuf) {
+    if (intermediateBuf)
         GLCALL(glTexImage2D(fromTex.target, 0, PIXEL_BUFFER_FORMAT, fromDma.size.x, fromDma.size.y, 0, PIXEL_BUFFER_FORMAT, GL_UNSIGNED_BYTE, intermediateBuf));
-    }
 
     GLCALL(glUseProgram(SHADER.program));
     GLCALL(glDisable(GL_BLEND));

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -24,7 +24,7 @@ namespace Aquamarine {
     class CDRMRendererBufferAttachment : public IAttachment {
       public:
         CDRMRendererBufferAttachment(Hyprutils::Memory::CWeakPointer<CDRMRenderer> renderer_, Hyprutils::Memory::CSharedPointer<IBuffer> buffer, EGLImageKHR image, GLuint fbo_,
-                                     GLuint rbo_, SGLTex tex);
+                                     GLuint rbo_, SGLTex tex, uint8_t* intermediateBuf, size_t intermediateBufLen);
         virtual ~CDRMRendererBufferAttachment() {
             ;
         }
@@ -36,6 +36,8 @@ namespace Aquamarine {
         GLuint                                        fbo = 0, rbo = 0;
         SGLTex                                        tex;
         Hyprutils::Signal::CHyprSignalListener        bufferDestroy;
+        uint8_t*                                      intermediateBuf    = nullptr;
+        size_t                                        intermediateBufLen = 0;
 
         Hyprutils::Memory::CWeakPointer<CDRMRenderer> renderer;
     };
@@ -55,7 +57,8 @@ namespace Aquamarine {
             std::optional<int> syncFD;
         };
 
-        SBlitResult blit(Hyprutils::Memory::CSharedPointer<IBuffer> from, Hyprutils::Memory::CSharedPointer<IBuffer> to, int waitFD = -1);
+        SBlitResult blit(Hyprutils::Memory::CSharedPointer<IBuffer> from, Hyprutils::Memory::CSharedPointer<IBuffer> to,
+                         Hyprutils::Memory::CSharedPointer<CDRMRenderer> primaryRenderer, int waitFD = -1);
         // can't be a SP<> because we call it from buf's ctor...
         void clearBuffer(IBuffer* buf);
 
@@ -86,6 +89,7 @@ namespace Aquamarine {
             PFNEGLDEBUGMESSAGECONTROLKHRPROC              eglDebugMessageControlKHR              = nullptr;
             PFNEGLQUERYDEVICESEXTPROC                     eglQueryDevicesEXT                     = nullptr;
             PFNEGLQUERYDEVICESTRINGEXTPROC                eglQueryDeviceStringEXT                = nullptr;
+            PFNGLREADNPIXELSEXTPROC                       glReadnPixelsEXT                       = nullptr;
         } proc;
 
         struct {
@@ -114,6 +118,7 @@ namespace Aquamarine {
         } savedEGLState;
 
         SGLTex                                        glTex(Hyprutils::Memory::CSharedPointer<IBuffer> buf);
+        void                                          readBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buf, uint8_t* out, size_t out_len);
 
         Hyprutils::Memory::CWeakPointer<CDRMRenderer> self;
         std::vector<SGLFormat>                        formats;

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <tuple>
 #include <vector>
+#include <span>
 
 namespace Aquamarine {
 

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -32,10 +32,10 @@ namespace Aquamarine {
             return AQ_ATTACHMENT_DRM_RENDERER_DATA;
         }
 
-        EGLImageKHR                                   eglImage = nullptr;
-        GLuint                                        fbo = 0, rbo = 0;
-        SGLTex                                        tex;
-        Hyprutils::Signal::CHyprSignalListener        bufferDestroy;
+        EGLImageKHR                            eglImage = nullptr;
+        GLuint                                 fbo = 0, rbo = 0;
+        SGLTex                                 tex;
+        Hyprutils::Signal::CHyprSignalListener bufferDestroy;
         // This is malloc'd manually instead of using a std::vector to keep lifetime management in line with the rest of the class,
         // which e.g. doesn't immediately free the eglImage on drop but instead waits until onBufferAttachmentDrop.
         uint8_t*                                      intermediateBuf    = nullptr;

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -24,7 +24,7 @@ namespace Aquamarine {
     class CDRMRendererBufferAttachment : public IAttachment {
       public:
         CDRMRendererBufferAttachment(Hyprutils::Memory::CWeakPointer<CDRMRenderer> renderer_, Hyprutils::Memory::CSharedPointer<IBuffer> buffer, EGLImageKHR image, GLuint fbo_,
-                                     GLuint rbo_, SGLTex tex, uint8_t* intermediateBuf, size_t intermediateBufLen);
+                                     GLuint rbo_, SGLTex tex, std::vector<uint8_t> intermediateBuf_);
         virtual ~CDRMRendererBufferAttachment() {
             ;
         }
@@ -32,14 +32,11 @@ namespace Aquamarine {
             return AQ_ATTACHMENT_DRM_RENDERER_DATA;
         }
 
-        EGLImageKHR                            eglImage = nullptr;
-        GLuint                                 fbo = 0, rbo = 0;
-        SGLTex                                 tex;
-        Hyprutils::Signal::CHyprSignalListener bufferDestroy;
-        // This is malloc'd manually instead of using a std::vector to keep lifetime management in line with the rest of the class,
-        // which e.g. doesn't immediately free the eglImage on drop but instead waits until onBufferAttachmentDrop.
-        uint8_t*                                      intermediateBuf    = nullptr;
-        size_t                                        intermediateBufLen = 0;
+        EGLImageKHR                                   eglImage = nullptr;
+        GLuint                                        fbo = 0, rbo = 0;
+        SGLTex                                        tex;
+        Hyprutils::Signal::CHyprSignalListener        bufferDestroy;
+        std::vector<uint8_t>                          intermediateBuf;
 
         Hyprutils::Memory::CWeakPointer<CDRMRenderer> renderer;
     };
@@ -120,7 +117,7 @@ namespace Aquamarine {
         } savedEGLState;
 
         SGLTex                                        glTex(Hyprutils::Memory::CSharedPointer<IBuffer> buf);
-        void                                          readBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buf, uint8_t* out, size_t out_len);
+        void                                          readBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buf, std::span<uint8_t> out);
 
         Hyprutils::Memory::CWeakPointer<CDRMRenderer> self;
         std::vector<SGLFormat>                        formats;

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -36,6 +36,8 @@ namespace Aquamarine {
         GLuint                                        fbo = 0, rbo = 0;
         SGLTex                                        tex;
         Hyprutils::Signal::CHyprSignalListener        bufferDestroy;
+        // This is malloc'd manually instead of using a std::vector to keep lifetime management in line with the rest of the class,
+        // which e.g. doesn't immediately free the eglImage on drop but instead waits until onBufferAttachmentDrop.
         uint8_t*                                      intermediateBuf    = nullptr;
         size_t                                        intermediateBufLen = 0;
 


### PR DESCRIPTION
This PR has two commits to fix running aquamarine against multiple Nvidia GPUs which provide different output monitors:
- A small commit to not force linear allocation on devices which don't support it, even if multigpu is enabled. This is necessary as Nvidia doesn't support the linear format.
- A Renderer commit to, if creating an EGL image from the source buffer fails, instead copy it to an intermediate buffer on the CPU memory first, then copy that intermediate buffer to the output buffer. This fixes Nvidia multigpu because Nvidia doesn't support attaching another gpu's buffer as an EGL image, so instead this PR first reads the source buffer into CPU memory using the primary renderer's EGL context, and then does the rest of the blit as normal on the secondary GPU which writes to the output buffer.