### PR TITLE
renderer: set EGL_CONTEXT_RELEASE_BEHAVIOR_KHR if supported

### DIFF
--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -453,6 +453,7 @@ void CDRMRenderer::initContext() {
     exts.EXT_create_context_robustness      = EGLEXTENSIONS.contains("EXT_create_context_robustness");
     exts.EXT_image_dma_buf_import           = EGLEXTENSIONS.contains("EXT_image_dma_buf_import");
     exts.EXT_image_dma_buf_import_modifiers = EGLEXTENSIONS.contains("EXT_image_dma_buf_import_modifiers");
+    exts.KHR_context_flush_control          = EGLEXTENSIONS.contains("EGL_KHR_context_flush_control");
 
     std::vector<EGLint> attrs;
 
@@ -466,6 +467,12 @@ void CDRMRenderer::initContext() {
         backend->log(AQ_LOG_DEBUG, "CDRMRenderer: EXT_create_context_robustness supported, requesting lose on reset");
         attrs.push_back(EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT);
         attrs.push_back(EGL_LOSE_CONTEXT_ON_RESET_EXT);
+    }
+
+    if (exts.KHR_context_flush_control) {
+        backend->log(AQ_LOG_DEBUG, "CDRMRenderer: Using KHR_context_flush_control");
+        attrs.push_back(EGL_CONTEXT_RELEASE_BEHAVIOR_KHR);
+        attrs.push_back(EGL_CONTEXT_RELEASE_BEHAVIOR_NONE_KHR); // or _FLUSH_KHR
     }
 
     attrs.push_back(EGL_CONTEXT_OPENGL_DEBUG);

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -137,6 +137,7 @@ namespace Aquamarine {
             bool KHR_platform_gbm                   = false;
             bool EXT_image_dma_buf_import           = false;
             bool EXT_image_dma_buf_import_modifiers = false;
+            bool KHR_context_flush_control          = false;
             bool KHR_display_reference              = false;
             bool IMG_context_priority               = false;
             bool EXT_create_context_robustness      = false;


### PR DESCRIPTION
EGL_CONTEXT_RELEASE_BEHAVIOR_KHR determines what happends with implicit flushes when context changes, on multigpu scenario we change context frequently when blitting content. while we still rely on explicit sync fences, the flush is destroying driver optimisations.

setting it to EGL_CONTEXT_RELEASE_BEHAVIOR_NONE_KHR essentially mean just swap context and continue processing on the next context.

might require some various dual gpu testing so this implicit flush wasnt something we relied on, here it upped the blitting performance by 6 times, glmark went from 900 to 6200 score. the cpu usage went from ~90% to mere ~10% when blitting.