### PR TITLE
rendernode: dont bother finding one on evdi

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -150,7 +150,12 @@ static std::vector<SP<CSessionDevice>> scanGPUs(SP<CBackend> backend) {
             continue;
         }
 
-        sessionDevice->resolveMatchingRenderNode(device);
+        auto drmVer     = drmGetVersion(sessionDevice->fd);
+        auto drmVerName = drmVer->name ? drmVer->name : "unknown";
+        if (std::string_view(drmVerName) != "evdi")
+            sessionDevice->resolveMatchingRenderNode(device);
+
+        drmFreeVersion(drmVer);
 
         udev_device_unref(device);
 


### PR DESCRIPTION
evdi/displaylink devices doesnt give us a rendernode at all, and asahi was hard to associate if a rendernode was related to the displaynode/card so we fallback to just first found if that occurs. might be more appropiate to figure out a proper way to deal with these cases then workaround ever single driver that doesnt give rendernodes but so far seems only to be evdi.

problem that occured is a 3 gpu situation, the evdi card ended up using a rendernode for a complete different gpu because it fallbacked to that.

fixes: #210 