### PR TITLE
Ensure disconnect called for removed connectors

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -847,12 +847,12 @@ void Aquamarine::CDRMBackend::scanConnectors() {
     }
 
     // cleanup hot unplugged connectors
-    std::erase_if(connectors, [resources](const auto& conn) {
+    std::erase_if(connectors, [resources](auto& conn) {
         for (int i = 0; i < resources->count_connectors; ++i) {
             if (resources->connectors[i] == conn->id)
                 return false;
         }
-
+        conn->disconnect();
         return true;
     });
 


### PR DESCRIPTION
Originally disconnected monitors were not removed from hyprland correctly and duplications were created when an external monitor was reattached leading to invalid behavior when switching (empty desktop is visible).

Now removed monitors are explicitly disconnected during connectors scanning.