### PR TITLE
drmdumb: reopen displaynode

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -249,7 +249,7 @@ SP<CDRMBackend> Aquamarine::CDRMBackend::fromGpu(std::string path, SP<CBackend> 
 
     drmBackend->grabFormats();
 
-    drmBackend->dumbAllocator = CDRMDumbAllocator::create(gpu->fd, backend);
+    drmBackend->dumbAllocator = CDRMDumbAllocator::create(drmBackend->backend->reopenDRMNode(gpu->fd), backend);
 
     // so that session can handle udev change/remove events for this gpu
     backend->session->sessionDevices.push_back(gpu);
@@ -333,7 +333,7 @@ std::vector<SP<CDRMBackend>> Aquamarine::CDRMBackend::attempt(SP<CBackend> backe
             newPrimary = drmBackend;
         }
 
-        drmBackend->dumbAllocator = CDRMDumbAllocator::create(gpu->fd, backend);
+        drmBackend->dumbAllocator = CDRMDumbAllocator::create(drmBackend->backend->reopenDRMNode(gpu->fd), backend);
 
         backends.emplace_back(drmBackend);
 


### PR DESCRIPTION
if the backends now gets a rendernode it wont call the authmagic on the displaynode making dumb buffer creation failing on certain drivers. so reopen it again in the creation of the CDRMDumbAllocator.


im not sure if this breaks it further, or actually solves it. i cant even reproduce it. the only place so far i noticed this happening is on the nix test suite on hyprland. https://github.com/hyprwm/Hyprland/actions/runs/17022533814/job/48253900013?pr=11087#step:5:5414


ive tested intel only, nvidia only, and intel + nvidia. so idk