### PR TITLE
backend: add freeDrmDevice on error in initDmabuf

### DIFF
--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -374,6 +374,7 @@ bool Aquamarine::CWaylandBackend::initDmabuf() {
 
         if (!name) {
             backend->log(AQ_LOG_ERROR, "zwp_linux_dmabuf_v1: no node name");
+            drmFreeDevice(&drmDev);
             return;
         }
 


### PR DESCRIPTION
I was just perusing the code for nefarious reasons and found this, which may cause a small memory leak in some rare cases.