### PR TITLE
drm: convert vd path before compare with explicit device path

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -200,7 +200,14 @@ static std::vector<SP<CSessionDevice>> scanGPUs(SP<CBackend> backend) {
         for (auto const& d : explicitDevices) {
             bool found = false;
             for (auto const& vd : devices) {
-                if (vd->path == d) {
+                std::error_code ec;
+                auto            canonicalFilePath = std::filesystem::canonical(vd->path, ec);
+                if (ec) {
+                    backend->log(AQ_LOG_ERROR, std::format("drm: Failed to canonicalize path {}", d));
+                    canonicalFilePath = vd->path;
+                }
+                
+                if (canonicalFilePath == d) {
                     vecDevices.emplace_back(vd);
                     found = true;
                     break;


### PR DESCRIPTION
FreeBSD always returning symbolic links '/dev/dri/card*' pointed to '/dev/drm/*', so output device will never be found if `AQ_DRM_DEVICES` is set as explicit devices path is converted to canonical file path.