### PR TITLE
drm: Add Vulkan host mapping blit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,8 @@ pkg_check_modules(
   gbm
   libudev
   libdisplay-info
-  hwdata)
+  hwdata
+  vulkan)
 
 configure_file(aquamarine.pc.in aquamarine.pc @ONLY)
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -16,6 +16,7 @@
   pkg-config,
   seatd,
   udev,
+  vulkan-loader,
   wayland,
   wayland-protocols,
   wayland-scanner,
@@ -62,6 +63,7 @@ in
       pixman
       seatd
       udev
+      vulkan-loader
       wayland
       wayland-protocols
       wayland-scanner

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1679,7 +1679,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
 
         SP<CDRMFB> drmFB;
 
-        if (backend->shouldBlit() || true) {
+        if (backend->shouldBlit()) {
             if (!backend->rendererState.renderer) {
                 backend->backend->log(AQ_LOG_ERROR, "drm: No renderer attached to backend when required for blitting");
                 return false;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1679,7 +1679,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
 
         SP<CDRMFB> drmFB;
 
-        if (backend->shouldBlit()) {
+        if (backend->shouldBlit() || true) {
             if (!backend->rendererState.renderer) {
                 backend->backend->log(AQ_LOG_ERROR, "drm: No renderer attached to backend when required for blitting");
                 return false;

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -1258,7 +1258,7 @@ CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, S
                 if (!copyRes.success)
                     return {};
                 auto fromSyncFd = copyRes.syncFD;
-                copyRes         = self->copyVkStagingBuffer(to, true, -1, true);
+                copyRes         = copyVkStagingBuffer(to, true, -1, true);
                 if (!copyRes.success)
                     return {};
 

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -1271,7 +1271,7 @@ CDRMRenderer::SBlitResult CDRMRenderer::vkBlit(SP<IBuffer> from, SP<IBuffer> to,
     fromAtt->submitCopyThreadTask([self = self.lock(), fromAtt, fromMem, toAtt, toMem, fromSyncFd, semaphorePoint] {
         if (!cpuWaitOnSyncWithoutBackend(fromSyncFd.value_or(-1))) {
             // if this fails, there's not really much we can do here as backend->log might not support being called from another thread
-            fprintf(stderr, "[AQ] Failed to wait on sync FD in background thread\n");
+            fprintf(stderr, "[AQ] Failed to wait on sync FD in background thread: errno %d\n", errno);
         }
         std::memcpy(toMem.data(), fromMem.data(), toMem.size());
         // This is safe to call from a background thread because nothing else is using the semaphore concurrently

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -17,7 +17,7 @@
 #include "Math.hpp"
 #include "Shared.hpp"
 #include "FormatUtils.hpp"
-#include "aquamarine/backend/Backend.hpp"
+#include <aquamarine/backend/Backend.hpp>
 #include <aquamarine/allocator/GBM.hpp>
 
 using namespace Aquamarine;

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -387,9 +387,8 @@ void CDRMRenderer::loadVulkanAPI() {
     if (res.result == vk::Result::eSuccess) {
         g_pVulkanInstance = std::move(res.value);
         backend->log(AQ_LOG_DEBUG, "Successfully created Vulkan instance");
-    } else {
+    } else
         backend->log(AQ_LOG_WARNING, std::format("Failed to create Vulkan instance: {}", vk::to_string(res.result)));
-    }
 }
 
 void CDRMRenderer::loadVulkanDevice() {
@@ -448,9 +447,9 @@ void CDRMRenderer::loadVulkanDevice() {
     uint32_t bestFamIdx            = UINT32_MAX;
     for (uint32_t i = 0; i < queueFamilyProperties.size(); i++) {
         const auto& fam = queueFamilyProperties[i];
-        if (fam.queueFlags & (vk::QueueFlagBits::eGraphics | vk::QueueFlagBits::eCompute)) {
+        if (fam.queueFlags & (vk::QueueFlagBits::eGraphics | vk::QueueFlagBits::eCompute))
             bestFamIdx = i;
-        } else if (fam.queueFlags & vk::QueueFlagBits::eTransfer) {
+        else if (fam.queueFlags & vk::QueueFlagBits::eTransfer) {
             bestFamIdx = i;
             break;
         }

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -1,7 +1,6 @@
 #include "Renderer.hpp"
 #include <drm.h>
 #include <hyprutils/os/FileDescriptor.hpp>
-#include <sys/mman.h>
 #include <utility>
 #include <vulkan/vulkan.hpp>
 #include <vulkan/vulkan_core.h>

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -1,14 +1,9 @@
 #pragma once
 
 #include <hyprutils/memory/SharedPtr.hpp>
-#define VULKAN_HPP_NO_EXCEPTIONS
-#define VULKAN_HPP_ASSERT_ON_RESULT(...)                                                                                                                                           \
-    do {                                                                                                                                                                           \
-    } while (0)
-
-#include "aquamarine/misc/Attachment.hpp"
 #include <hyprutils/memory/UniquePtr.hpp>
 #include <aquamarine/backend/DRM.hpp>
+#include <aquamarine/misc/Attachment.hpp>
 #include "FormatUtils.hpp"
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
@@ -16,13 +11,16 @@
 #include <GLES2/gl2ext.h>
 #include <gbm.h>
 #include <optional>
-#include <tuple>
 #include <vector>
 #include <span>
-#include <vulkan/vulkan.hpp>
 #include <condition_variable>
-#include <queue>
 #include <hyprutils/os/FileDescriptor.hpp>
+
+#define VULKAN_HPP_NO_EXCEPTIONS
+#define VULKAN_HPP_ASSERT_ON_RESULT(...)                                                                                                                                           \
+    do {                                                                                                                                                                           \
+    } while (0)
+#include <vulkan/vulkan.hpp>
 
 namespace Aquamarine {
 

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -1,5 +1,12 @@
 #pragma once
 
+#include "aquamarine/misc/Attachment.hpp"
+#include <hyprutils/memory/UniquePtr.hpp>
+#define VULKAN_HPP_NO_EXCEPTIONS
+#define VULKAN_HPP_ASSERT_ON_RESULT(...)                                                                                                                                           \
+    do {                                                                                                                                                                           \
+    } while (0)
+
 #include <aquamarine/backend/DRM.hpp>
 #include "FormatUtils.hpp"
 #include <EGL/egl.h>
@@ -11,6 +18,7 @@
 #include <tuple>
 #include <vector>
 #include <span>
+#include <vulkan/vulkan.hpp>
 
 namespace Aquamarine {
 
@@ -21,6 +29,8 @@ namespace Aquamarine {
         GLuint   texid  = 0;
         GLuint   target = GL_TEXTURE_2D;
     };
+
+    inline vk::UniqueInstance g_pVulkanInstance;
 
     class CDRMRendererBufferAttachment : public IAttachment {
       public:
@@ -143,6 +153,8 @@ namespace Aquamarine {
         int                                                   recreateBlitSync();
 
         void                                                  loadEGLAPI();
+        void                                                  loadVulkanAPI();
+        void                                                  loadVulkanDevice();
         EGLDeviceEXT                                          eglDeviceFromDRMFD(int drmFD);
         void                                                  initContext(bool GLES2);
         void                                                  initResources();
@@ -151,6 +163,21 @@ namespace Aquamarine {
         bool                                                  hasModifiers = false;
 
         Hyprutils::Memory::CWeakPointer<CBackend>             backend;
+
+        std::span<uint8_t>                                    vkMapBufferToHost(Hyprutils::Memory::CSharedPointer<IBuffer> from);
+        vk::UniqueDevice                                      vkDevice;
+        uint32_t                                              vkMemTypeIndex = UINT32_MAX;
+
+        class CVulkanBufferAttachment : public IAttachment {
+          public:
+            CVulkanBufferAttachment(vk::UniqueDeviceMemory vkMemory_, std::span<uint8_t> hostMapping_);
+            virtual ~CVulkanBufferAttachment() {
+                ;
+            }
+
+            vk::UniqueDeviceMemory vkMemory;
+            std::span<uint8_t>     hostMapping;
+        };
 
         friend class CEglContextGuard;
     };

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -165,29 +165,30 @@ namespace Aquamarine {
         Hyprutils::Memory::CWeakPointer<CBackend>             backend;
 
         std::span<uint8_t>                                    vkMapBufferToHost(Hyprutils::Memory::CSharedPointer<IBuffer> from, bool writing);
-        void                                                  copyVkStagingBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buf, bool writing);
+        SBlitResult                                           copyVkStagingBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buf, bool writing, int waitFD);
         vk::UniqueDevice                                      vkDevice;
         vk::UniqueCommandPool                                 vkCmdPool;
-        vk::UniqueCommandBuffer                               vkCmdBuf;
         vk::Queue                                             vkQueue;
+        vk::detail::DispatchLoaderDynamic                     vkDynamicDispatcher;
         uint32_t                                              vkGpuMemTypeIdx  = UINT32_MAX;
         uint32_t                                              vkHostMemTypeIdx = UINT32_MAX;
 
         class CVulkanBufferAttachment : public IAttachment {
           public:
-            CVulkanBufferAttachment(vk::UniqueDeviceMemory gpuMem_, vk::UniqueBuffer gpuBuf_, vk::UniqueDeviceMemory hostVisibleMem_, vk::UniqueBuffer hostVisibleBuf_,
-                                    std::span<uint8_t> hostMapping_) :
-                gpuMem(std::move(gpuMem_)), gpuBuf(std::move(gpuBuf_)), hostVisibleMem(std::move(hostVisibleMem_)), hostVisibleBuf(std::move(hostVisibleBuf_)),
-                hostMapping(hostMapping_) {}
+            CVulkanBufferAttachment() {}
             virtual ~CVulkanBufferAttachment() {
                 ;
             }
 
-            vk::UniqueDeviceMemory gpuMem;
-            vk::UniqueBuffer       gpuBuf;
-            vk::UniqueDeviceMemory hostVisibleMem;
-            vk::UniqueBuffer       hostVisibleBuf;
-            std::span<uint8_t>     hostMapping;
+            vk::UniqueSemaphore     semaphore;
+            vk::UniqueDeviceMemory  gpuMem;
+            vk::UniqueBuffer        gpuBuf;
+            vk::UniqueDeviceMemory  hostVisibleMem;
+            vk::UniqueBuffer        hostVisibleBuf;
+            vk::UniqueFence         fence;
+            int                     fenceFd = -1;
+            vk::UniqueCommandBuffer commandBuffer;
+            std::span<uint8_t>      hostMapping;
         };
 
         friend class CEglContextGuard;

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "aquamarine/misc/Attachment.hpp"
-#include <hyprutils/memory/UniquePtr.hpp>
 #define VULKAN_HPP_NO_EXCEPTIONS
 #define VULKAN_HPP_ASSERT_ON_RESULT(...)                                                                                                                                           \
     do {                                                                                                                                                                           \
     } while (0)
 
+#include "aquamarine/misc/Attachment.hpp"
+#include <hyprutils/memory/UniquePtr.hpp>
 #include <aquamarine/backend/DRM.hpp>
 #include "FormatUtils.hpp"
 #include <EGL/egl.h>

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -195,6 +195,8 @@ namespace Aquamarine {
             bool                           copyThreadShuttingDown = false;
         };
 
+        SBlitResult                       vkBlit(Hyprutils::Memory::CSharedPointer<IBuffer> from, Hyprutils::Memory::CSharedPointer<IBuffer> to,
+                                                 Hyprutils::Memory::CSharedPointer<CDRMRenderer> primaryRenderer, int waitFD = -1);
         void                              finishAndCleanupVkBlit(Hyprutils::Memory::CSharedPointer<CVulkanBufferAttachment> att);
         std::span<uint8_t>                vkMapBufferToHost(Hyprutils::Memory::CSharedPointer<IBuffer> from, bool writing);
         SBlitResult                       copyVkStagingBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buf, bool writing, int waitFD, bool waitForTimelineSemaphore);

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -175,6 +175,7 @@ namespace Aquamarine {
             virtual ~CVulkanBufferAttachment();
 
             void                           submitCopyThreadTask(std::function<void()> task);
+            void                           waitForCopyTaskCompletion();
 
             vk::UniqueSemaphore            syncFdSemaphore;
             vk::UniqueSemaphore            timelineSemaphore;

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -171,10 +171,10 @@ namespace Aquamarine {
 
         class CVulkanBufferAttachment : public IAttachment {
           public:
-            CVulkanBufferAttachment() {}
-            virtual ~CVulkanBufferAttachment() {
-                ;
-            }
+            CVulkanBufferAttachment();
+            virtual ~CVulkanBufferAttachment();
+
+            void                           submitCopyThreadTask(std::function<void()> task);
 
             vk::UniqueSemaphore            syncFdSemaphore;
             vk::UniqueSemaphore            timelineSemaphore;
@@ -187,7 +187,12 @@ namespace Aquamarine {
             Hyprutils::OS::CFileDescriptor fenceFD;
             vk::UniqueCommandBuffer        commandBuffer;
             std::span<uint8_t>             hostMapping;
-            std::thread                    copyingThread;
+
+            std::thread                    copyThread;
+            std::function<void()>          copyThreadTask;
+            std::mutex                     copyThreadMutex;
+            std::condition_variable        copyThreadCondVar;
+            bool                           copyThreadShuttingDown = false;
         };
 
         void                              finishAndCleanupVkBlit(Hyprutils::Memory::CSharedPointer<CVulkanBufferAttachment> att);

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -164,18 +164,29 @@ namespace Aquamarine {
 
         Hyprutils::Memory::CWeakPointer<CBackend>             backend;
 
-        std::span<uint8_t>                                    vkMapBufferToHost(Hyprutils::Memory::CSharedPointer<IBuffer> from);
+        std::span<uint8_t>                                    vkMapBufferToHost(Hyprutils::Memory::CSharedPointer<IBuffer> from, bool writing);
+        void                                                  copyVkStagingBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buf, bool writing);
         vk::UniqueDevice                                      vkDevice;
-        uint32_t                                              vkMemTypeIndex = UINT32_MAX;
+        vk::UniqueCommandPool                                 vkCmdPool;
+        vk::UniqueCommandBuffer                               vkCmdBuf;
+        vk::Queue                                             vkQueue;
+        uint32_t                                              vkGpuMemTypeIdx  = UINT32_MAX;
+        uint32_t                                              vkHostMemTypeIdx = UINT32_MAX;
 
         class CVulkanBufferAttachment : public IAttachment {
           public:
-            CVulkanBufferAttachment(vk::UniqueDeviceMemory vkMemory_, std::span<uint8_t> hostMapping_);
+            CVulkanBufferAttachment(vk::UniqueDeviceMemory gpuMem_, vk::UniqueBuffer gpuBuf_, vk::UniqueDeviceMemory hostVisibleMem_, vk::UniqueBuffer hostVisibleBuf_,
+                                    std::span<uint8_t> hostMapping_) :
+                gpuMem(std::move(gpuMem_)), gpuBuf(std::move(gpuBuf_)), hostVisibleMem(std::move(hostVisibleMem_)), hostVisibleBuf(std::move(hostVisibleBuf_)),
+                hostMapping(hostMapping_) {}
             virtual ~CVulkanBufferAttachment() {
                 ;
             }
 
-            vk::UniqueDeviceMemory vkMemory;
+            vk::UniqueDeviceMemory gpuMem;
+            vk::UniqueBuffer       gpuBuf;
+            vk::UniqueDeviceMemory hostVisibleMem;
+            vk::UniqueBuffer       hostVisibleBuf;
             std::span<uint8_t>     hostMapping;
         };
 


### PR DESCRIPTION
This PR adds a more efficient alternative CPU based copy if the formats between the buffers are the same (i.e. there's two NVIDIA cards). In addition, this PR lays the groundwork for other uses of Vulkan especially in blit. Vulkan is a lot more powerful than OpenGL here, and any future blit optimizations will likely also use it.

There are two reasons this copy is more efficient than the `intermediateBuf` codepath:
1. There's no format conversion. OpenGL needs to convert the pixel data into `GL_RGBA` whereas Vulkan can keep the pixel data in the existing format and simply copy the memory. However, the Vulkan code could be extended to support a format conversion in the future.
2. The copy is asynchronous. The previous OpenGL copy was entirely blocking, relying on glReadPixels and glTexImage2d. This new copy uses Vulkan semaphores and fences to consume and produce a sync_file, and even has a background thread for the memcpy itself to make it asynchronous (don't worry, I made sure it's isolated and doesn't cause concurrency concerns for the rest of the system).

Right now I think this is only useful if you have two NVIDIA cards, but @gulafaran has been looking at using Vulkan to optimize the blit for the NVIDIA<>Intel case and this PR lays important groundwork for that as well.

If you want to test this PR on a single-GPU system you can use this patch to force enable Vulkan based blitting: https://gist.github.com/PlasmaPower/1499e2db2abbb1ab88aa1334c145f3fa