### PR TITLE
drm: Use RAII to manage EGL context

### DIFF
--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -447,7 +447,7 @@ void CDRMRenderer::initContext(bool GLES2) {
             backend->log(AQ_LOG_DEBUG, "CDRMRenderer: Got a high priority context");
     }
 
-    EglContextGuard eglContext(*this);
+    CEglContextGuard eglContext(*this);
 
     EGLEXTENSIONS = (const char*)glGetString(GL_EXTENSIONS);
 
@@ -469,7 +469,7 @@ void CDRMRenderer::initContext(bool GLES2) {
 }
 
 void CDRMRenderer::initResources() {
-    EglContextGuard eglContext(*this);
+    CEglContextGuard eglContext(*this);
 
     if (!exts.EXT_image_dma_buf_import || !initDRMFormats())
         backend->log(AQ_LOG_ERROR, "CDRMRenderer: initDRMFormats failed, dma-buf won't work");
@@ -571,7 +571,7 @@ SP<CDRMRenderer> CDRMRenderer::attempt(SP<CBackend> backend_, Hyprutils::Memory:
     return renderer;
 }
 
-EglContextGuard::EglContextGuard(const CDRMRenderer& renderer_) : renderer(renderer_) {
+CEglContextGuard::CEglContextGuard(const CDRMRenderer& renderer_) : renderer(renderer_) {
     savedEGLState.display = eglGetCurrentDisplay();
     savedEGLState.context = eglGetCurrentContext();
     savedEGLState.draw    = eglGetCurrentSurface(EGL_DRAW);
@@ -581,7 +581,7 @@ EglContextGuard::EglContextGuard(const CDRMRenderer& renderer_) : renderer(rende
         renderer.backend->log(AQ_LOG_WARNING, "CDRMRenderer: setEGL eglMakeCurrent failed");
 }
 
-EglContextGuard::~EglContextGuard() {
+CEglContextGuard::~CEglContextGuard() {
     EGLDisplay dpy = savedEGLState.display ? savedEGLState.display : renderer.egl.display;
 
     // egl can't handle this
@@ -779,9 +779,9 @@ int CDRMRenderer::recreateBlitSync() {
 }
 
 void CDRMRenderer::clearBuffer(IBuffer* buf) {
-    EglContextGuard eglContext(*this);
-    auto            dmabuf = buf->dmabuf();
-    GLuint          rboID = 0, fboID = 0;
+    CEglContextGuard eglContext(*this);
+    auto             dmabuf = buf->dmabuf();
+    GLuint           rboID = 0, fboID = 0;
 
     if (!dmabuf.success) {
         backend->log(AQ_LOG_ERROR, "EGL (clear): cannot clear a non-dmabuf");
@@ -822,7 +822,7 @@ void CDRMRenderer::clearBuffer(IBuffer* buf) {
 }
 
 CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, int waitFD) {
-    EglContextGuard eglContext(*this);
+    CEglContextGuard eglContext(*this);
 
     if (from->dmabuf().size != to->dmabuf().size) {
         backend->log(AQ_LOG_ERROR, "EGL (blit): buffer sizes mismatched");
@@ -994,7 +994,7 @@ CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, i
 }
 
 void CDRMRenderer::onBufferAttachmentDrop(CDRMRendererBufferAttachment* attachment) {
-    EglContextGuard eglContext(*this);
+    CEglContextGuard eglContext(*this);
 
     TRACE(backend->log(AQ_LOG_TRACE,
                        std::format("EGL (onBufferAttachmentDrop): dropping fbo {} rbo {} image 0x{:x}", attachment->fbo, attachment->rbo, (uintptr_t)attachment->eglImage)));

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -447,7 +447,7 @@ void CDRMRenderer::initContext(bool GLES2) {
             backend->log(AQ_LOG_DEBUG, "CDRMRenderer: Got a high priority context");
     }
 
-    setEGL();
+    EglContextGuard eglContext(*this);
 
     EGLEXTENSIONS = (const char*)glGetString(GL_EXTENSIONS);
 
@@ -466,12 +466,10 @@ void CDRMRenderer::initContext(bool GLES2) {
 
     exts.EXT_read_format_bgra        = EGLEXTENSIONS.contains("GL_EXT_read_format_bgra");
     exts.EXT_texture_format_BGRA8888 = EGLEXTENSIONS.contains("GL_EXT_texture_format_BGRA8888");
-
-    restoreEGL();
 }
 
 void CDRMRenderer::initResources() {
-    setEGL();
+    EglContextGuard eglContext(*this);
 
     if (!exts.EXT_image_dma_buf_import || !initDRMFormats())
         backend->log(AQ_LOG_ERROR, "CDRMRenderer: initDRMFormats failed, dma-buf won't work");
@@ -493,8 +491,6 @@ void CDRMRenderer::initResources() {
     gl.shaderExt.posAttrib = glGetAttribLocation(gl.shaderExt.program, "pos");
     gl.shaderExt.texAttrib = glGetAttribLocation(gl.shaderExt.program, "texcoord");
     gl.shaderExt.tex       = glGetUniformLocation(gl.shaderExt.program, "tex");
-
-    restoreEGL();
 }
 
 SP<CDRMRenderer> CDRMRenderer::attempt(SP<CBackend> backend_, int drmFD, bool GLES2) {
@@ -575,25 +571,25 @@ SP<CDRMRenderer> CDRMRenderer::attempt(SP<CBackend> backend_, Hyprutils::Memory:
     return renderer;
 }
 
-void CDRMRenderer::setEGL() {
+EglContextGuard::EglContextGuard(CDRMRenderer& renderer_) : renderer(renderer_) {
     savedEGLState.display = eglGetCurrentDisplay();
     savedEGLState.context = eglGetCurrentContext();
     savedEGLState.draw    = eglGetCurrentSurface(EGL_DRAW);
     savedEGLState.read    = eglGetCurrentSurface(EGL_READ);
 
-    if (!eglMakeCurrent(egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, egl.context))
-        backend->log(AQ_LOG_WARNING, "CDRMRenderer: setEGL eglMakeCurrent failed");
+    if (!eglMakeCurrent(renderer.egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, renderer.egl.context))
+        renderer.backend->log(AQ_LOG_WARNING, "CDRMRenderer: setEGL eglMakeCurrent failed");
 }
 
-void CDRMRenderer::restoreEGL() {
-    EGLDisplay dpy = savedEGLState.display ? savedEGLState.display : egl.display;
+EglContextGuard::~EglContextGuard() {
+    EGLDisplay dpy = savedEGLState.display ? savedEGLState.display : renderer.egl.display;
 
     // egl can't handle this
     if (dpy == EGL_NO_DISPLAY)
         return;
 
     if (!eglMakeCurrent(dpy, savedEGLState.draw, savedEGLState.read, savedEGLState.context))
-        backend->log(AQ_LOG_WARNING, "CDRMRenderer: restoreEGL eglMakeCurrent failed");
+        renderer.backend->log(AQ_LOG_WARNING, "CDRMRenderer: restoreEGL eglMakeCurrent failed");
 }
 
 EGLImageKHR CDRMRenderer::createEGLImage(const SDMABUFAttrs& attrs) {
@@ -783,10 +779,9 @@ int CDRMRenderer::recreateBlitSync() {
 }
 
 void CDRMRenderer::clearBuffer(IBuffer* buf) {
-    setEGL();
-
-    auto   dmabuf = buf->dmabuf();
-    GLuint rboID = 0, fboID = 0;
+    EglContextGuard eglContext(*this);
+    auto            dmabuf = buf->dmabuf();
+    GLuint          rboID = 0, fboID = 0;
 
     if (!dmabuf.success) {
         backend->log(AQ_LOG_ERROR, "EGL (clear): cannot clear a non-dmabuf");
@@ -824,12 +819,10 @@ void CDRMRenderer::clearBuffer(IBuffer* buf) {
     glDeleteFramebuffers(1, &fboID);
     glDeleteRenderbuffers(1, &rboID);
     proc.eglDestroyImageKHR(egl.display, rboImage);
-
-    restoreEGL();
 }
 
 CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, int waitFD) {
-    setEGL();
+    EglContextGuard eglContext(*this);
 
     if (from->dmabuf().size != to->dmabuf().size) {
         backend->log(AQ_LOG_ERROR, "EGL (blit): buffer sizes mismatched");
@@ -997,13 +990,11 @@ CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, i
     GLCALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
     GLCALL(glBindRenderbuffer(GL_RENDERBUFFER, 0));
 
-    restoreEGL();
-
     return {.success = true, .syncFD = explicitFD == -1 ? std::nullopt : std::optional<int>{explicitFD}};
 }
 
 void CDRMRenderer::onBufferAttachmentDrop(CDRMRendererBufferAttachment* attachment) {
-    setEGL();
+    EglContextGuard eglContext(*this);
 
     TRACE(backend->log(AQ_LOG_TRACE,
                        std::format("EGL (onBufferAttachmentDrop): dropping fbo {} rbo {} image 0x{:x}", attachment->fbo, attachment->rbo, (uintptr_t)attachment->eglImage)));
@@ -1018,8 +1009,6 @@ void CDRMRenderer::onBufferAttachmentDrop(CDRMRendererBufferAttachment* attachme
         proc.eglDestroyImageKHR(egl.display, attachment->eglImage);
     if (attachment->tex.image)
         proc.eglDestroyImageKHR(egl.display, attachment->tex.image);
-
-    restoreEGL();
 }
 
 bool CDRMRenderer::verifyDestinationDMABUF(const SDMABUFAttrs& attrs) {

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -571,7 +571,7 @@ SP<CDRMRenderer> CDRMRenderer::attempt(SP<CBackend> backend_, Hyprutils::Memory:
     return renderer;
 }
 
-EglContextGuard::EglContextGuard(CDRMRenderer& renderer_) : renderer(renderer_) {
+EglContextGuard::EglContextGuard(const CDRMRenderer& renderer_) : renderer(renderer_) {
     savedEGLState.display = eglGetCurrentDisplay();
     savedEGLState.context = eglGetCurrentContext();
     savedEGLState.draw    = eglGetCurrentSurface(EGL_DRAW);

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -45,7 +45,7 @@ namespace Aquamarine {
     // and on destruction, it restores the previous EGL context.
     class EglContextGuard {
       public:
-        EglContextGuard(CDRMRenderer& renderer_);
+        EglContextGuard(const CDRMRenderer& renderer_);
         ~EglContextGuard();
 
         // No copy or move constructors
@@ -55,7 +55,7 @@ namespace Aquamarine {
         EglContextGuard& operator=(EglContextGuard&&)      = delete;
 
       private:
-        CDRMRenderer& renderer;
+        const CDRMRenderer& renderer;
         struct {
             EGLDisplay display = nullptr;
             EGLContext context = nullptr;

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -40,6 +40,29 @@ namespace Aquamarine {
         Hyprutils::Memory::CWeakPointer<CDRMRenderer> renderer;
     };
 
+    // EglContextGuard is a RAII abstraction for the EGL context.
+    // On initialization, it sets the EGL context to the renderer's display,
+    // and on destruction, it restores the previous EGL context.
+    class EglContextGuard {
+      public:
+        EglContextGuard(CDRMRenderer& renderer_);
+        ~EglContextGuard();
+
+        // No copy or move constructors
+        EglContextGuard(const EglContextGuard&)            = delete;
+        EglContextGuard& operator=(const EglContextGuard&) = delete;
+        EglContextGuard(EglContextGuard&&)                 = delete;
+        EglContextGuard& operator=(EglContextGuard&&)      = delete;
+
+      private:
+        CDRMRenderer& renderer;
+        struct {
+            EGLDisplay display = nullptr;
+            EGLContext context = nullptr;
+            EGLSurface draw = nullptr, read = nullptr;
+        } savedEGLState;
+    };
+
     class CDRMRenderer {
       public:
         ~CDRMRenderer();
@@ -58,9 +81,6 @@ namespace Aquamarine {
         SBlitResult blit(Hyprutils::Memory::CSharedPointer<IBuffer> from, Hyprutils::Memory::CSharedPointer<IBuffer> to, int waitFD = -1);
         // can't be a SP<> because we call it from buf's ctor...
         void clearBuffer(IBuffer* buf);
-
-        void setEGL();
-        void restoreEGL();
 
         void onBufferAttachmentDrop(CDRMRendererBufferAttachment* attachment);
 
@@ -107,12 +127,6 @@ namespace Aquamarine {
             int        lastBlitSyncFD = -1;
         } egl;
 
-        struct {
-            EGLDisplay display = nullptr;
-            EGLContext context = nullptr;
-            EGLSurface draw = nullptr, read = nullptr;
-        } savedEGLState;
-
         SGLTex                                        glTex(Hyprutils::Memory::CSharedPointer<IBuffer> buf);
 
         Hyprutils::Memory::CWeakPointer<CDRMRenderer> self;
@@ -135,5 +149,7 @@ namespace Aquamarine {
         bool                                                  hasModifiers = false;
 
         Hyprutils::Memory::CWeakPointer<CBackend>             backend;
+
+        friend class EglContextGuard;
     };
 };

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -40,19 +40,19 @@ namespace Aquamarine {
         Hyprutils::Memory::CWeakPointer<CDRMRenderer> renderer;
     };
 
-    // EglContextGuard is a RAII abstraction for the EGL context.
+    // CEglContextGuard is a RAII abstraction for the EGL context.
     // On initialization, it sets the EGL context to the renderer's display,
     // and on destruction, it restores the previous EGL context.
-    class EglContextGuard {
+    class CEglContextGuard {
       public:
-        EglContextGuard(const CDRMRenderer& renderer_);
-        ~EglContextGuard();
+        CEglContextGuard(const CDRMRenderer& renderer_);
+        ~CEglContextGuard();
 
         // No copy or move constructors
-        EglContextGuard(const EglContextGuard&)            = delete;
-        EglContextGuard& operator=(const EglContextGuard&) = delete;
-        EglContextGuard(EglContextGuard&&)                 = delete;
-        EglContextGuard& operator=(EglContextGuard&&)      = delete;
+        CEglContextGuard(const CEglContextGuard&)            = delete;
+        CEglContextGuard& operator=(const CEglContextGuard&) = delete;
+        CEglContextGuard(CEglContextGuard&&)                 = delete;
+        CEglContextGuard& operator=(CEglContextGuard&&)      = delete;
 
       private:
         const CDRMRenderer& renderer;
@@ -150,6 +150,6 @@ namespace Aquamarine {
 
         Hyprutils::Memory::CWeakPointer<CBackend>             backend;
 
-        friend class EglContextGuard;
+        friend class CEglContextGuard;
     };
 };


### PR DESCRIPTION
Using RAII to manage the EGL context:
- Correctly restores the EGL context if an early return occurs due to an error
- Correctly handles recursive Renderer calls (though we don't do any at the moment, #147 only calls a separate Renderer)
- Prevents other code oversights like forgetting to call restoreEGL()

I took inspiration from the std::lock_guard API for this, but I haven't worked in C++ for a while so let me know if there's a better API.

This has a small conflict with #147 but I can resolve that depending on which one gets merged first.