### PR TITLE
session: Add AQ_NO_KMS_REQUIREMENT environment variable for bypassing KMS requirement

### DIFF
--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -245,7 +245,7 @@ void Aquamarine::CSessionDevice::resolveMatchingRenderNode(udev_device* cardDevi
 
 SP<CSessionDevice> Aquamarine::CSessionDevice::openIfKMS(SP<CSession> session_, const std::string& path_) {
     auto dev = makeShared<CSessionDevice>(session_, path_);
-    if (!dev->supportsKMS())
+    if (!getenv("AQ_NO_KMS") && !dev->supportsKMS())
         return nullptr;
     return dev;
 }

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -1,5 +1,6 @@
 #include <aquamarine/backend/Backend.hpp>
 #include <fcntl.h>
+#include "Shared.hpp"
 
 extern "C" {
 #include <libseat.h>
@@ -245,7 +246,7 @@ void Aquamarine::CSessionDevice::resolveMatchingRenderNode(udev_device* cardDevi
 
 SP<CSessionDevice> Aquamarine::CSessionDevice::openIfKMS(SP<CSession> session_, const std::string& path_) {
     auto dev = makeShared<CSessionDevice>(session_, path_);
-    if (!getenv("AQ_NO_KMS") && !dev->supportsKMS())
+    if (!envEnabled("AQ_NO_KMS") && !dev->supportsKMS())
         return nullptr;
     return dev;
 }

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -246,9 +246,9 @@ void Aquamarine::CSessionDevice::resolveMatchingRenderNode(udev_device* cardDevi
 
 SP<CSessionDevice> Aquamarine::CSessionDevice::openIfKMS(SP<CSession> session_, const std::string& path_) {
     auto dev = makeShared<CSessionDevice>(session_, path_);
-    if (!envEnabled("AQ_NO_KMS") && !dev->supportsKMS())
-        return nullptr;
-    return dev;
+    if (envEnabled("AQ_NO_KMS_REQUIREMENT") || dev->supportsKMS())
+        return dev;
+    return nullptr;
 }
 
 SP<CSession> Aquamarine::CSession::attempt(Hyprutils::Memory::CSharedPointer<CBackend> backend_) {


### PR DESCRIPTION
Aquamarine part of https://github.com/hyprwm/Hyprland/pull/13616. Consult it for more context.

This PR allow users to bypass the KMS requirement for a GPU with the `AQ_NO_KMS_REQUIREMENT` environment variable.