### PR TITLE
drm: CRTC starvation recovery + clear stale page-flip state after suspend

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -312,7 +312,8 @@ namespace Aquamarine {
         Hyprutils::Math::Vector2D                      cursorPos, cursorSize, cursorHotspot;
         Hyprutils::Memory::CSharedPointer<CDRMFB>      pendingCursorFB;
 
-        bool                                           isPageFlipPending = false;
+        bool                                           isPageFlipPending   = false;
+        uint64_t                                       pageFlipPendingAtMs = 0; // CLOCK_BOOTTIME ms when isPageFlipPending was set
         SDRMPageFlip                                   pendingPageFlip;
         bool                                           frameEventScheduled = false;
         bool                                           isFrameRunning      = false;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -710,6 +710,12 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
             continue;
         }
 
+        // disabled outputs release their CRTCs so active outputs get priority
+        if (c->crtc && c->status == DRM_MODE_CONNECTED && c->output && !c->output->enabledState) {
+            backend->log(AQ_LOG_DEBUG, std::format("drm: {} is disabled, releasing crtc {}", c->szName, c->crtc->id));
+            c->crtc.reset();
+        }
+
         if (c->crtc && c->status == DRM_MODE_CONNECTED) {
             backend->log(AQ_LOG_DEBUG, std::format("drm: Skipping connector {}, has crtc {} and is connected", c->szName, c->crtc->id));
             continue;
@@ -739,12 +745,16 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
 
         bool assigned = false;
 
-        // try to use a connected connector
+        // try to use a connected, enabled connector
         for (auto const& c : recheck) {
             if (!(c->possibleCrtcs & (1 << i)))
                 continue;
 
             if (c->status != DRM_MODE_CONNECTED)
+                continue;
+
+            // Pass 1 only assigns to enabled connectors
+            if (c->output && !c->output->enabledState)
                 continue;
 
             // deactivate old output
@@ -766,11 +776,38 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
             backend->log(AQ_LOG_DEBUG, std::format("drm: slot {} crtc {} unassigned", i, crtc->id));
     }
 
+    // Pass 2: assign remaining CRTCs to disabled connectors as backup slots
+    for (size_t i = 0; i < crtcs.size(); ++i) {
+        bool taken = false;
+        for (auto const& c : connectors) {
+            if (c->crtc == crtcs.at(i)) {
+                taken = true;
+                break;
+            }
+        }
+        if (taken)
+            continue;
+
+        for (auto const& c : recheck) {
+            if (!(c->possibleCrtcs & (1 << i)))
+                continue;
+            if (c->status != DRM_MODE_CONNECTED)
+                continue;
+
+            backend->log(AQ_LOG_DEBUG, std::format("drm: backup slot {} crtc {} assigned to disabled {}", i, crtcs.at(i)->id, c->szName));
+            c->crtc = crtcs.at(i);
+            std::erase(recheck, c);
+            break;
+        }
+    }
+
     for (auto const& c : connectors) {
         if (c->status == DRM_MODE_CONNECTED)
             continue;
 
-        backend->log(AQ_LOG_DEBUG, std::format("drm: Connector {} is not connected{}", c->szName, c->crtc ? std::format(", removing old crtc {}", c->crtc->id) : ""));
+        if (c->crtc)
+            backend->log(AQ_LOG_DEBUG, std::format("drm: {} is not connected, clearing stale crtc {}", c->szName, c->crtc->id));
+        c->crtc.reset();
     }
 
     // tell the user to re-assign a valid mode etc, if needed
@@ -896,6 +933,11 @@ void Aquamarine::CDRMBackend::recheckOutputs() {
     // now that crtcs are assigned, connect outputs
     for (const auto& conn : connectors) {
         if (conn->status == DRM_MODE_CONNECTED && !conn->output && !conn->tilingRedundant) {
+            if (!conn->crtc) {
+                backend->log(AQ_LOG_DEBUG, std::format("drm: {} has no CRTC, deferring connection", conn->szName));
+                continue;
+            }
+
             backend->log(AQ_LOG_DEBUG, std::format("drm: Connector {} connected", conn->szName));
 
             auto drmConn = drmModeGetConnector(gpu->fd, conn->id);
@@ -1740,13 +1782,27 @@ void Aquamarine::SDRMConnector::applyCommit(const SDRMConnectorCommitData& data)
     if (output->state->state().committed & COutputState::AQ_OUTPUT_STATE_MODE)
         refresh = calculateRefresh(data.modeInfo);
 
-    output->enabledState = output->state->state().enabled;
+    const bool wasEnabled = output->enabledState;
+    output->enabledState  = output->state->state().enabled;
 
     if (!output->enabledState)
         releaseFBReferences();
 
     if (!backend->updateSecondaryRendererState())
         backend->backend->log(AQ_LOG_ERROR, std::format("drm: Failed to update renderer state for {} on applyCommit", szName));
+
+    if (wasEnabled != output->enabledState) {
+        auto bk = backend.lock();
+        if (bk) {
+            bk->backend->log(AQ_LOG_DEBUG, std::format("drm: Connector {} enabledState changed {} -> {}", szName, wasEnabled, output->enabledState));
+            auto weak = bk->self;
+            bk->backend->addIdleEvent(makeShared<std::function<void(void)>>([weak] {
+                auto b = weak.lock();
+                if (b)
+                    b->recheckOutputs();
+            }));
+        }
+    }
 }
 
 void Aquamarine::SDRMConnector::rollbackCommit(const SDRMConnectorCommitData& data) {

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -378,6 +378,27 @@ bool Aquamarine::CDRMBackend::sessionActive() {
 void Aquamarine::CDRMBackend::restoreAfterVT() {
     backend->log(AQ_LOG_DEBUG, "drm: Restoring after VT switch");
 
+    // Clear stale page-flip bookkeeping for all connectors.
+    // During S3 suspend the display hardware powers off, so any pending
+    // page-flip completion events are lost. The handlePF() callback that
+    // normally clears these flags will never fire. Without this reset,
+    // commitState() rejects every frame with "Cannot commit when a
+    // page-flip is awaiting" and scheduleFrame() returns early, leaving
+    // outputs permanently black after resume.
+    //
+    // For VT switch this is also safe: pending events from the old session
+    // are still queued in the fd buffer and will fire handlePF() after
+    // restore, but isPageFlipPending is already false so the = false
+    // assignment is a harmless no-op.
+    for (auto const& c : connectors) {
+        if (c->isPageFlipPending || c->isFrameRunning) {
+            backend->log(AQ_LOG_DEBUG, std::format("drm: Clearing stale page-flip state for {}", c->szName));
+            c->isPageFlipPending   = false;
+            c->isFrameRunning      = false;
+            c->frameEventScheduled = false;
+        }
+    }
+
     recheckOutputs();
 
     backend->log(AQ_LOG_DEBUG, "drm: Rescanned connectors");
@@ -1954,8 +1975,30 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
         }
 
         if (STATE.enabled && (NEEDS_RECONFIG || (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER)) && connector->isPageFlipPending) {
-            backend->backend->log(AQ_LOG_ERROR, "drm: Cannot commit when a page-flip is awaiting");
-            return false;
+            // Check if the pending page-flip is stale (>500ms — well beyond
+            // any vblank interval, even at low refresh rates). Stale flips
+            // occur after S3/S4 suspend when page-flip completion events are
+            // lost because the display hardware was powered off.
+            struct timespec ts;
+            clock_gettime(CLOCK_BOOTTIME, &ts);
+            uint64_t nowMs     = ts.tv_sec * 1000ULL + ts.tv_nsec / 1000000ULL;
+            bool     staleFlip = (nowMs - connector->pageFlipPendingAtMs) > 500;
+
+            if (NEEDS_RECONFIG && staleFlip) {
+                // A blocking modeset uses DRM_MODE_ATOMIC_ALLOW_MODESET which
+                // fully resets the CRTC, implicitly cancelling any stale
+                // page-flip at the kernel level. Clear the stale userspace
+                // bookkeeping to match.
+                backend->backend->log(AQ_LOG_DEBUG,
+                                      std::format("drm: Clearing stale page-flip state for {} during modeset (pending for {}ms)", name,
+                                                  nowMs - connector->pageFlipPendingAtMs));
+                connector->isPageFlipPending   = false;
+                connector->isFrameRunning      = false;
+                connector->frameEventScheduled = false;
+            } else {
+                backend->backend->log(AQ_LOG_ERROR, "drm: Cannot commit when a page-flip is awaiting");
+                return false;
+            }
         }
 
         if (STATE.enabled && (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER))

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -462,8 +462,12 @@ bool Aquamarine::CDRMAtomicImpl::commit(Hyprutils::Memory::CSharedPointer<SDRMCo
 
     if (ok) {
         request.apply(data);
-        if (!data.test && data.mainFB && connector->output->state->state().enabled && (flags & DRM_MODE_PAGE_FLIP_EVENT))
+        if (!data.test && data.mainFB && connector->output->state->state().enabled && (flags & DRM_MODE_PAGE_FLIP_EVENT)) {
             connector->isPageFlipPending = true;
+            struct timespec ts;
+            clock_gettime(CLOCK_BOOTTIME, &ts);
+            connector->pageFlipPendingAtMs = ts.tv_sec * 1000ULL + ts.tv_nsec / 1000000ULL;
+        }
     } else
         request.rollback(data);
 

--- a/src/backend/drm/impl/Legacy.cpp
+++ b/src/backend/drm/impl/Legacy.cpp
@@ -138,6 +138,9 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
     }
 
     connector->isPageFlipPending = true;
+    struct timespec ts;
+    clock_gettime(CLOCK_BOOTTIME, &ts);
+    connector->pageFlipPendingAtMs = ts.tv_sec * 1000ULL + ts.tv_nsec / 1000000ULL;
 
     return true;
 }


### PR DESCRIPTION
## Setup

I run a laptop (Intel HD 630 iGPU, Quadro M620 dGPU unused) with 3 external monitors (HDMI-A-1, DP-3, DP-5) and the built-in lid display (eDP-1). The HD 630 has exactly 3 CRTCs but 4 connectors. Since I force `AQ_DRM_DEVICES=/dev/dri/intel-igpu` to avoid the dGPU, all 4 connectors compete for those 3 CRTCs.

A `lid-manager.sh` daemon disables eDP-1 when the lid is closed or when all 3 externals are connected (`hyprctl keyword monitor "eDP-1,disable"`).

---

## Commit 1: CRTC starvation recovery

### The bug

When I boot with lid closed and all 3 externals connected, everything works. But if I unplug one external and replug it (or open the lid while only 2 externals are connected), the formerly-starved connector never gets a CRTC. The output stays dark. Only fix: restart Hyprland entirely.

What happens: all 3 CRTCs get claimed at boot. When a connector disconnects, its CRTC should be freed, but the cleanup in `recheckCRTCs()` only *logged* "removing old crtc" without calling `crtc.reset()`, so the stale reference stayed. When the compositor disables an output, nothing triggers CRTC reassignment. `applyCommit()` updates `enabledState` but never tells the backend to re-evaluate which connectors should get which CRTCs.

This affects anyone with more connectors than CRTCs. Common on Intel iGPU laptops with docking stations. Related issues: aquamarine#36, #40, #59, Hyprland#7572, #7694.

### The fix

Three changes in `DRM.cpp`:

1. Two-pass CRTC assignment in `recheckCRTCs()`. Pass 1 releases CRTCs from disabled-but-connected outputs and assigns CRTCs to enabled connectors. Pass 2 gives remaining free CRTCs to disabled connectors as backup slots for quick re-enable. The disconnected-connector cleanup now actually calls `crtc.reset()`.

2. No-CRTC guard in `recheckOutputs()`. If a connector has no CRTC after `recheckCRTCs()`, `connect()` is skipped. It gets connected later when a CRTC frees up via the deferred recheck.

3. Deferred recheck on `enabledState` change in `applyCommit()`. When `enabledState` transitions, `addIdleEvent()` schedules `recheckOutputs()` on the next event loop iteration. Same mechanism already used for frame scheduling. Avoids reentrancy since `applyCommit` runs inside the DRM commit path.

### Safety

If all outputs have CRTCs (the common case), Pass 1 releases nothing, Pass 2 has no leftovers, and the idle-event never fires. Tiled display connectors (`tilingRedundant`) are skipped at the top of `recheckCRTCs()`. Multi-GPU setups run each backend independently. The idle event uses a weak pointer so it's safe if the backend is destroyed between scheduling and firing.

---

## Commit 2: Clear stale page-flip state after suspend/resume

### The bug

After S3 suspend or suspend-then-hibernate, all monitors go permanently black. The only recovery is a hard restart. I ran into this on the same laptop after suspending overnight.

The page-flip lifecycle works like this: compositor submits a buffer, atomic commit sets `DRM_MODE_PAGE_FLIP_EVENT`, `isPageFlipPending` becomes true. Kernel completes the flip, delivers an event on the DRM fd, `handlePF()` fires and sets `isPageFlipPending = false`. Next frame gets scheduled.

During suspend, the display hardware powers off. Any in-flight page-flip completion event is lost because no vblank interrupt fires when the hardware is off. On resume, libseat fires `changeActive`, `restoreAfterVT()` runs, but `isPageFlipPending` is still true from before suspend. `handlePF()` never fires because there's no event to process. `scheduleFrame()` checks `isPageFlipPending`, sees true, returns early. No frames ever get scheduled. Display stays black.

VT switch doesn't hit this because the kernel preserves DRM state and queues pending page-flip events in the fd buffer. They get delivered when the session reactivates. During suspend the hardware is off, so there's nothing to deliver.

The regression trace: commit d83c97f (Dec 2025) removed `impl->reset()` from `restoreAfterVT()`. That reset used to deactivate all CRTCs at the kernel level, implicitly clearing stale page-flip state. It was removed for valid reasons (caused flicker during VT switch), but left no replacement for the suspend path. Commit 603f5cd (Feb 2026) added `isFrameRunning` as a third guard in `scheduleFrame()`, making the stale-state problem worse.

wlroots had the same bug class: issues #2290, #2325, #2373, #2395, fixed in commit 324eeaa0cd ("disable all CRTCs after VT switch").

Related: Hyprland#8312 ("freezes after suspension"), Hyprland#6289 ("black screen after resuming from suspend").

### The fix

Changes across `DRM.cpp`, `DRM.hpp`, `Atomic.cpp`, `Legacy.cpp`:

1. In `restoreAfterVT()`, clear `isPageFlipPending`, `isFrameRunning`, and `frameEventScheduled` for all connectors before `recheckOutputs()`. For VT switch this is a no-op since events still arrive and `handlePF()` would set them false anyway. For suspend it removes the blocker so frames can be scheduled again.

2. In `commitState()`, detect stale page-flips using a `CLOCK_BOOTTIME` timestamp recorded when `isPageFlipPending` is set. If a modeset commit finds a flip pending for >500ms (well past any vblank interval even at low refresh rates), treat it as stale and clear the flags. `CLOCK_BOOTTIME` is used instead of `CLOCK_MONOTONIC` because `CLOCK_MONOTONIC` does not advance during suspend on Linux, making elapsed time appear near-zero after resume.

3. Added `pageFlipPendingAtMs` field to `SDRMConnector`. Timestamp recorded in both atomic (`Atomic.cpp`) and legacy (`Legacy.cpp`) commit paths when `isPageFlipPending` is set true.

### Safety

**VT switch**: Pending page-flip events survive in the DRM fd buffer. After `restoreAfterVT()` returns, `dispatchEvents()` processes them. `handlePF()` fires and sees `isPageFlipPending = false` (already cleared). The `= false` is a no-op. `onPresent()` rotates buffer refs normally. No visible difference.

**S3/S4 resume**: No pending events in fd buffer. The flag clearing removes the blocker. The blocking modeset in `restoreAfterVT()` displays the restored frame. Next input or DPMS-on triggers `scheduleFrame()`, which succeeds, and frames render.

**Edge case — flip completes just before suspend**: `handlePF()` already fired before suspend. `isPageFlipPending` is already false. The clearing loop skips that connector. No change.

### Tested

On Intel HD 630 (3 CRTCs, 4 connectors) with:
- Short S3 suspend/resume: screens recover, log shows "Clearing stale page-flip state for HDMI-A-1 during modeset (pending for 503ms)"
- Long suspend-then-hibernate (>10h): screens recover on resume
- VT switch (Ctrl+Alt+F2 and back): no regression, screens restore cleanly
- Hotplug cycles after resume: CRTC starvation recovery still works
- Fresh boot: no false stale detection, flags are zero