### PR TITLE
renderer: ensure makecurrent isnt called twice

### DIFF
--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -637,21 +637,26 @@ SP<CDRMRenderer> CDRMRenderer::attempt(SP<CBackend> backend_, Hyprutils::Memory:
 CEglContextGuard::CEglContextGuard(const CDRMRenderer& renderer_) : renderer(renderer_) {
     savedEGLState.display = eglGetCurrentDisplay();
     savedEGLState.context = eglGetCurrentContext();
-    savedEGLState.draw    = eglGetCurrentSurface(EGL_DRAW);
-    savedEGLState.read    = eglGetCurrentSurface(EGL_READ);
 
-    if (!eglMakeCurrent(renderer.egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, renderer.egl.context))
-        renderer.backend->log(AQ_LOG_WARNING, "CDRMRenderer: setEGL eglMakeCurrent failed");
+    const bool alreadyCurrent = savedEGLState.display == renderer.egl.display && savedEGLState.context == renderer.egl.context;
+
+    if (!alreadyCurrent) {
+        if (!eglMakeCurrent(renderer.egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, renderer.egl.context))
+            renderer.backend->log(AQ_LOG_WARNING, "CDRMRenderer: setEGL eglMakeCurrent failed");
+        madeChange = true;
+    }
 }
 
 CEglContextGuard::~CEglContextGuard() {
+    if (!madeChange)
+        return; // Skip restore if we didn’t change anything
+
     EGLDisplay dpy = savedEGLState.display ? savedEGLState.display : renderer.egl.display;
 
-    // egl can't handle this
     if (dpy == EGL_NO_DISPLAY)
         return;
 
-    if (!eglMakeCurrent(dpy, savedEGLState.draw, savedEGLState.read, savedEGLState.context))
+    if (!eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, savedEGLState.context))
         renderer.backend->log(AQ_LOG_WARNING, "CDRMRenderer: restoreEGL eglMakeCurrent failed");
 }
 

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -77,8 +77,8 @@ namespace Aquamarine {
         struct {
             EGLDisplay display = nullptr;
             EGLContext context = nullptr;
-            EGLSurface draw = nullptr, read = nullptr;
         } savedEGLState;
+        bool madeChange = false;
     };
 
     class CDRMRenderer {


### PR DESCRIPTION
depending on the attachment and commitstate we might end up calling makecurrent twice on an already current context, and on destruction we also make it current yet again even tho it was current. drivers doesnt keep track of this and is very inefficient when calling this on itself all the time. add a bool and only call it when it has changed or require change.

also remove unusued EGLSurface draw, read.