### PR TITLE
libinput: fix pad groups not being ref'd

### DIFF
--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -1140,6 +1140,7 @@ const std::string& Aquamarine::CLibinputTabletPad::getName() {
 
 SP<ITabletPad::STabletPadGroup> Aquamarine::CLibinputTabletPad::createGroupFromID(int id) {
     auto libinputGroup = libinput_device_tablet_pad_get_mode_group(device->device, id);
+    libinput_tablet_pad_mode_group_ref(libinputGroup);
 
     auto group = makeShared<STabletPadGroup>();
     for (size_t i = 0; i < rings; ++i) {


### PR DESCRIPTION
Without refing pad groups they would get destroyed when the current event gets out of scope, causing a segfault when destroying a CLibinputTabletPad.

I can't test myself but it seems it fixes the issue.
Fixes #207