### PR TITLE
Fix hdr modeset

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -8,6 +8,7 @@ Unless specified otherwise, a variable is enabled if and only if it's set to `1`
 `AQ_NO_ATOMIC` -> Disables drm atomic modesetting
 `AQ_MGPU_NO_EXPLICIT` -> Disables explicit syncing on mgpu buffers
 `AQ_NO_MODIFIERS` -> Disables modifiers for DRM buffers
+`AQ_FAST_MODESET` -> Skips modeset if mode is unchanged
 
 ### Debugging
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -897,6 +897,8 @@ void Aquamarine::CDRMBackend::scanLeases() {
 }
 
 bool Aquamarine::CDRMBackend::start() {
+    if (!envEnabled("AQ_FAST_MODESET"))
+        impl->reset();
     return true;
 }
 

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -187,11 +187,13 @@ void Aquamarine::CDRMAtomicRequest::addConnectorModeset(Hyprutils::Memory::CShar
         return;
     }
 
-    drmModeModeInfo* currentMode = connector->getCurrentMode();
-    bool             modeDiffers = true;
-    if (currentMode) {
-        modeDiffers = memcmp(currentMode, &data.modeInfo, sizeof(drmModeModeInfo)) != 0;
-        free(currentMode);
+    bool modeDiffers = true;
+    if (envEnabled("AQ_FAST_MODESET")) {
+        drmModeModeInfo* currentMode = connector->getCurrentMode();
+        if (currentMode) {
+            modeDiffers = memcmp(currentMode, &data.modeInfo, sizeof(drmModeModeInfo)) != 0;
+            free(currentMode);
+        }
     }
 
     if (modeDiffers) {


### PR DESCRIPTION
#184 broke hdr by introducing an extra condition. #188 fixed that by moving hdr stuff outside of `addConnectorModeset`. This skips `data.modeset` check for hdr properties. Probably causes black screen on some systems and increased cpu usage on others.

Restored the old hdr modeset behavior while keeping faster modeset from #184. HDR should work as expected, faster modeset and black screen issue need more testing.
