### PR TITLE
misc: Add strict typing to attachment manager

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -25,9 +25,6 @@ namespace Aquamarine {
         virtual ~CDRMBufferAttachment() {
             ;
         }
-        virtual eAttachmentType type() {
-            return AQ_ATTACHMENT_DRM_BUFFER;
-        }
 
         Hyprutils::Memory::CSharedPointer<CDRMFB> fb;
     };
@@ -39,9 +36,6 @@ namespace Aquamarine {
         }
         virtual ~CDRMBufferUnimportable() {
             ;
-        }
-        virtual eAttachmentType type() {
-            return AQ_ATTACHMENT_DRM_KMS_UNIMPORTABLE;
         }
     };
 

--- a/include/aquamarine/misc/Attachment.hpp
+++ b/include/aquamarine/misc/Attachment.hpp
@@ -21,13 +21,10 @@ namespace Aquamarine {
     // However, only one attachment of a given type is permitted.
     class CAttachmentManager {
       public:
-        // has checks if the manager has an attachment of the specified type
         template <AttachmentConcept T>
         bool has() const {
             return attachments.contains(typeid(T));
         }
-        // get retrieves the attachment on the specified type,
-        // returning nullptr if no attachment of the specified type is present.
         template <AttachmentConcept T>
         const Hyprutils::Memory::CSharedPointer<T>& get() const {
             auto it = attachments.find(typeid(T));
@@ -38,17 +35,13 @@ namespace Aquamarine {
             // so it must be an SP<T>.
             return *reinterpret_cast<const Hyprutils::Memory::CSharedPointer<T>*>(&it->second);
         }
-        // add adds an attachment, removing the previous attachment of the same type if it exists
+        // Also removes the previous attachment of the same type if one exists
         void add(Hyprutils::Memory::CSharedPointer<IAttachment> attachment);
-        // remove removes the specified attachment, doing nothing if it does not exist.
-        // Note that this will not remove a different attachment of the same type.
         void remove(Hyprutils::Memory::CSharedPointer<IAttachment> attachment);
-        // remove removes the attachment of the specified type, doing nothing if it does not exist
         template <AttachmentConcept T>
         void removeByType() {
             attachments.erase(typeid(T));
         }
-        // clear removes all attachments
         void clear();
 
       private:

--- a/include/aquamarine/misc/Attachment.hpp
+++ b/include/aquamarine/misc/Attachment.hpp
@@ -26,7 +26,7 @@ namespace Aquamarine {
             return attachments.contains(typeid(T));
         }
         template <AttachmentConcept T>
-        const Hyprutils::Memory::CSharedPointer<T>& get() const {
+        Hyprutils::Memory::CSharedPointer<T> get() const {
             auto it = attachments.find(typeid(T));
             if (it == attachments.end())
                 return nullptr;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1621,7 +1621,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
         return false;
     }
 
-    if ((COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER) && STATE.buffer->attachments.has(AQ_ATTACHMENT_DRM_KMS_UNIMPORTABLE)) {
+    if ((COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER) && STATE.buffer->attachments.has<CDRMBufferUnimportable>()) {
         TRACE(backend->backend->log(AQ_LOG_TRACE, "drm: Cannot commit a KMS-unimportable buffer."));
         return false;
     }
@@ -2003,9 +2003,8 @@ SP<CDRMFB> Aquamarine::CDRMFB::create(SP<IBuffer> buffer_, Hyprutils::Memory::CW
     if (isNew)
         *isNew = true;
 
-    if (buffer_->attachments.has(AQ_ATTACHMENT_DRM_BUFFER)) {
-        auto at = (CDRMBufferAttachment*)buffer_->attachments.get(AQ_ATTACHMENT_DRM_BUFFER).get();
-        fb      = at->fb;
+    if (auto at = buffer_->attachments.get<CDRMBufferAttachment>()) {
+        fb = at->fb;
         TRACE(backend_->log(AQ_LOG_TRACE, std::format("drm: CDRMFB: buffer has drmfb attachment with fb {:x}", (uintptr_t)fb.get())));
     }
 
@@ -2036,7 +2035,7 @@ void Aquamarine::CDRMFB::import() {
         return;
     }
 
-    if (buffer->attachments.has(AQ_ATTACHMENT_DRM_KMS_UNIMPORTABLE)) {
+    if (buffer->attachments.has<CDRMBufferUnimportable>()) {
         backend->backend->log(AQ_LOG_ERROR, "drm: Buffer submitted is unimportable");
         return;
     }

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -29,9 +29,6 @@ namespace Aquamarine {
         virtual ~CDRMRendererBufferAttachment() {
             ;
         }
-        virtual eAttachmentType type() {
-            return AQ_ATTACHMENT_DRM_RENDERER_DATA;
-        }
 
         EGLImageKHR                                   eglImage = nullptr;
         GLuint                                        fbo = 0, rbo = 0;

--- a/src/misc/Attachment.cpp
+++ b/src/misc/Attachment.cpp
@@ -4,32 +4,16 @@ using namespace Aquamarine;
 using namespace Hyprutils::Memory;
 #define SP CSharedPointer
 
-bool Aquamarine::CAttachmentManager::has(eAttachmentType type) {
-    for (auto const& a : attachments) {
-        if (a->type() == type)
-            return true;
-    }
-    return false;
-}
-
-SP<IAttachment> Aquamarine::CAttachmentManager::get(eAttachmentType type) {
-    for (auto const& a : attachments) {
-        if (a->type() == type)
-            return a;
-    }
-    return nullptr;
-}
-
 void Aquamarine::CAttachmentManager::add(SP<IAttachment> attachment) {
-    attachments.emplace_back(attachment);
+    const IAttachment& att   = *attachment;
+    attachments[typeid(att)] = attachment;
 }
 
 void Aquamarine::CAttachmentManager::remove(SP<IAttachment> attachment) {
-    std::erase(attachments, attachment);
-}
-
-void Aquamarine::CAttachmentManager::removeByType(eAttachmentType type) {
-    std::erase_if(attachments, [type](const auto& e) { return e->type() == type; });
+    const IAttachment& att = *attachment;
+    auto               it  = attachments.find(typeid(att));
+    if (it != attachments.end())
+        attachments.erase(it);
 }
 
 void Aquamarine::CAttachmentManager::clear() {


### PR DESCRIPTION
Feel free to reject this PR if the new abstraction is too complicated or otherwise not your preference, but it fixes a couple of potential pitfalls and simplifies the external API:
- You no longer have to manage the eAttachmentType and figure out which enum values correspond to which types. This also makes it easier to add new attachment types in the future, and provides flexibility to use this in other non-DRM contexts or with external attachment types.
- You no longer have to cast returned attachments to the right type, as the attachment manager now does the cast for you. This also avoids the potential pitfall of casting to the wrong attachment type.
- Previously, we called `removeByType` before `add` because it was possible to have multiple attachments of the same type by accident, but attachments are now stored in a map instead of a vector to guarantee uniqueness.