### PR TITLE
buffer: Get rid of buffer locking

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -101,7 +101,7 @@ namespace Aquamarine {
     struct SDRMLayer {
         // we expect the consumers to use double-buffering, so we keep the 2 last FBs around. If any of these goes out of
         // scope, the DRM FB will be destroyed, but the IBuffer will stay, as long as it's ref'd somewhere.
-        Hyprutils::Memory::CSharedPointer<CDRMFB>    front /* currently displaying */, back /* submitted */, last /* keep just in case */;
+        Hyprutils::Memory::CSharedPointer<CDRMFB>    front /* currently displaying */, back /* submitted */;
         Hyprutils::Memory::CWeakPointer<CDRMBackend> backend;
     };
 
@@ -112,7 +112,7 @@ namespace Aquamarine {
         uint32_t                                     id        = 0;
         uint32_t                                     initialID = 0;
 
-        Hyprutils::Memory::CSharedPointer<CDRMFB>    front /* currently displaying */, back /* submitted */, last /* keep just in case */;
+        Hyprutils::Memory::CSharedPointer<CDRMFB>    front /* currently displaying */, back /* submitted */;
         Hyprutils::Memory::CWeakPointer<CDRMBackend> backend;
         Hyprutils::Memory::CWeakPointer<SDRMPlane>   self;
         std::vector<SDRMFormat>                      formats;

--- a/include/aquamarine/buffer/Buffer.hpp
+++ b/include/aquamarine/buffer/Buffer.hpp
@@ -54,24 +54,21 @@ namespace Aquamarine {
         virtual SSHMAttrs                              shm();
         virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
         virtual void                                   endDataPtr();
-        virtual void                                   sendRelease();
-        virtual void                                   lock();
-        virtual void                                   unlock();
-        virtual bool                                   locked();
 
-        Hyprutils::Math::Vector2D                      size;
-        bool                                           opaque          = false;
-        bool                                           lockedByBackend = false;
+        virtual bool                                   getOpaque();
+        virtual Hyprutils::Math::Vector2D&             getSize();
+        virtual CAttachmentManager&                    getAttachments();
+        virtual Hyprutils::Signal::CSignal&            getDestroyEvent();
 
-        CAttachmentManager                             attachments;
+      protected:
+        Hyprutils::Math::Vector2D size;
+        bool                      opaque = false;
+
+        CAttachmentManager        attachments;
 
         struct {
             Hyprutils::Signal::CSignal destroy;
-            Hyprutils::Signal::CSignal backendRelease;
         } events;
-
-      private:
-        int locks = 0;
     };
 
 };

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -62,12 +62,13 @@ void Aquamarine::CDRMAtomicRequest::planeProps(Hyprutils::Memory::CSharedPointer
                                  plane->props.src_y, plane->props.src_w, plane->props.src_h, plane->props.crtc_w, plane->props.crtc_h, plane->props.fb_id, plane->props.crtc_id)));
 
     // src_ are 16.16 fixed point (lol)
+    auto size = fb->buffer->getSize();
     add(plane->id, plane->props.src_x, 0);
     add(plane->id, plane->props.src_y, 0);
-    add(plane->id, plane->props.src_w, ((uint64_t)fb->buffer->size.x) << 16);
-    add(plane->id, plane->props.src_h, ((uint64_t)fb->buffer->size.y) << 16);
-    add(plane->id, plane->props.crtc_w, (uint32_t)fb->buffer->size.x);
-    add(plane->id, plane->props.crtc_h, (uint32_t)fb->buffer->size.y);
+    add(plane->id, plane->props.src_w, ((uint64_t)size.x) << 16);
+    add(plane->id, plane->props.src_h, ((uint64_t)size.y) << 16);
+    add(plane->id, plane->props.crtc_w, (uint32_t)size.x);
+    add(plane->id, plane->props.crtc_h, (uint32_t)size.y);
     add(plane->id, plane->props.fb_id, fb->id);
     add(plane->id, plane->props.crtc_id, crtc);
     planePropsPos(plane, pos);

--- a/src/backend/drm/impl/Legacy.cpp
+++ b/src/backend/drm/impl/Legacy.cpp
@@ -97,7 +97,7 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
 
         connector->backend->backend->log(AQ_LOG_DEBUG,
                                          std::format("legacy drm: cursor fb: {} with bo handle {} from fd {}, size {}", connector->backend->gpu->fd, boHandle,
-                                                     data.cursorFB->buffer->dmabuf().fds.at(0), data.cursorFB->buffer->size));
+                                                     data.cursorFB->buffer->dmabuf().fds.at(0), data.cursorFB->buffer->getSize()));
 
         Vector2D                cursorPos = connector->output->cursorPos;
 
@@ -106,8 +106,8 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
             .crtc_id = connector->crtc->id,
             .x       = (int32_t)cursorPos.x,
             .y       = (int32_t)cursorPos.y,
-            .width   = (uint32_t)data.cursorFB->buffer->size.x,
-            .height  = (uint32_t)data.cursorFB->buffer->size.y,
+            .width   = (uint32_t)data.cursorFB->buffer->getSize().x,
+            .height  = (uint32_t)data.cursorFB->buffer->getSize().y,
             .handle  = boHandle,
             .hot_x   = (int32_t)connector->output->cursorHotspot.x,
             .hot_y   = (int32_t)connector->output->cursorHotspot.y,

--- a/src/buffer/Buffer.cpp
+++ b/src/buffer/Buffer.cpp
@@ -19,23 +19,18 @@ void Aquamarine::IBuffer::endDataPtr() {
     ; // empty
 }
 
-void Aquamarine::IBuffer::sendRelease() {
-    ;
+bool Aquamarine::IBuffer::getOpaque() {
+    return opaque;
 }
 
-void Aquamarine::IBuffer::lock() {
-    locks++;
+Hyprutils::Math::Vector2D& Aquamarine::IBuffer::getSize() {
+    return size;
 }
 
-void Aquamarine::IBuffer::unlock() {
-    locks--;
-
-    ASSERT(locks >= 0);
-
-    if (locks <= 0)
-        sendRelease();
+CAttachmentManager& Aquamarine::IBuffer::getAttachments() {
+    return attachments;
 }
 
-bool Aquamarine::IBuffer::locked() {
-    return locks;
+Hyprutils::Signal::CSignal& Aquamarine::IBuffer::getDestroyEvent() {
+    return events.destroy;
 }


### PR DESCRIPTION
Also changes the public fields in IBuffer to getters, so that they can be overridden.