### PR TITLE
Remove Unnecessary Modeset After Restoring from VT

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -383,9 +383,6 @@ void Aquamarine::CDRMBackend::restoreAfterVT() {
 
     backend->log(AQ_LOG_DEBUG, "drm: Rescanned connectors");
 
-    if (!impl->reset())
-        backend->log(AQ_LOG_ERROR, "drm: failed reset");
-
     std::vector<SP<SDRMConnector>> noMode;
 
     for (auto const& c : connectors) {


### PR DESCRIPTION
This PR removes a forced monitor mode reset after restoring from a VT switch.

I've tested DPMS and different monitor modes with this change, and everything seems to be working exactly as expected.

This PR has a sister in Hyprland [here](https://github.com/hyprwm/Hyprland/pull/12645)