### PR TITLE
fix atomic reset being skipped, check nullptr elsewhere instead

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -909,7 +909,7 @@ int Aquamarine::CDRMBackend::drmFD() {
 static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, unsigned crtc_id, void* data) {
     auto pageFlip = (SDRMPageFlip*)data;
 
-    if (!pageFlip->connector)
+    if (!pageFlip || !pageFlip->connector)
         return;
 
     pageFlip->connector->isPageFlipPending = false;

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -244,10 +244,7 @@ bool Aquamarine::CDRMAtomicRequest::commit(uint32_t flagssss) {
         return false;
     }
 
-    if (!conn)
-        return false;
-
-    if (auto ret = drmModeAtomicCommit(backend->gpu->fd, req, flagssss, &conn->pendingPageFlip); ret) {
+    if (auto ret = drmModeAtomicCommit(backend->gpu->fd, req, flagssss, conn ? &conn->pendingPageFlip : nullptr); ret) {
         backend->log((flagssss & DRM_MODE_ATOMIC_TEST_ONLY) ? AQ_LOG_DEBUG : AQ_LOG_ERROR,
                      std::format("atomic drm request: failed to commit: {}, flags: {}", strerror(ret == -1 ? errno : -ret), flagsToStr(flagssss)));
         return false;


### PR DESCRIPTION
kinda reverts 4468981c, really just fixes it better

probably fixes #125
also fixes issue I observed where hw pointer isn't reset on vt switch so you can get a cursor on multiple screens

edit:
btw the `&conn->pendingPageFlip` paramter is just a classic `void* data` and its ok to set null