### PR TITLE
Avoid unnecessary modeset (fixed)

### DIFF
--- a/src/allocator/DRMDumb.cpp
+++ b/src/allocator/DRMDumb.cpp
@@ -18,8 +18,7 @@ using namespace Hyprutils::Memory;
 #define WP CWeakPointer
 
 Aquamarine::CDRMDumbBuffer::CDRMDumbBuffer(const SAllocatorBufferParams& params, Hyprutils::Memory::CWeakPointer<CDRMDumbAllocator> allocator_,
-                                           Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain) :
-    allocator(allocator_) {
+                                           Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain) : allocator(allocator_) {
     attrs.format = params.format;
 
     if (int ret = drmModeCreateDumbBuffer(allocator->drmFD(), params.size.x, params.size.y, 32, 0, &handle, &stride, &bufferLen); ret < 0) {

--- a/src/allocator/GBM.cpp
+++ b/src/allocator/GBM.cpp
@@ -62,8 +62,7 @@ static SDRMFormat guessFormatFrom(std::vector<SDRMFormat> formats, bool cursor, 
 }
 
 Aquamarine::CGBMBuffer::CGBMBuffer(const SAllocatorBufferParams& params, Hyprutils::Memory::CWeakPointer<CGBMAllocator> allocator_,
-                                   Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain) :
-    allocator(allocator_) {
+                                   Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain) : allocator(allocator_) {
     if (!allocator)
         return;
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -895,7 +895,6 @@ void Aquamarine::CDRMBackend::scanLeases() {
 }
 
 bool Aquamarine::CDRMBackend::start() {
-    impl->reset();
     return true;
 }
 

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -100,8 +100,16 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
     TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic addConnector values: CRTC {}, mode {}", enable ? connector->crtc->id : 0, data.atomic.modeBlob)));
 
     conn = connector;
+    drmModeModeInfo* currentMode = connector->getCurrentMode();
+    bool modeDiffers = true;
+    if (currentMode) {
+        modeDiffers = memcmp(currentMode, &data.modeInfo, sizeof(drmModeModeInfo)) != 0;
+        free(currentMode);
+    }
 
-    addConnectorModeset(connector, data);
+    if (modeDiffers) {
+        addConnectorModeset(connector, data);
+    }
     addConnectorCursor(connector, data);
 
     add(connector->id, connector->props.crtc_id, enable ? connector->crtc->id : 0);
@@ -455,22 +463,7 @@ bool Aquamarine::CDRMAtomicImpl::commit(Hyprutils::Memory::CSharedPointer<SDRMCo
 }
 
 bool Aquamarine::CDRMAtomicImpl::reset() {
-    CDRMAtomicRequest request(backend);
-
-    for (auto const& crtc : backend->crtcs) {
-        request.add(crtc->id, crtc->props.mode_id, 0);
-        request.add(crtc->id, crtc->props.active, 0);
-    }
-
-    for (auto const& conn : backend->connectors) {
-        request.add(conn->id, conn->props.crtc_id, 0);
-    }
-
-    for (auto const& plane : backend->planes) {
-        request.planeProps(plane, nullptr, 0, {});
-    }
-
-    return request.commit(DRM_MODE_ATOMIC_ALLOW_MODESET);
+    return true;
 }
 
 bool Aquamarine::CDRMAtomicImpl::moveCursor(SP<SDRMConnector> connector, bool skipSchedule) {

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -463,7 +463,22 @@ bool Aquamarine::CDRMAtomicImpl::commit(Hyprutils::Memory::CSharedPointer<SDRMCo
 }
 
 bool Aquamarine::CDRMAtomicImpl::reset() {
-    return true;
+    CDRMAtomicRequest request(backend);
+
+    for (auto const& crtc : backend->crtcs) {
+        request.add(crtc->id, crtc->props.mode_id, 0);
+        request.add(crtc->id, crtc->props.active, 0);
+    }
+
+    for (auto const& conn : backend->connectors) {
+        request.add(conn->id, conn->props.crtc_id, 0);
+    }
+
+    for (auto const& plane : backend->planes) {
+        request.planeProps(plane, nullptr, 0, {});
+    }
+
+    return request.commit(DRM_MODE_ATOMIC_ALLOW_MODESET);
 }
 
 bool Aquamarine::CDRMAtomicImpl::moveCursor(SP<SDRMConnector> connector, bool skipSchedule) {

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -99,16 +99,17 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
 
     TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic addConnector values: CRTC {}, mode {}", enable ? connector->crtc->id : 0, data.atomic.modeBlob)));
 
-    conn = connector;
+    conn                         = connector;
     drmModeModeInfo* currentMode = connector->getCurrentMode();
-    bool modeDiffers = true;
+    bool             modeDiffers = true;
     if (currentMode) {
         modeDiffers = memcmp(currentMode, &data.modeInfo, sizeof(drmModeModeInfo)) != 0;
         free(currentMode);
     }
 
-    if (modeDiffers) addConnectorModeset(connector, data);
-    
+    if (modeDiffers)
+        addConnectorModeset(connector, data);
+
     addConnectorCursor(connector, data);
 
     add(connector->id, connector->props.crtc_id, enable ? connector->crtc->id : 0);

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -100,16 +100,19 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
     TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic addConnector values: CRTC {}, mode {}", enable ? connector->crtc->id : 0, data.atomic.modeBlob)));
 
     conn                         = connector;
-    drmModeModeInfo* currentMode = connector->getCurrentMode();
-    bool             modeDiffers = true;
-    if (currentMode) {
-        modeDiffers = memcmp(currentMode, &data.modeInfo, sizeof(drmModeModeInfo)) != 0;
-        free(currentMode);
+    if(enable){
+	    drmModeModeInfo* currentMode = connector->getCurrentMode();
+	    bool             modeDiffers = true;
+	    if (currentMode) {
+	        modeDiffers = memcmp(currentMode, &data.modeInfo, sizeof(drmModeModeInfo)) != 0;
+	        free(currentMode);
+	    }
+
+	    if (modeDiffers)
+	        addConnectorModeset(connector, data);
+    } else {
+    	addConnectorModeset(connector, data);
     }
-
-    if (modeDiffers)
-        addConnectorModeset(connector, data);
-
     addConnectorCursor(connector, data);
 
     add(connector->id, connector->props.crtc_id, enable ? connector->crtc->id : 0);
@@ -189,7 +192,7 @@ void Aquamarine::CDRMAtomicRequest::addConnectorModeset(Hyprutils::Memory::CShar
     const auto& STATE  = connector->output->state->state();
     const bool  enable = STATE.enabled && data.mainFB;
 
-    add(connector->crtc->id, connector->crtc->props.mode_id, data.atomic.modeBlob);
+    add(connector->crtc->id, connector->crtc->props.mode_id, enable ? data.atomic.modeBlob : 0);
     data.atomic.blobbed = true;
 
     if (!enable)

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -107,9 +107,8 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
         free(currentMode);
     }
 
-    if (modeDiffers) {
-        addConnectorModeset(connector, data);
-    }
+    if (modeDiffers) addConnectorModeset(connector, data);
+    
     addConnectorCursor(connector, data);
 
     add(connector->id, connector->props.crtc_id, enable ? connector->crtc->id : 0);

--- a/tests/SimpleWindow.cpp
+++ b/tests/SimpleWindow.cpp
@@ -70,15 +70,13 @@ int main(int argc, char** argv, char** envp) {
     });
 
     newMouseListener = aqBackend->events.newPointer.listen([](const SP<Aquamarine::IPointer>& pointer) {
-        mouseMotionListener = pointer->events.warp.listen([](const Aquamarine::IPointer::SWarpEvent& event) {
-            std::cout << "[Client] Mouse warped to " << std::format("{}", event.absolute) << "\n";
-        });
+        mouseMotionListener = pointer->events.warp.listen(
+            [](const Aquamarine::IPointer::SWarpEvent& event) { std::cout << "[Client] Mouse warped to " << std::format("{}", event.absolute) << "\n"; });
     });
 
     newKeyboardListener = aqBackend->events.newKeyboard.listen([](const SP<Aquamarine::IKeyboard>& keyboard) {
-        keyboardKeyListener = keyboard->events.key.listen([](const Aquamarine::IKeyboard::SKeyEvent& event) {
-            std::cout << "[Client] Key " << std::format("{}", event.key) << " state: " << event.pressed << " \n";
-        });
+        keyboardKeyListener = keyboard->events.key.listen(
+            [](const Aquamarine::IKeyboard::SKeyEvent& event) { std::cout << "[Client] Key " << std::format("{}", event.key) << " state: " << event.pressed << " \n"; });
     });
 
     if (!aqBackend || !aqBackend->start()) {


### PR DESCRIPTION
This PR adds back fastboot to aquamarine but `hyprctl dpms` is now fixed.