### PR TITLE
drm: ignore redundant tiled display connectors

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -267,6 +267,14 @@ namespace Aquamarine {
     struct SDRMConnector {
         ~SDRMConnector();
 
+        struct STileInfo {
+            uint32_t groupId         = 0;
+            bool     isSingleMonitor = false;
+            int      numHTile = 0, numVTile = 0;
+            int      tileHLoc = 0, tileVLoc = 0;
+            int      tileHSize = 0, tileVSize = 0;
+        };
+
         bool                                           init(drmModeConnector* connector);
         void                                           connect(drmModeConnector* connector);
         void                                           disconnect();
@@ -278,6 +286,7 @@ namespace Aquamarine {
         void                                           rollbackCommit(const SDRMConnectorCommitData& data);
         void                                           onPresent();
         void                                           recheckCRTCProps();
+        void                                           parseTileInfo();
 
         Hyprutils::Memory::CSharedPointer<CDRMOutput>  output;
         Hyprutils::Memory::CWeakPointer<CDRMBackend>   backend;
@@ -291,6 +300,10 @@ namespace Aquamarine {
         uint32_t                                       possibleCrtcs = 0;
         std::string                                    make, serial, model;
         bool                                           canDoVrr = false;
+
+        STileInfo                                      tileInfo;
+        bool                                           tilingRedundant = false;
+        Hyprutils::Math::Vector2D                      maxMode;
 
         bool                                           cursorEnabled = false;
         Hyprutils::Math::Vector2D                      cursorPos, cursorSize, cursorHotspot;
@@ -323,12 +336,13 @@ namespace Aquamarine {
                 uint32_t max_bpc;             // not guaranteed to exist
                 uint32_t Colorspace;          // not guaranteed to exist
                 uint32_t hdr_output_metadata; // not guaranteed to exist
+                uint32_t tile;                // not guaranteed to exist
 
                 // atomic-modesetting only
 
                 uint32_t crtc_id;
             } values;
-            uint32_t props[13] = {0};
+            uint32_t props[14] = {0};
         };
         UDRMConnectorProps props;
 
@@ -400,6 +414,7 @@ namespace Aquamarine {
         void restoreAfterVT();
         void recheckOutputs();
         void recheckCRTCs();
+        void markRedundantTiles();
         void buildGlFormats(const std::vector<SGLFormat>& fmts);
 
         Hyprutils::Memory::CSharedPointer<CSessionDevice>     gpu;

--- a/src/backend/drm/Props.cpp
+++ b/src/backend/drm/Props.cpp
@@ -26,6 +26,7 @@ static const struct prop_info connector_info[] = {
     {.name = "EDID", .index = INDEX(edid)},
     {.name = "HDR_OUTPUT_METADATA", .index = INDEX(hdr_output_metadata)},
     {.name = "PATH", .index = INDEX(path)},
+    {.name = "TILE", .index = INDEX(tile)},
     {.name = "content type", .index = INDEX(content_type)},
     {.name = "link-status", .index = INDEX(link_status)},
     {.name = "max bpc", .index = INDEX(max_bpc)},


### PR DESCRIPTION
Some high-resolution displays (e.g. Apple Studio Display 5K) expose multiple connectors in a tile group, even though the driver is handling the tiling internally. In this case, there will be one "real" connector that supports the full resolution of the monitor, along with a "dead" connector that refers to the other tile. In this configuration, the real connector is the only one that can actually be used; the dead connector has no output. But exposing it as a valid connector means that compositors will think there is another display connected that doesn't actually exist, leading to problems like ghost workspaces that you can't see.

So to avoid these ghost outputs from those dead connectors, we can filter out any tiles where there is another connector in that group that offers the full resolution all by itself, which signals that the tiling is being handled by the driver.