### PR TITLE
core: use -Wpedantic and fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,8 @@ add_compile_options(
   -Wextra
   -Wno-unused-parameter
   -Wno-unused-value
-  -Wno-missing-field-initializers)
+  -Wno-missing-field-initializers
+  -Wpedantic)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750960192,
-        "narHash": "sha256-AbaeiQAFq66XRMkhnwzxe8uZO2d81RdqO2XuuMzZU8U=",
+        "lastModified": 1751888065,
+        "narHash": "sha256-F2SV9WGqgtRsXIdUrl3sRe0wXlQD+kRRZcSfbepjPJY=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "d844a08d830e87d023ba2838e645004cb08118f6",
+        "rev": "a8229739cf36d159001cfc203871917b83fdf917",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750371869,
-        "narHash": "sha256-lGk4gLjgZQ/rndUkzmPYcgbHr8gKU5u71vyrjnwfpB4=",
+        "lastModified": 1751897909,
+        "narHash": "sha256-FnhBENxihITZldThvbO7883PdXC/2dzW4eiNvtoV5Ao=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "aa38edd6e3e277ae6a97ea83a69261a5c3aab9fd",
+        "rev": "fcca0c61f988a9d092cbb33e906775014c61579d",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750776420,
-        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
+        "lastModified": 1751792365,
+        "narHash": "sha256-J1kI6oAj25IG4EdVlg2hQz8NZTBNYvIS0l4wpr9KcUo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
+        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
         "type": "github"
       },
       "original": {

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -139,7 +139,7 @@ namespace Aquamarine {
                 uint32_t hotspot_x;
                 uint32_t hotspot_y;
                 uint32_t in_fence_fd;
-            };
+            } bits;
             uint32_t props[17] = {0};
         };
         UDRMPlaneProps props;
@@ -181,7 +181,7 @@ namespace Aquamarine {
                 uint32_t active;
                 uint32_t mode_id;
                 uint32_t out_fence_ptr;
-            };
+            } bits;
             uint32_t props[9] = {0};
         };
         UDRMCRTCProps props;
@@ -326,7 +326,7 @@ namespace Aquamarine {
                 // atomic-modesetting only
 
                 uint32_t crtc_id;
-            };
+            } bits;
             uint32_t props[13] = {0};
         };
         UDRMConnectorProps props;
@@ -336,7 +336,7 @@ namespace Aquamarine {
                 uint32_t Default;
                 uint32_t BT2020_RGB;
                 uint32_t BT2020_YCC;
-            };
+            } bits;
             uint32_t props[3] = {0};
         };
         UDRMConnectorColorspace colorspace;

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -139,7 +139,7 @@ namespace Aquamarine {
                 uint32_t hotspot_x;
                 uint32_t hotspot_y;
                 uint32_t in_fence_fd;
-            } bits;
+            } values;
             uint32_t props[17] = {0};
         };
         UDRMPlaneProps props;
@@ -181,7 +181,7 @@ namespace Aquamarine {
                 uint32_t active;
                 uint32_t mode_id;
                 uint32_t out_fence_ptr;
-            } bits;
+            } values;
             uint32_t props[9] = {0};
         };
         UDRMCRTCProps props;
@@ -326,7 +326,7 @@ namespace Aquamarine {
                 // atomic-modesetting only
 
                 uint32_t crtc_id;
-            } bits;
+            } values;
             uint32_t props[13] = {0};
         };
         UDRMConnectorProps props;
@@ -336,7 +336,7 @@ namespace Aquamarine {
                 uint32_t Default;
                 uint32_t BT2020_RGB;
                 uint32_t BT2020_YCC;
-            } bits;
+            } values;
             uint32_t props[3] = {0};
         };
         UDRMConnectorColorspace colorspace;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1084,7 +1084,7 @@ bool Aquamarine::SDRMPlane::init(drmModePlane* plane) {
     if (!getDRMPlaneProps(backend->gpu->fd, id, &props))
         return false;
 
-    if (!getDRMProp(backend->gpu->fd, id, props.type, &type))
+    if (!getDRMProp(backend->gpu->fd, id, props.bits.type, &type))
         return false;
 
     initialID = id;
@@ -1102,11 +1102,11 @@ bool Aquamarine::SDRMPlane::init(drmModePlane* plane) {
         TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("drm: | Format {}", fourccToName(plane->formats[i]))));
     }
 
-    if (props.in_formats && backend->drmProps.supportsAddFb2Modifiers) {
+    if (props.bits.in_formats && backend->drmProps.supportsAddFb2Modifiers) {
         backend->backend->log(AQ_LOG_DEBUG, "drm: Plane: checking for modifiers");
 
         uint64_t blobID = 0;
-        if (!getDRMProp(backend->gpu->fd, id, props.in_formats, &blobID)) {
+        if (!getDRMProp(backend->gpu->fd, id, props.bits.in_formats, &blobID)) {
             backend->backend->log(AQ_LOG_ERROR, "drm: Plane: No blob id");
             return false;
         }
@@ -1154,10 +1154,10 @@ bool Aquamarine::SDRMPlane::init(drmModePlane* plane) {
 
 SP<SDRMCRTC> Aquamarine::SDRMConnector::getCurrentCRTC(const drmModeConnector* connector) {
     uint32_t crtcID = 0;
-    if (props.crtc_id) {
+    if (props.bits.crtc_id) {
         TRACE(backend->backend->log(AQ_LOG_TRACE, "drm: Using crtc_id for finding crtc"));
         uint64_t value = 0;
-        if (!getDRMProp(backend->gpu->fd, id, props.crtc_id, &value)) {
+        if (!getDRMProp(backend->gpu->fd, id, props.bits.crtc_id, &value)) {
             backend->backend->log(AQ_LOG_ERROR, "drm: Failed to get CRTC_ID");
             return nullptr;
         }
@@ -1196,8 +1196,8 @@ bool Aquamarine::SDRMConnector::init(drmModeConnector* connector) {
 
     if (!getDRMConnectorProps(backend->gpu->fd, id, &props))
         return false;
-    if (props.Colorspace)
-        getDRMConnectorColorspace(backend->gpu->fd, props.Colorspace, &colorspace);
+    if (props.bits.Colorspace)
+        getDRMConnectorColorspace(backend->gpu->fd, props.bits.Colorspace, &colorspace);
 
     auto name = drmModeGetConnectorTypeName(connector->connector_type);
     if (!name)
@@ -1238,9 +1238,9 @@ drmModeModeInfo* Aquamarine::SDRMConnector::getCurrentMode() {
     if (!crtc)
         return nullptr;
 
-    if (crtc->props.mode_id) {
+    if (crtc->props.bits.mode_id) {
         size_t size = 0;
-        return (drmModeModeInfo*)getDRMPropBlob(backend->gpu->fd, crtc->id, crtc->props.mode_id, &size);
+        return (drmModeModeInfo*)getDRMPropBlob(backend->gpu->fd, crtc->id, crtc->props.bits.mode_id, &size);
     }
 
     auto drmCrtc = drmModeGetCrtc(backend->gpu->fd, crtc->id);
@@ -1350,23 +1350,24 @@ void Aquamarine::SDRMConnector::recheckCRTCProps() {
         return;
 
     uint64_t prop      = 0;
-    canDoVrr           = props.vrr_capable && crtc->props.vrr_enabled && getDRMProp(backend->gpu->fd, id, props.vrr_capable, &prop) && prop;
+    canDoVrr           = props.bits.vrr_capable && crtc->props.bits.vrr_enabled && getDRMProp(backend->gpu->fd, id, props.bits.vrr_capable, &prop) && prop;
     output->vrrCapable = canDoVrr;
 
     backend->backend->log(AQ_LOG_DEBUG,
                           std::format("drm: connector {} crtc is {} of vrr: props.vrr_capable -> {}, crtc->props.vrr_enabled -> {}", szName, (canDoVrr ? "capable" : "incapable"),
-                                      props.vrr_capable, crtc->props.vrr_enabled));
+                                      props.bits.vrr_capable, crtc->props.bits.vrr_enabled));
 
-    output->supportsExplicit = backend->drmProps.supportsTimelines && crtc->props.out_fence_ptr && crtc->primary->props.in_fence_fd;
+    output->supportsExplicit = backend->drmProps.supportsTimelines && crtc->props.bits.out_fence_ptr && crtc->primary->props.bits.in_fence_fd;
 
     backend->backend->log(AQ_LOG_DEBUG, std::format("drm: Explicit sync {}", output->supportsExplicit ? "supported" : "unsupported"));
 
-    backend->backend->log(AQ_LOG_DEBUG, std::format("drm: connector {} crtc {} CTM", szName, (crtc->props.ctm ? "supports" : "doesn't support")));
+    backend->backend->log(AQ_LOG_DEBUG, std::format("drm: connector {} crtc {} CTM", szName, (crtc->props.bits.ctm ? "supports" : "doesn't support")));
+
+    backend->backend->log(
+        AQ_LOG_DEBUG, std::format("drm: connector {} crtc {} HDR ({})", szName, (props.bits.hdr_output_metadata ? "supports" : "doesn't support"), props.bits.hdr_output_metadata));
 
     backend->backend->log(AQ_LOG_DEBUG,
-                          std::format("drm: connector {} crtc {} HDR ({})", szName, (props.hdr_output_metadata ? "supports" : "doesn't support"), props.hdr_output_metadata));
-
-    backend->backend->log(AQ_LOG_DEBUG, std::format("drm: connector {} crtc {} Colorspace ({})", szName, (props.Colorspace ? "supports" : "doesn't support"), props.Colorspace));
+                          std::format("drm: connector {} crtc {} Colorspace ({})", szName, (props.bits.Colorspace ? "supports" : "doesn't support"), props.bits.Colorspace));
 }
 
 void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
@@ -1434,7 +1435,7 @@ void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
     }
 
     uint64_t prop = 0;
-    if (getDRMProp(backend->gpu->fd, id, props.non_desktop, &prop)) {
+    if (getDRMProp(backend->gpu->fd, id, props.bits.non_desktop, &prop)) {
         if (prop == 1)
             backend->backend->log(AQ_LOG_DEBUG, "drm: Non-desktop connector");
         output->nonDesktop = prop;
@@ -1442,11 +1443,11 @@ void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
 
     maxBpcBounds.fill(0);
 
-    if (props.max_bpc && !introspectDRMPropRange(backend->gpu->fd, props.max_bpc, maxBpcBounds.data(), &maxBpcBounds[1]))
+    if (props.bits.max_bpc && !introspectDRMPropRange(backend->gpu->fd, props.bits.max_bpc, maxBpcBounds.data(), &maxBpcBounds[1]))
         backend->backend->log(AQ_LOG_ERROR, "drm: Failed to check max_bpc");
 
     size_t               edidLen  = 0;
-    uint8_t*             edidData = (uint8_t*)getDRMPropBlob(backend->gpu->fd, id, props.edid, &edidLen);
+    uint8_t*             edidData = (uint8_t*)getDRMPropBlob(backend->gpu->fd, id, props.bits.edid, &edidLen);
 
     std::vector<uint8_t> edid{edidData, edidData + edidLen};
     auto                 parsedEDID = parseEDID(edid);
@@ -1955,7 +1956,7 @@ size_t Aquamarine::CDRMOutput::getGammaSize() {
     }
 
     uint64_t size = 0;
-    if (!getDRMProp(backend->gpu->fd, connector->crtc->id, connector->crtc->props.gamma_lut_size, &size)) {
+    if (!getDRMProp(backend->gpu->fd, connector->crtc->id, connector->crtc->props.bits.gamma_lut_size, &size)) {
         backend->log(AQ_LOG_ERROR, "Couldn't get the gamma_size prop");
         return 0;
     }
@@ -1970,7 +1971,7 @@ size_t Aquamarine::CDRMOutput::getDeGammaSize() {
     }
 
     uint64_t size = 0;
-    if (!getDRMProp(backend->gpu->fd, connector->crtc->id, connector->crtc->props.degamma_lut_size, &size)) {
+    if (!getDRMProp(backend->gpu->fd, connector->crtc->id, connector->crtc->props.bits.degamma_lut_size, &size)) {
         backend->log(AQ_LOG_ERROR, "Couldn't get the degamma_size prop");
         return 0;
     }
@@ -2209,7 +2210,7 @@ void Aquamarine::SDRMConnectorCommitData::calculateMode(Hyprutils::Memory::CShar
     uint16_t hsync_end   = hsync_start + timing.h_sync;
     uint16_t vsync_end   = vsync_start + timing.v_sync;
 
-    modeInfo = (drmModeModeInfo){
+    modeInfo = drmModeModeInfo{
         .clock       = (uint32_t)std::round(timing.act_pixel_freq * 1000),
         .hdisplay    = (uint16_t)MODE->pixelSize.x,
         .hsync_start = hsync_start,

--- a/src/backend/drm/Props.cpp
+++ b/src/backend/drm/Props.cpp
@@ -19,7 +19,7 @@ struct prop_info {
 };
 
 static const struct prop_info connector_info[] = {
-#define INDEX(name) (offsetof(SDRMConnector::UDRMConnectorProps, name) / sizeof(uint32_t))
+#define INDEX(name) (offsetof(SDRMConnector::UDRMConnectorProps, bits.name) / sizeof(uint32_t))
     {.name = "CRTC_ID", .index = INDEX(crtc_id)},
     {.name = "Colorspace", .index = INDEX(Colorspace)},
     {.name = "DPMS", .index = INDEX(dpms)},
@@ -37,7 +37,7 @@ static const struct prop_info connector_info[] = {
 };
 
 static const struct prop_info colorspace_info[] = {
-#define INDEX(name) (offsetof(SDRMConnector::UDRMConnectorColorspace, name) / sizeof(uint32_t))
+#define INDEX(name) (offsetof(SDRMConnector::UDRMConnectorColorspace, bits.name) / sizeof(uint32_t))
     {.name = "BT2020_RGB", .index = INDEX(BT2020_RGB)},
     {.name = "BT2020_YCC", .index = INDEX(BT2020_YCC)},
     {.name = "Default", .index = INDEX(Default)},
@@ -45,7 +45,7 @@ static const struct prop_info colorspace_info[] = {
 };
 
 static const struct prop_info crtc_info[] = {
-#define INDEX(name) (offsetof(SDRMCRTC::UDRMCRTCProps, name) / sizeof(uint32_t))
+#define INDEX(name) (offsetof(SDRMCRTC::UDRMCRTCProps, bits.name) / sizeof(uint32_t))
     {.name = "ACTIVE", .index = INDEX(active)},           {.name = "CTM", .index = INDEX(ctm)},
     {.name = "DEGAMMA_LUT", .index = INDEX(degamma_lut)}, {.name = "DEGAMMA_LUT_SIZE", .index = INDEX(degamma_lut_size)},
     {.name = "GAMMA_LUT", .index = INDEX(gamma_lut)},     {.name = "GAMMA_LUT_SIZE", .index = INDEX(gamma_lut_size)},
@@ -55,7 +55,7 @@ static const struct prop_info crtc_info[] = {
 };
 
 static const struct prop_info plane_info[] = {
-#define INDEX(name) (offsetof(SDRMPlane::UDRMPlaneProps, name) / sizeof(uint32_t))
+#define INDEX(name) (offsetof(SDRMPlane::UDRMPlaneProps, bits.name) / sizeof(uint32_t))
     {.name = "CRTC_H", .index = INDEX(crtc_h)},
     {.name = "CRTC_ID", .index = INDEX(crtc_id)},
     {.name = "CRTC_W", .index = INDEX(crtc_w)},

--- a/src/backend/drm/Props.cpp
+++ b/src/backend/drm/Props.cpp
@@ -19,7 +19,7 @@ struct prop_info {
 };
 
 static const struct prop_info connector_info[] = {
-#define INDEX(name) (offsetof(SDRMConnector::UDRMConnectorProps, bits.name) / sizeof(uint32_t))
+#define INDEX(name) (offsetof(SDRMConnector::UDRMConnectorProps, values.name) / sizeof(uint32_t))
     {.name = "CRTC_ID", .index = INDEX(crtc_id)},
     {.name = "Colorspace", .index = INDEX(Colorspace)},
     {.name = "DPMS", .index = INDEX(dpms)},
@@ -37,7 +37,7 @@ static const struct prop_info connector_info[] = {
 };
 
 static const struct prop_info colorspace_info[] = {
-#define INDEX(name) (offsetof(SDRMConnector::UDRMConnectorColorspace, bits.name) / sizeof(uint32_t))
+#define INDEX(name) (offsetof(SDRMConnector::UDRMConnectorColorspace, values.name) / sizeof(uint32_t))
     {.name = "BT2020_RGB", .index = INDEX(BT2020_RGB)},
     {.name = "BT2020_YCC", .index = INDEX(BT2020_YCC)},
     {.name = "Default", .index = INDEX(Default)},
@@ -45,7 +45,7 @@ static const struct prop_info colorspace_info[] = {
 };
 
 static const struct prop_info crtc_info[] = {
-#define INDEX(name) (offsetof(SDRMCRTC::UDRMCRTCProps, bits.name) / sizeof(uint32_t))
+#define INDEX(name) (offsetof(SDRMCRTC::UDRMCRTCProps, values.name) / sizeof(uint32_t))
     {.name = "ACTIVE", .index = INDEX(active)},           {.name = "CTM", .index = INDEX(ctm)},
     {.name = "DEGAMMA_LUT", .index = INDEX(degamma_lut)}, {.name = "DEGAMMA_LUT_SIZE", .index = INDEX(degamma_lut_size)},
     {.name = "GAMMA_LUT", .index = INDEX(gamma_lut)},     {.name = "GAMMA_LUT_SIZE", .index = INDEX(gamma_lut_size)},
@@ -55,7 +55,7 @@ static const struct prop_info crtc_info[] = {
 };
 
 static const struct prop_info plane_info[] = {
-#define INDEX(name) (offsetof(SDRMPlane::UDRMPlaneProps, bits.name) / sizeof(uint32_t))
+#define INDEX(name) (offsetof(SDRMPlane::UDRMPlaneProps, values.name) / sizeof(uint32_t))
     {.name = "CRTC_H", .index = INDEX(crtc_h)},
     {.name = "CRTC_ID", .index = INDEX(crtc_id)},
     {.name = "CRTC_W", .index = INDEX(crtc_w)},

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -50,27 +50,27 @@ void Aquamarine::CDRMAtomicRequest::planeProps(Hyprutils::Memory::CSharedPointer
     if (!fb || !crtc) {
         // Disable the plane
         TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic planeProps: disabling plane {}", plane->id)));
-        add(plane->id, plane->props.fb_id, 0);
-        add(plane->id, plane->props.crtc_id, 0);
-        add(plane->id, plane->props.crtc_x, (uint64_t)pos.x);
-        add(plane->id, plane->props.crtc_y, (uint64_t)pos.y);
+        add(plane->id, plane->props.bits.fb_id, 0);
+        add(plane->id, plane->props.bits.crtc_id, 0);
+        add(plane->id, plane->props.bits.crtc_x, (uint64_t)pos.x);
+        add(plane->id, plane->props.bits.crtc_y, (uint64_t)pos.y);
         return;
     }
 
-    TRACE(
-        backend->log(AQ_LOG_TRACE,
-                     std::format("atomic planeProps: prop blobs: src_x {}, src_y {}, src_w {}, src_h {}, crtc_w {}, crtc_h {}, fb_id {}, crtc_id {}", plane->props.src_x,
-                                 plane->props.src_y, plane->props.src_w, plane->props.src_h, plane->props.crtc_w, plane->props.crtc_h, plane->props.fb_id, plane->props.crtc_id)));
+    TRACE(backend->log(AQ_LOG_TRACE,
+                       std::format("atomic planeProps: prop blobs: src_x {}, src_y {}, src_w {}, src_h {}, crtc_w {}, crtc_h {}, fb_id {}, crtc_id {}", plane->props.bits.src_x,
+                                   plane->props.bits.src_y, plane->props.bits.src_w, plane->props.bits.src_h, plane->props.bits.crtc_w, plane->props.bits.crtc_h,
+                                   plane->props.bits.fb_id, plane->props.bits.crtc_id)));
 
     // src_ are 16.16 fixed point (lol)
-    add(plane->id, plane->props.src_x, 0);
-    add(plane->id, plane->props.src_y, 0);
-    add(plane->id, plane->props.src_w, ((uint64_t)fb->buffer->size.x) << 16);
-    add(plane->id, plane->props.src_h, ((uint64_t)fb->buffer->size.y) << 16);
-    add(plane->id, plane->props.crtc_w, (uint32_t)fb->buffer->size.x);
-    add(plane->id, plane->props.crtc_h, (uint32_t)fb->buffer->size.y);
-    add(plane->id, plane->props.fb_id, fb->id);
-    add(plane->id, plane->props.crtc_id, crtc);
+    add(plane->id, plane->props.bits.src_x, 0);
+    add(plane->id, plane->props.bits.src_y, 0);
+    add(plane->id, plane->props.bits.src_w, ((uint64_t)fb->buffer->size.x) << 16);
+    add(plane->id, plane->props.bits.src_h, ((uint64_t)fb->buffer->size.y) << 16);
+    add(plane->id, plane->props.bits.crtc_w, (uint32_t)fb->buffer->size.x);
+    add(plane->id, plane->props.bits.crtc_h, (uint32_t)fb->buffer->size.y);
+    add(plane->id, plane->props.bits.fb_id, fb->id);
+    add(plane->id, plane->props.bits.crtc_id, crtc);
     planePropsPos(plane, pos);
 }
 
@@ -79,10 +79,10 @@ void Aquamarine::CDRMAtomicRequest::planePropsPos(Hyprutils::Memory::CSharedPoin
     if (failed)
         return;
 
-    TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic planeProps: pos blobs: crtc_x {}, crtc_y {}", plane->props.crtc_x, plane->props.crtc_y)));
+    TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic planeProps: pos blobs: crtc_x {}, crtc_y {}", plane->props.bits.crtc_x, plane->props.bits.crtc_y)));
 
-    add(plane->id, plane->props.crtc_x, (uint64_t)pos.x);
-    add(plane->id, plane->props.crtc_y, (uint64_t)pos.y);
+    add(plane->id, plane->props.bits.crtc_x, (uint64_t)pos.x);
+    add(plane->id, plane->props.bits.crtc_y, (uint64_t)pos.y);
 }
 
 void Aquamarine::CDRMAtomicRequest::setConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector) {
@@ -94,8 +94,8 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
     const bool  enable = STATE.enabled && data.mainFB;
 
     TRACE(backend->log(AQ_LOG_TRACE,
-                       std::format("atomic addConnector blobs: mode_id {}, active {}, crtc_id {}, link_status {}, content_type {}", connector->crtc->props.mode_id,
-                                   connector->crtc->props.active, connector->props.crtc_id, connector->props.link_status, connector->props.content_type)));
+                       std::format("atomic addConnector blobs: mode_id {}, active {}, crtc_id {}, link_status {}, content_type {}", connector->crtc->props.bits.mode_id,
+                                   connector->crtc->props.bits.active, connector->props.bits.crtc_id, connector->props.bits.link_status, connector->props.bits.content_type)));
 
     TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic addConnector values: CRTC {}, mode {}", enable ? connector->crtc->id : 0, data.atomic.modeBlob)));
 
@@ -110,41 +110,41 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
 
         if (modeDiffers)
             addConnectorModeset(connector, data);
-    } else 
+    } else
         addConnectorModeset(connector, data);
-    
+
     addConnectorCursor(connector, data);
 
-    add(connector->id, connector->props.crtc_id, enable ? connector->crtc->id : 0);
+    add(connector->id, connector->props.bits.crtc_id, enable ? connector->crtc->id : 0);
 
-    if (enable && connector->props.content_type)
-        add(connector->id, connector->props.content_type, STATE.contentType);
+    if (enable && connector->props.bits.content_type)
+        add(connector->id, connector->props.bits.content_type, STATE.contentType);
 
-    add(connector->crtc->id, connector->crtc->props.active, enable);
+    add(connector->crtc->id, connector->crtc->props.bits.active, enable);
 
     if (enable) {
         if (connector->output->supportsExplicit && STATE.committed & COutputState::AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE)
-            add(connector->crtc->id, connector->crtc->props.out_fence_ptr, (uintptr_t)&STATE.explicitOutFence);
+            add(connector->crtc->id, connector->crtc->props.bits.out_fence_ptr, (uintptr_t)&STATE.explicitOutFence);
 
-        if (connector->crtc->props.gamma_lut && data.atomic.gammad)
-            add(connector->crtc->id, connector->crtc->props.gamma_lut, data.atomic.gammaLut);
+        if (connector->crtc->props.bits.gamma_lut && data.atomic.gammad)
+            add(connector->crtc->id, connector->crtc->props.bits.gamma_lut, data.atomic.gammaLut);
 
-        if (connector->crtc->props.degamma_lut && data.atomic.degammad)
-            add(connector->crtc->id, connector->crtc->props.degamma_lut, data.atomic.degammaLut);
+        if (connector->crtc->props.bits.degamma_lut && data.atomic.degammad)
+            add(connector->crtc->id, connector->crtc->props.bits.degamma_lut, data.atomic.degammaLut);
 
-        if (connector->crtc->props.ctm && data.atomic.ctmd)
-            add(connector->crtc->id, connector->crtc->props.ctm, data.atomic.ctmBlob);
+        if (connector->crtc->props.bits.ctm && data.atomic.ctmd)
+            add(connector->crtc->id, connector->crtc->props.bits.ctm, data.atomic.ctmBlob);
 
-        if (connector->crtc->props.vrr_enabled)
-            add(connector->crtc->id, connector->crtc->props.vrr_enabled, (uint64_t)STATE.adaptiveSync);
+        if (connector->crtc->props.bits.vrr_enabled)
+            add(connector->crtc->id, connector->crtc->props.bits.vrr_enabled, (uint64_t)STATE.adaptiveSync);
 
         planeProps(connector->crtc->primary, data.mainFB, connector->crtc->id, {});
 
         if (connector->output->supportsExplicit && STATE.explicitInFence >= 0)
-            add(connector->crtc->primary->id, connector->crtc->primary->props.in_fence_fd, STATE.explicitInFence);
+            add(connector->crtc->primary->id, connector->crtc->primary->props.bits.in_fence_fd, STATE.explicitInFence);
 
-        if (connector->crtc->primary->props.fb_damage_clips)
-            add(connector->crtc->primary->id, connector->crtc->primary->props.fb_damage_clips, data.atomic.fbDamage);
+        if (connector->crtc->primary->props.bits.fb_damage_clips)
+            add(connector->crtc->primary->id, connector->crtc->primary->props.bits.fb_damage_clips, data.atomic.fbDamage);
     } else {
         planeProps(connector->crtc->primary, nullptr, 0, {});
     }
@@ -192,23 +192,23 @@ void Aquamarine::CDRMAtomicRequest::addConnectorModeset(Hyprutils::Memory::CShar
     const auto& STATE  = connector->output->state->state();
     const bool  enable = STATE.enabled && data.mainFB;
 
-    add(connector->crtc->id, connector->crtc->props.mode_id, enable ? data.atomic.modeBlob : 0);
+    add(connector->crtc->id, connector->crtc->props.bits.mode_id, enable ? data.atomic.modeBlob : 0);
     data.atomic.blobbed = true;
 
     if (!enable)
         return;
 
-    if (connector->props.link_status)
-        add(connector->id, connector->props.link_status, DRM_MODE_LINK_STATUS_GOOD);
+    if (connector->props.bits.link_status)
+        add(connector->id, connector->props.bits.link_status, DRM_MODE_LINK_STATUS_GOOD);
 
-    if (connector->props.max_bpc && connector->maxBpcBounds.at(1))
-        add(connector->id, connector->props.max_bpc, getMaxBPC(data.mainFB->buffer->dmabuf().format));
+    if (connector->props.bits.max_bpc && connector->maxBpcBounds.at(1))
+        add(connector->id, connector->props.bits.max_bpc, getMaxBPC(data.mainFB->buffer->dmabuf().format));
 
-    if (connector->props.Colorspace && connector->colorspace.BT2020_RGB)
-        add(connector->id, connector->props.Colorspace, STATE.wideColorGamut ? connector->colorspace.BT2020_RGB : connector->colorspace.Default);
+    if (connector->props.bits.Colorspace && connector->colorspace.bits.BT2020_RGB)
+        add(connector->id, connector->props.bits.Colorspace, STATE.wideColorGamut ? connector->colorspace.bits.BT2020_RGB : connector->colorspace.bits.Default);
 
-    if (connector->props.hdr_output_metadata && data.atomic.hdrd)
-        add(connector->id, connector->props.hdr_output_metadata, data.atomic.hdrBlob);
+    if (connector->props.bits.hdr_output_metadata && data.atomic.hdrd)
+        add(connector->id, connector->props.bits.hdr_output_metadata, data.atomic.hdrBlob);
 }
 
 void Aquamarine::CDRMAtomicRequest::addConnectorCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data) {
@@ -365,13 +365,13 @@ bool Aquamarine::CDRMAtomicImpl::prepareConnector(Hyprutils::Memory::CSharedPoin
     };
 
     if (STATE.committed & COutputState::AQ_OUTPUT_STATE_GAMMA_LUT)
-        data.atomic.gammad = prepareGammaBlob(connector->crtc->props.gamma_lut, STATE.gammaLut, &data.atomic.gammaLut);
+        data.atomic.gammad = prepareGammaBlob(connector->crtc->props.bits.gamma_lut, STATE.gammaLut, &data.atomic.gammaLut);
 
     if (STATE.committed & COutputState::AQ_OUTPUT_STATE_DEGAMMA_LUT)
-        data.atomic.degammad = prepareGammaBlob(connector->crtc->props.degamma_lut, STATE.degammaLut, &data.atomic.degammaLut);
+        data.atomic.degammad = prepareGammaBlob(connector->crtc->props.bits.degamma_lut, STATE.degammaLut, &data.atomic.degammaLut);
 
     if ((STATE.committed & COutputState::AQ_OUTPUT_STATE_CTM) && data.ctm.has_value()) {
-        if (!connector->crtc->props.ctm)
+        if (!connector->crtc->props.bits.ctm)
             connector->backend->backend->log(AQ_LOG_ERROR, "atomic drm: failed to commit ctm: no ctm prop support");
         else {
             static auto doubleToS3132Fixed = [](const double val) -> uint64_t {
@@ -395,7 +395,7 @@ bool Aquamarine::CDRMAtomicImpl::prepareConnector(Hyprutils::Memory::CSharedPoin
     }
 
     if ((STATE.committed & COutputState::AQ_OUTPUT_STATE_HDR) && data.hdrMetadata.has_value()) {
-        if (!connector->props.hdr_output_metadata)
+        if (!connector->props.bits.hdr_output_metadata)
             connector->backend->backend->log(AQ_LOG_ERROR, "atomic drm: failed to commit hdr metadata: no HDR_OUTPUT_METADATA prop support");
         else {
             if (!data.hdrMetadata->hdmi_metadata_type1.eotf) {
@@ -421,7 +421,7 @@ bool Aquamarine::CDRMAtomicImpl::prepareConnector(Hyprutils::Memory::CSharedPoin
         }
     }
 
-    if ((STATE.committed & COutputState::AQ_OUTPUT_STATE_DAMAGE) && connector->crtc->primary->props.fb_damage_clips && MODE) {
+    if ((STATE.committed & COutputState::AQ_OUTPUT_STATE_DAMAGE) && connector->crtc->primary->props.bits.fb_damage_clips && MODE) {
         if (STATE.damage.empty())
             data.atomic.fbDamage = 0;
         else {
@@ -469,12 +469,12 @@ bool Aquamarine::CDRMAtomicImpl::reset() {
     CDRMAtomicRequest request(backend);
 
     for (auto const& crtc : backend->crtcs) {
-        request.add(crtc->id, crtc->props.mode_id, 0);
-        request.add(crtc->id, crtc->props.active, 0);
+        request.add(crtc->id, crtc->props.bits.mode_id, 0);
+        request.add(crtc->id, crtc->props.bits.active, 0);
     }
 
     for (auto const& conn : backend->connectors) {
-        request.add(conn->id, conn->props.crtc_id, 0);
+        request.add(conn->id, conn->props.bits.crtc_id, 0);
     }
 
     for (auto const& plane : backend->planes) {

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -50,27 +50,27 @@ void Aquamarine::CDRMAtomicRequest::planeProps(Hyprutils::Memory::CSharedPointer
     if (!fb || !crtc) {
         // Disable the plane
         TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic planeProps: disabling plane {}", plane->id)));
-        add(plane->id, plane->props.bits.fb_id, 0);
-        add(plane->id, plane->props.bits.crtc_id, 0);
-        add(plane->id, plane->props.bits.crtc_x, (uint64_t)pos.x);
-        add(plane->id, plane->props.bits.crtc_y, (uint64_t)pos.y);
+        add(plane->id, plane->props.values.fb_id, 0);
+        add(plane->id, plane->props.values.crtc_id, 0);
+        add(plane->id, plane->props.values.crtc_x, (uint64_t)pos.x);
+        add(plane->id, plane->props.values.crtc_y, (uint64_t)pos.y);
         return;
     }
 
     TRACE(backend->log(AQ_LOG_TRACE,
-                       std::format("atomic planeProps: prop blobs: src_x {}, src_y {}, src_w {}, src_h {}, crtc_w {}, crtc_h {}, fb_id {}, crtc_id {}", plane->props.bits.src_x,
-                                   plane->props.bits.src_y, plane->props.bits.src_w, plane->props.bits.src_h, plane->props.bits.crtc_w, plane->props.bits.crtc_h,
-                                   plane->props.bits.fb_id, plane->props.bits.crtc_id)));
+                       std::format("atomic planeProps: prop blobs: src_x {}, src_y {}, src_w {}, src_h {}, crtc_w {}, crtc_h {}, fb_id {}, crtc_id {}", plane->props.values.src_x,
+                                   plane->props.values.src_y, plane->props.values.src_w, plane->props.values.src_h, plane->props.values.crtc_w, plane->props.values.crtc_h,
+                                   plane->props.values.fb_id, plane->props.values.crtc_id)));
 
     // src_ are 16.16 fixed point (lol)
-    add(plane->id, plane->props.bits.src_x, 0);
-    add(plane->id, plane->props.bits.src_y, 0);
-    add(plane->id, plane->props.bits.src_w, ((uint64_t)fb->buffer->size.x) << 16);
-    add(plane->id, plane->props.bits.src_h, ((uint64_t)fb->buffer->size.y) << 16);
-    add(plane->id, plane->props.bits.crtc_w, (uint32_t)fb->buffer->size.x);
-    add(plane->id, plane->props.bits.crtc_h, (uint32_t)fb->buffer->size.y);
-    add(plane->id, plane->props.bits.fb_id, fb->id);
-    add(plane->id, plane->props.bits.crtc_id, crtc);
+    add(plane->id, plane->props.values.src_x, 0);
+    add(plane->id, plane->props.values.src_y, 0);
+    add(plane->id, plane->props.values.src_w, ((uint64_t)fb->buffer->size.x) << 16);
+    add(plane->id, plane->props.values.src_h, ((uint64_t)fb->buffer->size.y) << 16);
+    add(plane->id, plane->props.values.crtc_w, (uint32_t)fb->buffer->size.x);
+    add(plane->id, plane->props.values.crtc_h, (uint32_t)fb->buffer->size.y);
+    add(plane->id, plane->props.values.fb_id, fb->id);
+    add(plane->id, plane->props.values.crtc_id, crtc);
     planePropsPos(plane, pos);
 }
 
@@ -79,10 +79,10 @@ void Aquamarine::CDRMAtomicRequest::planePropsPos(Hyprutils::Memory::CSharedPoin
     if (failed)
         return;
 
-    TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic planeProps: pos blobs: crtc_x {}, crtc_y {}", plane->props.bits.crtc_x, plane->props.bits.crtc_y)));
+    TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic planeProps: pos blobs: crtc_x {}, crtc_y {}", plane->props.values.crtc_x, plane->props.values.crtc_y)));
 
-    add(plane->id, plane->props.bits.crtc_x, (uint64_t)pos.x);
-    add(plane->id, plane->props.bits.crtc_y, (uint64_t)pos.y);
+    add(plane->id, plane->props.values.crtc_x, (uint64_t)pos.x);
+    add(plane->id, plane->props.values.crtc_y, (uint64_t)pos.y);
 }
 
 void Aquamarine::CDRMAtomicRequest::setConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector) {
@@ -94,8 +94,9 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
     const bool  enable = STATE.enabled && data.mainFB;
 
     TRACE(backend->log(AQ_LOG_TRACE,
-                       std::format("atomic addConnector blobs: mode_id {}, active {}, crtc_id {}, link_status {}, content_type {}", connector->crtc->props.bits.mode_id,
-                                   connector->crtc->props.bits.active, connector->props.bits.crtc_id, connector->props.bits.link_status, connector->props.bits.content_type)));
+                       std::format("atomic addConnector blobs: mode_id {}, active {}, crtc_id {}, link_status {}, content_type {}", connector->crtc->props.values.mode_id,
+                                   connector->crtc->props.values.active, connector->props.values.crtc_id, connector->props.values.link_status,
+                                   connector->props.values.content_type)));
 
     TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic addConnector values: CRTC {}, mode {}", enable ? connector->crtc->id : 0, data.atomic.modeBlob)));
 
@@ -115,36 +116,36 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
 
     addConnectorCursor(connector, data);
 
-    add(connector->id, connector->props.bits.crtc_id, enable ? connector->crtc->id : 0);
+    add(connector->id, connector->props.values.crtc_id, enable ? connector->crtc->id : 0);
 
-    if (enable && connector->props.bits.content_type)
-        add(connector->id, connector->props.bits.content_type, STATE.contentType);
+    if (enable && connector->props.values.content_type)
+        add(connector->id, connector->props.values.content_type, STATE.contentType);
 
-    add(connector->crtc->id, connector->crtc->props.bits.active, enable);
+    add(connector->crtc->id, connector->crtc->props.values.active, enable);
 
     if (enable) {
         if (connector->output->supportsExplicit && STATE.committed & COutputState::AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE)
-            add(connector->crtc->id, connector->crtc->props.bits.out_fence_ptr, (uintptr_t)&STATE.explicitOutFence);
+            add(connector->crtc->id, connector->crtc->props.values.out_fence_ptr, (uintptr_t)&STATE.explicitOutFence);
 
-        if (connector->crtc->props.bits.gamma_lut && data.atomic.gammad)
-            add(connector->crtc->id, connector->crtc->props.bits.gamma_lut, data.atomic.gammaLut);
+        if (connector->crtc->props.values.gamma_lut && data.atomic.gammad)
+            add(connector->crtc->id, connector->crtc->props.values.gamma_lut, data.atomic.gammaLut);
 
-        if (connector->crtc->props.bits.degamma_lut && data.atomic.degammad)
-            add(connector->crtc->id, connector->crtc->props.bits.degamma_lut, data.atomic.degammaLut);
+        if (connector->crtc->props.values.degamma_lut && data.atomic.degammad)
+            add(connector->crtc->id, connector->crtc->props.values.degamma_lut, data.atomic.degammaLut);
 
-        if (connector->crtc->props.bits.ctm && data.atomic.ctmd)
-            add(connector->crtc->id, connector->crtc->props.bits.ctm, data.atomic.ctmBlob);
+        if (connector->crtc->props.values.ctm && data.atomic.ctmd)
+            add(connector->crtc->id, connector->crtc->props.values.ctm, data.atomic.ctmBlob);
 
-        if (connector->crtc->props.bits.vrr_enabled)
-            add(connector->crtc->id, connector->crtc->props.bits.vrr_enabled, (uint64_t)STATE.adaptiveSync);
+        if (connector->crtc->props.values.vrr_enabled)
+            add(connector->crtc->id, connector->crtc->props.values.vrr_enabled, (uint64_t)STATE.adaptiveSync);
 
         planeProps(connector->crtc->primary, data.mainFB, connector->crtc->id, {});
 
         if (connector->output->supportsExplicit && STATE.explicitInFence >= 0)
-            add(connector->crtc->primary->id, connector->crtc->primary->props.bits.in_fence_fd, STATE.explicitInFence);
+            add(connector->crtc->primary->id, connector->crtc->primary->props.values.in_fence_fd, STATE.explicitInFence);
 
-        if (connector->crtc->primary->props.bits.fb_damage_clips)
-            add(connector->crtc->primary->id, connector->crtc->primary->props.bits.fb_damage_clips, data.atomic.fbDamage);
+        if (connector->crtc->primary->props.values.fb_damage_clips)
+            add(connector->crtc->primary->id, connector->crtc->primary->props.values.fb_damage_clips, data.atomic.fbDamage);
     } else {
         planeProps(connector->crtc->primary, nullptr, 0, {});
     }
@@ -192,23 +193,23 @@ void Aquamarine::CDRMAtomicRequest::addConnectorModeset(Hyprutils::Memory::CShar
     const auto& STATE  = connector->output->state->state();
     const bool  enable = STATE.enabled && data.mainFB;
 
-    add(connector->crtc->id, connector->crtc->props.bits.mode_id, enable ? data.atomic.modeBlob : 0);
+    add(connector->crtc->id, connector->crtc->props.values.mode_id, enable ? data.atomic.modeBlob : 0);
     data.atomic.blobbed = true;
 
     if (!enable)
         return;
 
-    if (connector->props.bits.link_status)
-        add(connector->id, connector->props.bits.link_status, DRM_MODE_LINK_STATUS_GOOD);
+    if (connector->props.values.link_status)
+        add(connector->id, connector->props.values.link_status, DRM_MODE_LINK_STATUS_GOOD);
 
-    if (connector->props.bits.max_bpc && connector->maxBpcBounds.at(1))
-        add(connector->id, connector->props.bits.max_bpc, getMaxBPC(data.mainFB->buffer->dmabuf().format));
+    if (connector->props.values.max_bpc && connector->maxBpcBounds.at(1))
+        add(connector->id, connector->props.values.max_bpc, getMaxBPC(data.mainFB->buffer->dmabuf().format));
 
-    if (connector->props.bits.Colorspace && connector->colorspace.bits.BT2020_RGB)
-        add(connector->id, connector->props.bits.Colorspace, STATE.wideColorGamut ? connector->colorspace.bits.BT2020_RGB : connector->colorspace.bits.Default);
+    if (connector->props.values.Colorspace && connector->colorspace.values.BT2020_RGB)
+        add(connector->id, connector->props.values.Colorspace, STATE.wideColorGamut ? connector->colorspace.values.BT2020_RGB : connector->colorspace.values.Default);
 
-    if (connector->props.bits.hdr_output_metadata && data.atomic.hdrd)
-        add(connector->id, connector->props.bits.hdr_output_metadata, data.atomic.hdrBlob);
+    if (connector->props.values.hdr_output_metadata && data.atomic.hdrd)
+        add(connector->id, connector->props.values.hdr_output_metadata, data.atomic.hdrBlob);
 }
 
 void Aquamarine::CDRMAtomicRequest::addConnectorCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data) {
@@ -365,13 +366,13 @@ bool Aquamarine::CDRMAtomicImpl::prepareConnector(Hyprutils::Memory::CSharedPoin
     };
 
     if (STATE.committed & COutputState::AQ_OUTPUT_STATE_GAMMA_LUT)
-        data.atomic.gammad = prepareGammaBlob(connector->crtc->props.bits.gamma_lut, STATE.gammaLut, &data.atomic.gammaLut);
+        data.atomic.gammad = prepareGammaBlob(connector->crtc->props.values.gamma_lut, STATE.gammaLut, &data.atomic.gammaLut);
 
     if (STATE.committed & COutputState::AQ_OUTPUT_STATE_DEGAMMA_LUT)
-        data.atomic.degammad = prepareGammaBlob(connector->crtc->props.bits.degamma_lut, STATE.degammaLut, &data.atomic.degammaLut);
+        data.atomic.degammad = prepareGammaBlob(connector->crtc->props.values.degamma_lut, STATE.degammaLut, &data.atomic.degammaLut);
 
     if ((STATE.committed & COutputState::AQ_OUTPUT_STATE_CTM) && data.ctm.has_value()) {
-        if (!connector->crtc->props.bits.ctm)
+        if (!connector->crtc->props.values.ctm)
             connector->backend->backend->log(AQ_LOG_ERROR, "atomic drm: failed to commit ctm: no ctm prop support");
         else {
             static auto doubleToS3132Fixed = [](const double val) -> uint64_t {
@@ -395,7 +396,7 @@ bool Aquamarine::CDRMAtomicImpl::prepareConnector(Hyprutils::Memory::CSharedPoin
     }
 
     if ((STATE.committed & COutputState::AQ_OUTPUT_STATE_HDR) && data.hdrMetadata.has_value()) {
-        if (!connector->props.bits.hdr_output_metadata)
+        if (!connector->props.values.hdr_output_metadata)
             connector->backend->backend->log(AQ_LOG_ERROR, "atomic drm: failed to commit hdr metadata: no HDR_OUTPUT_METADATA prop support");
         else {
             if (!data.hdrMetadata->hdmi_metadata_type1.eotf) {
@@ -421,7 +422,7 @@ bool Aquamarine::CDRMAtomicImpl::prepareConnector(Hyprutils::Memory::CSharedPoin
         }
     }
 
-    if ((STATE.committed & COutputState::AQ_OUTPUT_STATE_DAMAGE) && connector->crtc->primary->props.bits.fb_damage_clips && MODE) {
+    if ((STATE.committed & COutputState::AQ_OUTPUT_STATE_DAMAGE) && connector->crtc->primary->props.values.fb_damage_clips && MODE) {
         if (STATE.damage.empty())
             data.atomic.fbDamage = 0;
         else {
@@ -469,12 +470,12 @@ bool Aquamarine::CDRMAtomicImpl::reset() {
     CDRMAtomicRequest request(backend);
 
     for (auto const& crtc : backend->crtcs) {
-        request.add(crtc->id, crtc->props.bits.mode_id, 0);
-        request.add(crtc->id, crtc->props.bits.active, 0);
+        request.add(crtc->id, crtc->props.values.mode_id, 0);
+        request.add(crtc->id, crtc->props.values.active, 0);
     }
 
     for (auto const& conn : backend->connectors) {
-        request.add(conn->id, conn->props.bits.crtc_id, 0);
+        request.add(conn->id, conn->props.values.crtc_id, 0);
     }
 
     for (auto const& plane : backend->planes) {

--- a/src/backend/drm/impl/Legacy.cpp
+++ b/src/backend/drm/impl/Legacy.cpp
@@ -40,7 +40,7 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
         connector->backend->backend->log(AQ_LOG_DEBUG, std::format("legacy drm: Modesetting CRTC {}", connector->crtc->id));
 
         uint32_t dpms = enable ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF;
-        if (drmModeConnectorSetProperty(connector->backend->gpu->fd, connector->id, connector->props.bits.dpms, dpms)) {
+        if (drmModeConnectorSetProperty(connector->backend->gpu->fd, connector->id, connector->props.values.dpms, dpms)) {
             connector->backend->backend->log(AQ_LOG_ERROR, "legacy drm: Failed to set dpms");
             return false;
         }
@@ -71,9 +71,9 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
             return false;
         }
 
-        if (connector->crtc->props.bits.vrr_enabled) {
+        if (connector->crtc->props.values.vrr_enabled) {
             if (auto ret =
-                    drmModeObjectSetProperty(backend->gpu->fd, connector->crtc->id, DRM_MODE_OBJECT_CRTC, connector->crtc->props.bits.vrr_enabled, (uint64_t)STATE.adaptiveSync);
+                    drmModeObjectSetProperty(backend->gpu->fd, connector->crtc->id, DRM_MODE_OBJECT_CRTC, connector->crtc->props.values.vrr_enabled, (uint64_t)STATE.adaptiveSync);
                 ret) {
                 connector->backend->backend->log(AQ_LOG_ERROR, std::format("legacy drm: drmModeObjectSetProperty: vrr -> {} failed: {}", STATE.adaptiveSync, strerror(-ret)));
                 return false;

--- a/src/backend/drm/impl/Legacy.cpp
+++ b/src/backend/drm/impl/Legacy.cpp
@@ -40,7 +40,7 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
         connector->backend->backend->log(AQ_LOG_DEBUG, std::format("legacy drm: Modesetting CRTC {}", connector->crtc->id));
 
         uint32_t dpms = enable ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF;
-        if (drmModeConnectorSetProperty(connector->backend->gpu->fd, connector->id, connector->props.dpms, dpms)) {
+        if (drmModeConnectorSetProperty(connector->backend->gpu->fd, connector->id, connector->props.bits.dpms, dpms)) {
             connector->backend->backend->log(AQ_LOG_ERROR, "legacy drm: Failed to set dpms");
             return false;
         }
@@ -71,8 +71,9 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
             return false;
         }
 
-        if (connector->crtc->props.vrr_enabled) {
-            if (auto ret = drmModeObjectSetProperty(backend->gpu->fd, connector->crtc->id, DRM_MODE_OBJECT_CRTC, connector->crtc->props.vrr_enabled, (uint64_t)STATE.adaptiveSync);
+        if (connector->crtc->props.bits.vrr_enabled) {
+            if (auto ret =
+                    drmModeObjectSetProperty(backend->gpu->fd, connector->crtc->id, DRM_MODE_OBJECT_CRTC, connector->crtc->props.bits.vrr_enabled, (uint64_t)STATE.adaptiveSync);
                 ret) {
                 connector->backend->backend->log(AQ_LOG_ERROR, std::format("legacy drm: drmModeObjectSetProperty: vrr -> {} failed: {}", STATE.adaptiveSync, strerror(-ret)));
                 return false;


### PR DESCRIPTION
dont use anonymous structs, iso c++ forbids it. compound literals is a c99 thing use designated c++20 initializing instead.

lets us catch issues ahead of time rather then later.