### PR TITLE
core: introduce drmRenderNodeFD()

### DIFF
--- a/include/aquamarine/backend/Backend.hpp
+++ b/include/aquamarine/backend/Backend.hpp
@@ -80,6 +80,7 @@ namespace Aquamarine {
         virtual bool                                                       start()                                    = 0;
         virtual std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>>    pollFDs()                                  = 0;
         virtual int                                                        drmFD()                                    = 0;
+        virtual int                                                        drmRenderNodeFD()                          = 0;
         virtual bool                                                       dispatchEvents()                           = 0;
         virtual uint32_t                                                   capabilities()                             = 0;
         virtual void                                                       onReady()                                  = 0;
@@ -112,6 +113,9 @@ namespace Aquamarine {
 
         /* Get the primary DRM FD */
         int drmFD();
+
+        /* Get the primary DRM RenderNode */
+        int drmRenderNodeFD();
 
         /* Get the render formats the primary backend supports */
         std::vector<SDRMFormat> getPrimaryRenderFormats();

--- a/include/aquamarine/backend/Backend.hpp
+++ b/include/aquamarine/backend/Backend.hpp
@@ -80,7 +80,6 @@ namespace Aquamarine {
         virtual bool                                                       start()                                    = 0;
         virtual std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>>    pollFDs()                                  = 0;
         virtual int                                                        drmFD()                                    = 0;
-        virtual int                                                        drmRenderNodeFD()                          = 0;
         virtual bool                                                       dispatchEvents()                           = 0;
         virtual uint32_t                                                   capabilities()                             = 0;
         virtual void                                                       onReady()                                  = 0;
@@ -89,8 +88,9 @@ namespace Aquamarine {
         virtual bool                                                       createOutput(const std::string& name = "") = 0; // "" means auto
         virtual Hyprutils::Memory::CSharedPointer<IAllocator>              preferredAllocator()                       = 0;
         virtual std::vector<SDRMFormat>                                    getRenderableFormats(); // empty = use getRenderFormats
-        virtual std::vector<Hyprutils::Memory::CSharedPointer<IAllocator>> getAllocators() = 0;
-        virtual Hyprutils::Memory::CWeakPointer<IBackendImplementation>    getPrimary()    = 0;
+        virtual std::vector<Hyprutils::Memory::CSharedPointer<IAllocator>> getAllocators()   = 0;
+        virtual Hyprutils::Memory::CWeakPointer<IBackendImplementation>    getPrimary()      = 0;
+        virtual int                                                        drmRenderNodeFD() = 0;
     };
 
     class CBackend {
@@ -113,9 +113,6 @@ namespace Aquamarine {
 
         /* Get the primary DRM FD */
         int drmFD();
-
-        /* Get the primary DRM RenderNode */
-        int drmRenderNodeFD();
 
         /* Get the render formats the primary backend supports */
         std::vector<SDRMFormat> getPrimaryRenderFormats();
@@ -151,6 +148,9 @@ namespace Aquamarine {
         Hyprutils::Memory::CSharedPointer<IAllocator> primaryAllocator;
         bool                                          ready = false;
         Hyprutils::Memory::CSharedPointer<CSession>   session;
+
+        /* Get the primary DRM RenderNode */
+        int drmRenderNodeFD();
 
       private:
         CBackend();

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -359,6 +359,7 @@ namespace Aquamarine {
         virtual bool                                                       start();
         virtual std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>>    pollFDs();
         virtual int                                                        drmFD();
+        virtual int                                                        drmRenderNodeFD();
         virtual bool                                                       dispatchEvents();
         virtual uint32_t                                                   capabilities();
         virtual bool                                                       setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot);

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -359,7 +359,6 @@ namespace Aquamarine {
         virtual bool                                                       start();
         virtual std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>>    pollFDs();
         virtual int                                                        drmFD();
-        virtual int                                                        drmRenderNodeFD();
         virtual bool                                                       dispatchEvents();
         virtual uint32_t                                                   capabilities();
         virtual bool                                                       setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot);
@@ -380,6 +379,7 @@ namespace Aquamarine {
 
         std::vector<FIdleCallback>                                         idleCallbacks;
         std::string                                                        gpuName;
+        virtual int                                                        drmRenderNodeFD();
 
       private:
         CDRMBackend(Hyprutils::Memory::CSharedPointer<CBackend> backend);

--- a/include/aquamarine/backend/Headless.hpp
+++ b/include/aquamarine/backend/Headless.hpp
@@ -40,7 +40,6 @@ namespace Aquamarine {
         virtual bool                                                       start();
         virtual std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>>    pollFDs();
         virtual int                                                        drmFD();
-        virtual int                                                        drmRenderNodeFD();
         virtual bool                                                       dispatchEvents();
         virtual uint32_t                                                   capabilities();
         virtual bool                                                       setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot);
@@ -53,6 +52,7 @@ namespace Aquamarine {
         virtual Hyprutils::Memory::CWeakPointer<IBackendImplementation>    getPrimary();
 
         Hyprutils::Memory::CWeakPointer<CHeadlessBackend>                  self;
+        virtual int                                                        drmRenderNodeFD();
 
       private:
         CHeadlessBackend(Hyprutils::Memory::CSharedPointer<CBackend> backend_);

--- a/include/aquamarine/backend/Headless.hpp
+++ b/include/aquamarine/backend/Headless.hpp
@@ -40,6 +40,7 @@ namespace Aquamarine {
         virtual bool                                                       start();
         virtual std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>>    pollFDs();
         virtual int                                                        drmFD();
+        virtual int                                                        drmRenderNodeFD();
         virtual bool                                                       dispatchEvents();
         virtual uint32_t                                                   capabilities();
         virtual bool                                                       setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot);

--- a/include/aquamarine/backend/Session.hpp
+++ b/include/aquamarine/backend/Session.hpp
@@ -29,9 +29,11 @@ namespace Aquamarine {
         static Hyprutils::Memory::CSharedPointer<CSessionDevice> openIfKMS(Hyprutils::Memory::CSharedPointer<CSession> session_, const std::string& path_);
 
         bool                                                     supportsKMS();
+        void                                                     resolveMatchingRenderNode(struct udev_device* cardDevice);
 
-        int                                                      fd       = -1;
-        int                                                      deviceID = -1;
+        int                                                      fd           = -1;
+        int                                                      renderNodeFd = -1;
+        int                                                      deviceID     = -1;
         dev_t                                                    dev;
         std::string                                              path;
 

--- a/include/aquamarine/backend/Session.hpp
+++ b/include/aquamarine/backend/Session.hpp
@@ -31,9 +31,8 @@ namespace Aquamarine {
         bool                                                     supportsKMS();
         void                                                     resolveMatchingRenderNode(udev_device* cardDevice);
 
-        int                                                      fd           = -1;
-        int                                                      renderNodeFd = -1;
-        int                                                      deviceID     = -1;
+        int                                                      fd       = -1;
+        int                                                      deviceID = -1;
         dev_t                                                    dev;
         std::string                                              path;
 
@@ -54,6 +53,8 @@ namespace Aquamarine {
             Hyprutils::Signal::CSignalT<SChangeEvent> change;
             Hyprutils::Signal::CSignalT<>             remove;
         } events;
+
+        int renderNodeFd = -1;
 
       private:
         Hyprutils::Memory::CWeakPointer<CSession> session;

--- a/include/aquamarine/backend/Session.hpp
+++ b/include/aquamarine/backend/Session.hpp
@@ -29,7 +29,7 @@ namespace Aquamarine {
         static Hyprutils::Memory::CSharedPointer<CSessionDevice> openIfKMS(Hyprutils::Memory::CSharedPointer<CSession> session_, const std::string& path_);
 
         bool                                                     supportsKMS();
-        void                                                     resolveMatchingRenderNode(struct udev_device* cardDevice);
+        void                                                     resolveMatchingRenderNode(udev_device* cardDevice);
 
         int                                                      fd           = -1;
         int                                                      renderNodeFd = -1;

--- a/include/aquamarine/backend/Wayland.hpp
+++ b/include/aquamarine/backend/Wayland.hpp
@@ -127,7 +127,6 @@ namespace Aquamarine {
         virtual bool                                                       start();
         virtual std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>>    pollFDs();
         virtual int                                                        drmFD();
-        virtual int                                                        drmRenderNodeFD();
         virtual bool                                                       dispatchEvents();
         virtual uint32_t                                                   capabilities();
         virtual bool                                                       setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot);
@@ -140,6 +139,7 @@ namespace Aquamarine {
         virtual Hyprutils::Memory::CWeakPointer<IBackendImplementation>    getPrimary();
 
         Hyprutils::Memory::CWeakPointer<CWaylandBackend>                   self;
+        virtual int                                                        drmRenderNodeFD();
 
       private:
         CWaylandBackend(Hyprutils::Memory::CSharedPointer<CBackend> backend);

--- a/include/aquamarine/backend/Wayland.hpp
+++ b/include/aquamarine/backend/Wayland.hpp
@@ -127,6 +127,7 @@ namespace Aquamarine {
         virtual bool                                                       start();
         virtual std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>>    pollFDs();
         virtual int                                                        drmFD();
+        virtual int                                                        drmRenderNodeFD();
         virtual bool                                                       dispatchEvents();
         virtual uint32_t                                                   capabilities();
         virtual bool                                                       setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot);

--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -210,6 +210,17 @@ int Aquamarine::CBackend::drmFD() {
     return -1;
 }
 
+int Aquamarine::CBackend::drmRenderNodeFD() {
+    for (auto const& i : implementations) {
+        int fd = i->drmRenderNodeFD();
+        if (fd < 0)
+            continue;
+
+        return fd;
+    }
+    return -1;
+}
+
 bool Aquamarine::CBackend::hasSession() {
     return session;
 }

--- a/src/backend/Headless.cpp
+++ b/src/backend/Headless.cpp
@@ -102,6 +102,10 @@ int Aquamarine::CHeadlessBackend::drmFD() {
     return -1;
 }
 
+int Aquamarine::CHeadlessBackend::drmRenderNodeFD() {
+    return -1;
+}
+
 bool Aquamarine::CHeadlessBackend::dispatchEvents() {
     return true;
 }

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -161,24 +161,24 @@ bool Aquamarine::CSessionDevice::supportsKMS() {
     return kms;
 }
 
-void Aquamarine::CSessionDevice::resolveMatchingRenderNode(struct udev_device* cardDevice) {
+void Aquamarine::CSessionDevice::resolveMatchingRenderNode(udev_device* cardDevice) {
     if (!cardDevice)
         return;
 
-    auto                   pciParent  = udev_device_get_parent_with_subsystem_devtype(cardDevice, "pci", nullptr);
-    const auto*            pciSyspath = pciParent ? udev_device_get_syspath(pciParent) : nullptr;
+    auto        pciParent  = udev_device_get_parent_with_subsystem_devtype(cardDevice, "pci", nullptr);
+    const auto* pciSyspath = pciParent ? udev_device_get_syspath(pciParent) : nullptr;
 
-    struct udev_enumerate* enumerate = udev_enumerate_new(session->udevHandle);
+    auto*       enumerate = udev_enumerate_new(session->udevHandle);
     if (!enumerate)
         return;
 
     udev_enumerate_add_match_subsystem(enumerate, "drm");
     udev_enumerate_scan_devices(enumerate);
 
-    struct udev_list_entry* devices = udev_enumerate_get_list_entry(enumerate);
-    struct udev_list_entry* entry   = nullptr;
+    auto*            devices = udev_enumerate_get_list_entry(enumerate);
+    udev_list_entry* entry   = nullptr;
 
-    bool                    matched = false;
+    bool             matched = false;
 
     udev_list_entry_foreach(entry, devices) {
         const auto* path = udev_list_entry_get_name(entry);

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -1,4 +1,5 @@
 #include <aquamarine/backend/Backend.hpp>
+#include <fcntl.h>
 
 extern "C" {
 #include <libseat.h>
@@ -141,6 +142,9 @@ Aquamarine::CSessionDevice::~CSessionDevice() {
             session->backend->log(AQ_LOG_ERROR, std::format("libseat: Couldn't close device at {}", path));
     if (fd >= 0)
         close(fd);
+
+    if (renderNodeFd)
+        close(renderNodeFd);
 }
 
 bool Aquamarine::CSessionDevice::supportsKMS() {
@@ -155,6 +159,57 @@ bool Aquamarine::CSessionDevice::supportsKMS() {
         session->backend->log(AQ_LOG_DEBUG, std::format("libseat: Device {} does not support kms", path));
 
     return kms;
+}
+
+void Aquamarine::CSessionDevice::resolveMatchingRenderNode(struct udev_device* cardDevice) {
+    if (!cardDevice)
+        return;
+
+    auto pciParent = udev_device_get_parent_with_subsystem_devtype(cardDevice, "pci", nullptr);
+    if (!pciParent)
+        return;
+
+    const char* pciSyspath = udev_device_get_syspath(pciParent);
+    if (!pciSyspath)
+        return;
+
+    struct udev_enumerate* enumerate = udev_enumerate_new(session->udevHandle);
+    if (!enumerate)
+        return;
+
+    udev_enumerate_add_match_subsystem(enumerate, "drm");
+    udev_enumerate_scan_devices(enumerate);
+
+    struct udev_list_entry* devices = udev_enumerate_get_list_entry(enumerate);
+    struct udev_list_entry* entry   = nullptr;
+
+    udev_list_entry_foreach(entry, devices) {
+        const char*         path = udev_list_entry_get_name(entry);
+        struct udev_device* dev  = udev_device_new_from_syspath(session->udevHandle, path);
+        if (!dev)
+            continue;
+
+        const char* devnode = udev_device_get_devnode(dev);
+        const char* devtype = udev_device_get_devtype(dev);
+
+        if (!devnode || !devtype || strcmp(devtype, "drm_minor") != 0 || !strstr(devnode, "renderD")) {
+            udev_device_unref(dev);
+            continue;
+        }
+
+        struct udev_device* devParent = udev_device_get_parent_with_subsystem_devtype(dev, "pci", nullptr);
+        if (devParent && strcmp(udev_device_get_syspath(devParent), pciSyspath) == 0) {
+            renderNodeFd = open(devnode, O_RDWR | O_CLOEXEC);
+            if (renderNodeFd < 0)
+                session->backend->log(AQ_LOG_WARNING, std::format("drm: Failed to open matching render node {}", devnode));
+            udev_device_unref(dev);
+            break;
+        }
+
+        udev_device_unref(dev);
+    }
+
+    udev_enumerate_unref(enumerate);
 }
 
 SP<CSessionDevice> Aquamarine::CSessionDevice::openIfKMS(SP<CSession> session_, const std::string& path_) {

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -139,6 +139,11 @@ int Aquamarine::CWaylandBackend::drmFD() {
     return drmState.fd;
 }
 
+int Aquamarine::CWaylandBackend::drmRenderNodeFD() {
+    // creation already attempts to use the rendernode, so just return same fd as drmFD().
+    return drmState.fd;
+}
+
 bool Aquamarine::CWaylandBackend::createOutput(const std::string& szName) {
     auto o  = outputs.emplace_back(SP<CWaylandOutput>(new CWaylandOutput(szName.empty() ? std::format("WAYLAND-{}", ++lastOutputID) : szName, self)));
     o->self = o;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -150,6 +150,8 @@ static std::vector<SP<CSessionDevice>> scanGPUs(SP<CBackend> backend) {
             continue;
         }
 
+        sessionDevice->resolveMatchingRenderNode(device);
+
         udev_device_unref(device);
 
         if (isBootVGA)
@@ -904,6 +906,10 @@ std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>> Aquamarine::CDRMBackend:
 
 int Aquamarine::CDRMBackend::drmFD() {
     return gpu->fd;
+}
+
+int Aquamarine::CDRMBackend::drmRenderNodeFD() {
+    return gpu->renderNodeFd;
 }
 
 static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, unsigned crtc_id, void* data) {


### PR DESCRIPTION
make a getter for drmRenderNodeFD() so we can create sync timelines on the rendernode on devices not supporting fences on the card* device directly.

add the rendernode matching the drm card if there is one. if none exist fallback to first found.