### PR TITLE
prevent use-after-free during DRM backend shutdown

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1499,7 +1499,7 @@ void Aquamarine::SDRMConnector::disconnect() {
         return;
     }
 
-    // Don't emit destroy here, the `IOutput` destructor will emit it
+    output->events.destroy.emit();
     output.reset();
 
     status = DRM_MODE_DISCONNECTED;
@@ -1565,10 +1565,8 @@ void Aquamarine::SDRMConnector::onPresent() {
 }
 
 Aquamarine::CDRMOutput::~CDRMOutput() {
-    auto backendLock = backend.lock();
-    if (backendLock && backendLock->backend) {
-        backendLock->backend->removeIdleEvent(frameIdle);
-    }
+    if (backend && backend->backend)
+        backend->backend->removeIdleEvent(frameIdle);
     connector->isPageFlipPending   = false;
     connector->frameEventScheduled = false;
 }


### PR DESCRIPTION
The DRM backend crashes during shutdown with heap corruption and null pointer dereferences. Two different stack traces below:

```
Stack trace of thread 3160:
#0  0x00007f9287e9caac __pthread_kill_implementation (libc.so.6 + 0x9caac)
#1  0x00007f9287e4190e raise (libc.so.6 + 0x4190e)
#2  0x00007f9287e28942 abort (libc.so.6 + 0x28942)
#3  0x00007f9287e299c3 __libc_message_impl.cold (libc.so.6 + 0x299c3)
#4  0x00007f9287ea7565 malloc_printerr (libc.so.6 + 0xa7565)
#5  0x00007f9287ea817c malloc_consolidate (libc.so.6 + 0xa817c)
#6  0x00007f9287ea9460 _int_free_maybe_consolidate.part.0 (libc.so.6 + 0xa9460)
#7  0x00007f9287ea9b12 _int_free (libc.so.6 + 0xa9b12)
#8  0x00007f9287eac3ee free (libc.so.6 + 0xac3ee)
#9  0x00007f9288e5d51a _ZN9Hyprutils6Memory14CSharedPointerIN10Aquamarine12COutputStateEE7_deleteEPv (libaquamarine.so.8 + 0x9051a)
#10 0x00007f9288eb977d _ZN10Aquamarine7IOutputD1Ev (libaquamarine.so.8 + 0xec77d)
#11 0x00007f9288e97ac9 _ZN9Hyprutils6Memory14CSharedPointerIN10Aquamarine10CDRMOutputEE7_deleteEPv (libaquamarine.so.8 + 0xcaac9)
#12 0x00007f9288e8ba7a _ZN10Aquamarine13SDRMConnector10disconnectEv (libaquamarine.so.8 + 0xbea7a)
#13 0x00007f9288e8bb4d _ZN10Aquamarine11CDRMBackendD2Ev (libaquamarine.so.8 + 0xbeb4d)
```

```
Stack trace of thread 39495:
#0  0x0000000000000000 n/a (n/a + 0x0)
#1  0x00007ff11332552e _ZN9Hyprutils6Memory5Impl_4implIN10Aquamarine10CDRMOutputEE7destroyEv (libaquamarine.so.8 + 0xf052e)
#2  0x00007ff1133173c9 _ZN10Aquamarine13SDRMConnector10disconnectEv (libaquamarine.so.8 + 0xe23c9)
#3  0x00007ff113317460 _ZN10Aquamarine11CDRMBackendD2Ev (libaquamarine.so.8 + 0xe2460)
```

Two separate but related issues in the destruction chain:
1. Double-emission of destroy event, first in `SDRMConnector::disconnect()` and after in `IOutput::~IOutput()`
2. Unchecked weak pointer dereference in `CDRMOutput::~CDRMOutput()`. During shutdown, the backend may already be destroyed.