### PR TITLE
backend, allocator: Fix multi-GPU format selection

### DIFF
--- a/include/aquamarine/backend/Backend.hpp
+++ b/include/aquamarine/backend/Backend.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <hyprutils/memory/SharedPtr.hpp>
+#include <hyprutils/memory/WeakPtr.hpp>
 #include <hyprutils/signal/Signal.hpp>
 #include <vector>
 #include <functional>
@@ -79,6 +80,7 @@ namespace Aquamarine {
         virtual Hyprutils::Memory::CSharedPointer<IAllocator>              preferredAllocator()                       = 0;
         virtual std::vector<SDRMFormat>                                    getRenderableFormats(); // empty = use getRenderFormats
         virtual std::vector<Hyprutils::Memory::CSharedPointer<IAllocator>> getAllocators() = 0;
+        virtual Hyprutils::Memory::CWeakPointer<IBackendImplementation>    getPrimary()    = 0;
     };
 
     class CBackend {

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -369,6 +369,7 @@ namespace Aquamarine {
         virtual Hyprutils::Memory::CSharedPointer<IAllocator>              preferredAllocator();
         virtual std::vector<SDRMFormat>                                    getRenderableFormats();
         virtual std::vector<Hyprutils::Memory::CSharedPointer<IAllocator>> getAllocators();
+        virtual Hyprutils::Memory::CWeakPointer<IBackendImplementation>    getPrimary();
 
         Hyprutils::Memory::CWeakPointer<CDRMBackend>                       self;
 

--- a/include/aquamarine/backend/Headless.hpp
+++ b/include/aquamarine/backend/Headless.hpp
@@ -49,6 +49,7 @@ namespace Aquamarine {
         virtual bool                                                       createOutput(const std::string& name = "");
         virtual Hyprutils::Memory::CSharedPointer<IAllocator>              preferredAllocator();
         virtual std::vector<Hyprutils::Memory::CSharedPointer<IAllocator>> getAllocators();
+        virtual Hyprutils::Memory::CWeakPointer<IBackendImplementation>    getPrimary();
 
         Hyprutils::Memory::CWeakPointer<CHeadlessBackend>                  self;
 

--- a/include/aquamarine/backend/Wayland.hpp
+++ b/include/aquamarine/backend/Wayland.hpp
@@ -136,6 +136,7 @@ namespace Aquamarine {
         virtual bool                                                       createOutput(const std::string& name = "");
         virtual Hyprutils::Memory::CSharedPointer<IAllocator>              preferredAllocator();
         virtual std::vector<Hyprutils::Memory::CSharedPointer<IAllocator>> getAllocators();
+        virtual Hyprutils::Memory::CWeakPointer<IBackendImplementation>    getPrimary();
 
         Hyprutils::Memory::CWeakPointer<CWaylandBackend>                   self;
 

--- a/src/allocator/GBM.cpp
+++ b/src/allocator/GBM.cpp
@@ -72,7 +72,7 @@ Aquamarine::CGBMBuffer::CGBMBuffer(const SAllocatorBufferParams& params, Hypruti
 
     const bool CURSOR           = params.cursor && params.scanout;
     const bool MULTIGPU         = params.multigpu && params.scanout;
-    const bool EXPLICIT_SCANOUT = params.scanout && swapchain->currentOptions().scanoutOutput;
+    const bool EXPLICIT_SCANOUT = params.scanout && swapchain->currentOptions().scanoutOutput && !params.multigpu;
 
     TRACE(allocator->backend->log(AQ_LOG_TRACE,
                                   std::format("GBM: Allocating a buffer: size {}, format {}, cursor: {}, multigpu: {}, scanout: {}", attrs.size, fourccToName(attrs.format), CURSOR,
@@ -153,7 +153,7 @@ Aquamarine::CGBMBuffer::CGBMBuffer(const SAllocatorBufferParams& params, Hypruti
     }
 
     uint32_t flags = GBM_BO_USE_RENDERING;
-    if (params.scanout)
+    if (params.scanout && !MULTIGPU)
         flags |= GBM_BO_USE_SCANOUT;
 
     uint64_t modifier = DRM_FORMAT_MOD_INVALID;
@@ -223,7 +223,7 @@ Aquamarine::CGBMBuffer::CGBMBuffer(const SAllocatorBufferParams& params, Hypruti
 
     free(modName);
 
-    if (params.scanout && swapchain->backendImpl->type() == AQ_BACKEND_DRM) {
+    if (params.scanout && !MULTIGPU && swapchain->backendImpl->type() == AQ_BACKEND_DRM) {
         // clear the buffer using the DRM renderer to avoid uninitialized mem
         auto impl = (CDRMBackend*)swapchain->backendImpl.get();
         if (impl->rendererState.renderer)

--- a/src/backend/Headless.cpp
+++ b/src/backend/Headless.cpp
@@ -211,6 +211,10 @@ std::vector<SP<IAllocator>> Aquamarine::CHeadlessBackend::getAllocators() {
     return {backend->primaryAllocator};
 }
 
+Hyprutils::Memory::CWeakPointer<IBackendImplementation> Aquamarine::CHeadlessBackend::getPrimary() {
+    return {};
+}
+
 bool Aquamarine::CHeadlessBackend::CTimer::expired() {
     return std::chrono::steady_clock::now() > when;
 }

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -447,6 +447,10 @@ std::vector<SP<IAllocator>> Aquamarine::CWaylandBackend::getAllocators() {
     return {backend->primaryAllocator};
 }
 
+Hyprutils::Memory::CWeakPointer<IBackendImplementation> Aquamarine::CWaylandBackend::getPrimary() {
+    return {};
+}
+
 Aquamarine::CWaylandOutput::CWaylandOutput(const std::string& name_, Hyprutils::Memory::CWeakPointer<CWaylandBackend> backend_) : backend(backend_) {
     name = name_;
 


### PR DESCRIPTION
Swapchains were created with the primary allocator, but the output's backend. This meant that the wrong format would be selected with multi-GPU setups such as NVIDIA primary and Intel secondary. We still try to use the LINEAR format if available, but if it's not available, we should use the format from the primary GPU instead of the secondary GPU.

My previous PR https://github.com/hyprwm/aquamarine/pull/147 fixed having two NVIDIA GPUs or having Intel as primary and NVIDIA as secondary, but this PR fixes having NVIDIA as primary and an Intel as secondary. Previously, the swapchain would create an Intel format buffer to render to for the secondary monitor, which NVIDIA would then fail to read due to being an unsupported format. Now, it'll correctly create an NVIDIA format buffer for the secondary monitor, which blit will then copy over to the Intel GPU memory, transforming the formats in the process.

This PR also adds a getPrimary method to IBackendImplementation for use in Hyprland to make the same fix for the cursor swapchain there: https://github.com/hyprwm/Hyprland/pull/9645