### PR TITLE
render: revert #203 and half of #202

### DIFF
--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -141,9 +141,8 @@ bool Aquamarine::CBackend::start() {
 
     // TODO: obviously change this when (if) we add different allocators.
     for (auto const& b : implementations) {
-        auto const& f = b->drmRenderNodeFD() >= 0 ? b->drmRenderNodeFD() : b->drmFD();
-        if (f >= 0) {
-            auto fd = reopenDRMNode(f);
+        if (b->drmFD() >= 0) {
+            auto fd = reopenDRMNode(b->drmFD());
             if (fd < 0) {
                 // this is critical, we cannot create an allocator properly
                 log(AQ_LOG_CRITICAL, "Failed to create an allocator (reopenDRMNode failed)");


### PR DESCRIPTION
either there is a fd going wrong here or certain drivers just plain fails with this. revert for now. but leave the cdrmrenderer using rendernode. 

cant reproduce it locally but CI running llvmpipe and virtualmachine fails on hyprland.