### PR TITLE
libinput: handle tablet axis on proximity, tip and button events

### DIFF
--- a/include/aquamarine/backend/Session.hpp
+++ b/include/aquamarine/backend/Session.hpp
@@ -237,6 +237,7 @@ namespace Aquamarine {
         void                                                    dispatchLibinputEvents();
         void                                                    dispatchLibseatEvents();
         void                                                    handleLibinputEvent(libinput_event* e);
+        void                                                    handleLibinputTabletToolAxis(libinput_event* e);
 
         friend class CSessionDevice;
         friend class CLibinputDevice;


### PR DESCRIPTION
The old way of handling tablet axis changes causes some changes to be missed.

For example, the pressure reaches 0 on tip up. So before this, when the pen gets out of contact, the pressure was always non-zero.
And while non-zero pressure is allowed by the tablet protocol, some apps can not work correctly. (I have seen it with some apps on Wine)

