### PR TITLE
allocator: Default to forcing linear blit for multigpu

### DIFF
--- a/src/allocator/GBM.cpp
+++ b/src/allocator/GBM.cpp
@@ -140,7 +140,7 @@ Aquamarine::CGBMBuffer::CGBMBuffer(const SAllocatorBufferParams& params, Hypruti
         return;
     }
 
-    static const auto forceLinearBlit = envEnabled("AQ_FORCE_LINEAR_BLIT");
+    static const auto forceLinearBlit = !envExplicitlyDisabled("AQ_FORCE_LINEAR_BLIT");
     auto const        oldMods         = explicitModifiers; // used in FORCE_LINEAR_BLIT case.
     if (MULTIGPU && !forceLinearBlit) {
         // Try to use the linear format if available for cross-GPU compatibility.

--- a/src/include/Shared.hpp
+++ b/src/include/Shared.hpp
@@ -6,6 +6,7 @@
 
 namespace Aquamarine {
     bool envEnabled(const std::string& env);
+    bool envExplicitlyDisabled(const std::string& env);
     bool isTrace();
 };
 

--- a/src/utils/Shared.cpp
+++ b/src/utils/Shared.cpp
@@ -6,6 +6,11 @@ bool Aquamarine::envEnabled(const std::string& env) {
     return e && e == std::string{"1"};
 }
 
+bool Aquamarine::envExplicitlyDisabled(const std::string& env) {
+    auto e = getenv(env.c_str());
+    return e && e == std::string{"0"};
+}
+
 static bool trace = []() -> bool { return Aquamarine::envEnabled("AQ_TRACE"); }();
 
 bool        Aquamarine::isTrace() {


### PR DESCRIPTION
Makes the behavior introduced in #174 default. I've confirmed that the fallback in case linear allocation fails means that this still works on NVIDIA<>NVIDIA. I left the env around in case it needs disabled, but since the new behavior seems to work on both NVIDIA<>NVIDIA and AMD<>AMD I think we should be good.

Fixes #196 by forcing linear allocation to avoid CPU blitting on AMD<>AMD.