### PR TITLE
backend: Fix compiler warnings

### DIFF
--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -102,8 +102,7 @@ Aquamarine::CBackend::~CBackend() {
 bool Aquamarine::CBackend::start() {
     log(AQ_LOG_DEBUG, "Starting the Aquamarine backend!");
 
-    bool fallback = false;
-    int  started  = 0;
+    int  started = 0;
 
     auto optionsForType = [this](eBackendType type) -> SBackendImplementationOptions {
         for (auto const& o : implementationOptions) {
@@ -118,7 +117,6 @@ bool Aquamarine::CBackend::start() {
 
         if (!ok) {
             log(AQ_LOG_ERROR, std::format("Requested backend ({}) could not start, enabling fallbacks", backendTypeToName(implementations.at(i)->type())));
-            fallback = true;
             if (optionsForType(implementations.at(i)->type()).backendRequestMode == AQ_BACKEND_REQUEST_MANDATORY) {
                 log(AQ_LOG_CRITICAL, std::format("Requested backend ({}) could not start and it's mandatory, cannot continue!", backendTypeToName(implementations.at(i)->type())));
                 implementations.clear();

--- a/src/backend/Headless.cpp
+++ b/src/backend/Headless.cpp
@@ -181,7 +181,6 @@ void Aquamarine::CHeadlessBackend::dispatchTimers() {
 void Aquamarine::CHeadlessBackend::updateTimerFD() {
     long long  lowestNs = TIMESPEC_NSEC_PER_SEC * 240 /* 240s, 4 mins */;
     const auto clocknow = std::chrono::steady_clock::now();
-    bool       any      = false;
 
     for (auto const& t : timers.timers) {
         auto delta = std::chrono::duration_cast<std::chrono::microseconds>(t.when - clocknow).count() * 1000 /* µs -> ns */;

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -620,7 +620,6 @@ void Aquamarine::CSession::handleLibinputEvent(libinput_event* e) {
             break;
         }
         case LIBINPUT_EVENT_TOUCH_FRAME: {
-            auto te = libinput_event_get_touch_event(e);
             hlDevice->touch->events.frame.emit();
             break;
         }
@@ -709,7 +708,8 @@ void Aquamarine::CSession::handleLibinputEvent(libinput_event* e) {
                 break;
             }
 
-            // fallthrough. If this is proximity in, also process axis.
+            // If this is proximity in, also process axis.
+            [[fallthrough]];
         }
         case LIBINPUT_EVENT_TABLET_TOOL_AXIS: {
             auto                tte  = libinput_event_get_tablet_tool_event(e);

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -542,8 +542,7 @@ bool Aquamarine::CWaylandOutput::test() {
 }
 
 bool Aquamarine::CWaylandOutput::commit() {
-    Vector2D pixelSize   = {};
-    uint32_t refreshRate = 0;
+    Vector2D pixelSize = {};
 
     if (state->internalState.customMode)
         pixelSize = state->internalState.customMode->pixelSize;


### PR DESCRIPTION
This PR should have no effect to behavior but cleans up compiler warnings (mostly removing unused variables)