### PR TITLE
backend: Fix Wayland backend idleCallbacks destruction

### DIFF
--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -769,8 +769,7 @@ void Aquamarine::CWaylandOutput::scheduleFrame(const scheduleFrameReason reason)
     if (waylandState.frameCallback)
         frameScheduledWhileWaiting = true;
     else {
-        auto w = self;
-        backend->idleCallbacks.emplace_back([w]() {
+        backend->idleCallbacks.emplace_back([w = self]() {
             if (auto o = w.lock())
                 o->sendFrameAndSetCallback();
         });


### PR DESCRIPTION
The old code was crashing for me on shutdown due to the fact that `CWaylandBackend`'s reverse field order destruction destroys `idleCallbacks` before destroying `outputs`, meaning that when `~CWaylandOutput` calls `backend->idleCallbacks.clear();` it's clearing an already destroyed vector which crashes.

To fix this I just removed the FIXME hack and properly handled the potential `sendFrameAndSetCallback` UAF by using the weak pointer to check if the output was already destroyed or not.