### PR TITLE
drm: keep secondary renderers alive only when they're needed

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -202,6 +202,7 @@ namespace Aquamarine {
         virtual size_t                                                    getGammaSize();
         virtual size_t                                                    getDeGammaSize();
         virtual std::vector<SDRMFormat>                                   getRenderFormats();
+        void                                                              releaseMgpuResources();
 
         int                                                               getConnectorID();
 
@@ -287,6 +288,7 @@ namespace Aquamarine {
         void                                           onPresent();
         void                                           recheckCRTCProps();
         void                                           parseTileInfo();
+        void                                           releaseFBReferences();
 
         Hyprutils::Memory::CSharedPointer<CDRMOutput>  output;
         Hyprutils::Memory::CWeakPointer<CDRMBackend>   backend;
@@ -407,6 +409,7 @@ namespace Aquamarine {
         bool checkFeatures();
         bool initResources();
         bool initMgpu();
+        bool updateSecondaryRendererState();
         bool grabFormats();
         bool shouldBlit();
         void scanConnectors();


### PR DESCRIPTION
Currently aquamarine initializes all the secondary renderers and keeps them alive all the time, even when no output on that GPU is enabled. Keeping a secondary renderer alive prevents unused GPU from powering down completely, which e.g. makes battery life significantly worse on Optimus laptops with DP/HDMI ports wired to dGPU.

This patch initializes secondary renderers only when at least one connected output is enabled, and deinitializes them when no enabled outputs remain.