### PR TITLE
atomic: fix compiler warning with string

### DIFF
--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -5,6 +5,7 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <sys/mman.h>
+#include <sstream>
 #include "Shared.hpp"
 #include "aquamarine/output/Output.hpp"
 
@@ -223,20 +224,20 @@ void Aquamarine::CDRMAtomicRequest::addConnectorCursor(Hyprutils::Memory::CShare
 
 bool Aquamarine::CDRMAtomicRequest::commit(uint32_t flagssss) {
     static auto flagsToStr = [](uint32_t flags) {
-        std::string result;
+        std::ostringstream result;
         if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
-            result += "ATOMIC_ALLOW_MODESET ";
+            result << "ATOMIC_ALLOW_MODESET ";
         if (flags & DRM_MODE_ATOMIC_NONBLOCK)
-            result += "ATOMIC_NONBLOCK ";
+            result << "ATOMIC_NONBLOCK ";
         if (flags & DRM_MODE_ATOMIC_TEST_ONLY)
-            result += "ATOMIC_TEST_ONLY ";
+            result << "ATOMIC_TEST_ONLY ";
         if (flags & DRM_MODE_PAGE_FLIP_EVENT)
-            result += "PAGE_FLIP_EVENT ";
+            result << "PAGE_FLIP_EVENT ";
         if (flags & DRM_MODE_PAGE_FLIP_ASYNC)
-            result += "PAGE_FLIP_ASYNC ";
+            result << "PAGE_FLIP_ASYNC ";
         if (flags & (~DRM_MODE_ATOMIC_FLAGS))
-            result += " + invalid...";
-        return result;
+            result << " + invalid...";
+        return result.str();
     };
 
     if (failed) {


### PR DESCRIPTION
the compiler tries to optimize this and inlines the +=, which might involve raw memcpy operations, and in doing so, it thinks there is a chance that the internal buffer doesnt have enough space. use ostringstream instead, and return the string from that.

```

In function ‘copy’,                                                                                                                         
     inlined from ‘_S_copy’ at /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/basic_string.h:435:21,                               
     inlined from ‘_M_append’ at /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/basic_string.tcc:421:19,                           
     inlined from ‘append’ at /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/basic_string.h:1485:18,                               
     inlined from ‘operator+=’ at /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/basic_string.h:1388:28,                           
     inlined from ‘operator()’ at /var/tmp/portage/gui-libs/aquamarine-9999/work/aquamarine-9999/src/backend/drm/impl/Atomic.cpp:230:23,     
     inlined from ‘commit’ at /var/tmp/portage/gui-libs/aquamarine-9999/work/aquamarine-9999/src/backend/drm/impl/Atomic.cpp:249:135:        
 /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/char_traits.h:427:56: warning: ‘__builtin_memcpy’ writing 16 bytes into a region    of size 10 overflows the destination [-Wstringop-overflow=]                                                                                 
   427 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));                                                          
 

```