### PR TITLE
atomic: use sequence_handler and drmEventcontext version 4

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -298,6 +298,7 @@ namespace Aquamarine {
         Hyprutils::Memory::CSharedPointer<CDRMFB>      pendingCursorFB;
 
         bool                                           isPageFlipPending = false;
+        bool                                           isFrameRunning    = false;
         SDRMPageFlip                                   pendingPageFlip;
         bool                                           frameEventScheduled = false;
 

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -233,6 +233,8 @@ namespace Aquamarine {
     };
 
     struct SDRMPageFlip {
+        uint64_t                                       queuedSequence = 0;
+        std::optional<std::pair<uint64_t, timespec>>   presentTime    = std::nullopt;
         Hyprutils::Memory::CWeakPointer<SDRMConnector> connector;
     };
 

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -258,6 +258,18 @@ bool Aquamarine::CDRMAtomicRequest::commit(uint32_t flagssss) {
         return false;
     }
 
+    if (conn && flagssss & DRM_MODE_PAGE_FLIP_EVENT) {
+        uint64_t prevSeq, prevNs;
+        if (drmCrtcGetSequence(backend->gpu->fd, conn->crtc->id, &prevSeq, &prevNs) == 0) {
+            if (drmCrtcQueueSequence(backend->gpu->fd, conn->crtc->id, DRM_CRTC_SEQUENCE_NEXT_ON_MISS, prevSeq + 1, &conn->pendingPageFlip.queuedSequence,
+                                     rc<uint64_t>(&conn->pendingPageFlip)) != 0) {
+                backend->log(AQ_LOG_TRACE, "atomic drm request: failed to queue crtc sequence");
+                conn->pendingPageFlip.queuedSequence = 0; // fallback to page_flip_handler2
+            }
+        } else
+            backend->log(AQ_LOG_TRACE, "atomic drm request: failed to get crtc sequence");
+    }
+
     if (auto ret = drmModeAtomicCommit(backend->gpu->fd, req, flagssss, conn ? &conn->pendingPageFlip : nullptr); ret) {
         backend->log((flagssss & DRM_MODE_ATOMIC_TEST_ONLY) ? AQ_LOG_DEBUG : AQ_LOG_ERROR,
                      std::format("atomic drm request: failed to commit: {}, flags: {}", strerror(ret == -1 ? errno : -ret), flagsToStr(flagssss)));


### PR DESCRIPTION
use CRTC Sequence handler if we can, poll the current sequence drmCrtcGetSequence and if it succeeds, try queue the next one if we can or fallback to the old pageflip handler.

by using crtc sequences we are allowed a much higher resolution timestamp and get much more correct timestamps for our presentation events that is not rounded away.

will reduce jitters and drifting in timestamps and get us lower latencies.