### PR TITLE
a few small renderer optimisations

### DIFF
--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -850,8 +850,6 @@ void CDRMRenderer::clearBuffer(IBuffer* buf) {
     glClearColor(0.F, 0.F, 0.F, 1.F);
     glClear(GL_COLOR_BUFFER_BIT);
 
-    glFlush();
-
     GLCALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
     GLCALL(glBindRenderbuffer(GL_RENDERBUFFER, 0));
 
@@ -964,8 +962,6 @@ CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, S
         }
     }
 
-    glFlush();
-
     TRACE(backend->log(AQ_LOG_TRACE, std::format("EGL (blit): rboImage 0x{:x}", (uintptr_t)rboImage)));
 
     GLCALL(glBindRenderbuffer(GL_RENDERBUFFER, rboID));
@@ -1032,9 +1028,6 @@ CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, S
     GLCALL(glDisableVertexAttribArray(SHADER.texAttrib));
 
     GLCALL(glBindTexture(fromTex.target, 0));
-
-    // rendered, cleanup
-    glFlush();
 
     // get an explicit sync fd for the secondary gpu.
     // when we pass buffers between gpus we should always use explicit sync,

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -20,11 +20,13 @@ using namespace Hyprutils::Math;
 #define GLCALL(__CALL__)                                                                                                                                                           \
     {                                                                                                                                                                              \
         __CALL__;                                                                                                                                                                  \
-        auto err = glGetError();                                                                                                                                                   \
-        if (err != GL_NO_ERROR) {                                                                                                                                                  \
-            backend->log(AQ_LOG_ERROR,                                                                                                                                             \
-                         std::format("[GLES] Error in call at {}@{}: 0x{:x}", __LINE__,                                                                                            \
-                                     ([]() constexpr -> std::string { return std::string(__FILE__).substr(std::string(__FILE__).find_last_of('/') + 1); })(), err));               \
+        if (Aquamarine::isTrace()) {                                                                                                                                               \
+            auto err = glGetError();                                                                                                                                               \
+            if (err != GL_NO_ERROR) {                                                                                                                                              \
+                backend->log(AQ_LOG_ERROR,                                                                                                                                         \
+                             std::format("[GLES] Error in call at {}@{}: 0x{:x}", __LINE__,                                                                                        \
+                                         ([]() constexpr -> std::string { return std::string(__FILE__).substr(std::string(__FILE__).find_last_of('/') + 1); })(), err));           \
+            }                                                                                                                                                                      \
         }                                                                                                                                                                          \
     }
 

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -743,16 +743,16 @@ inline const float fullVerts[] = {
 void CDRMRenderer::waitOnSync(int fd) {
     TRACE(backend->log(AQ_LOG_TRACE, std::format("EGL (waitOnSync): attempting to wait on fd {}", fd)));
 
-    std::vector<EGLint> attribs;
-    int                 dupFd = fcntl(fd, F_DUPFD_CLOEXEC, 0);
+    std::array<EGLint, 3> attribs;
+    int                   dupFd = fcntl(fd, F_DUPFD_CLOEXEC, 0);
     if (dupFd < 0) {
         backend->log(AQ_LOG_TRACE, "EGL (waitOnSync): failed to dup fd for wait");
         return;
     }
 
-    attribs.push_back(EGL_SYNC_NATIVE_FENCE_FD_ANDROID);
-    attribs.push_back(dupFd);
-    attribs.push_back(EGL_NONE);
+    attribs[0] = EGL_SYNC_NATIVE_FENCE_FD_ANDROID;
+    attribs[1] = dupFd;
+    attribs[2] = EGL_NONE;
 
     EGLSyncKHR sync = proc.eglCreateSyncKHR(egl.display, EGL_SYNC_NATIVE_FENCE_ANDROID, attribs.data());
     if (sync == EGL_NO_SYNC_KHR) {


### PR DESCRIPTION
dont call glflush when its not needed, avoid vector reallocations in waitOnSync and guard glgeterror behind AQ_TRACE