### PR TITLE
backend/drm: support semicolon delimiter for PCI paths in AQ_DRM_DEVICES

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -177,7 +177,18 @@ static std::vector<SP<CSessionDevice>> scanGPUs(SP<CBackend> backend) {
     auto                            explicitGpus = getenv("AQ_DRM_DEVICES");
     if (explicitGpus) {
         backend->log(AQ_LOG_DEBUG, std::format("drm: Explicit device list {}", explicitGpus));
-        Hyprutils::String::CVarList explicitDevices(explicitGpus, 0, ':', true);
+        std::string explicitGpusStr = explicitGpus;
+        char delimiter = ':';
+
+        std::error_code ec;
+        if (std::filesystem::exists(explicitGpusStr, ec)) {
+            delimiter = ';';
+        }
+
+        if (explicitGpusStr.find(';') != std::string::npos)
+            delimiter = ';';
+        
+        Hyprutils::String::CVarList explicitDevices(explicitGpus, 0, delimiter, true);
 
         // Iterate over GPUs and canonicalize the paths
         for (auto& d : explicitDevices) {
@@ -189,6 +200,10 @@ static std::vector<SP<CSessionDevice>> scanGPUs(SP<CBackend> backend) {
             // TODO: Verify that the path is a valid DRM device. (https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/backend/session/session.c?ref_type=heads#L369-387)
             if (ec) {
                 backend->log(AQ_LOG_ERROR, std::format("drm: Failed to canonicalize path {}", d));
+
+                if (delimiter == ':') {
+                     backend->log(AQ_LOG_ERROR, "drm: If you are using PCI paths with colons, use ';' as a separator instead of ':'.");
+                 }
                 continue;
             }
 


### PR DESCRIPTION
### Description
Fixes an issue where using complete PCI paths (e.g., `/dev/dri/by-path/pci-0000:03:00.0-card`) in `AQ_DRM_DEVICES` causes Aquamarine to crash. The default colon (`:`) delimiter conflicts with the colons inherent to standard Linux PCI addresses. 

This is especially critical for modern multi-GPU setups where isolating specific cards via exact PCI paths is required.

This PR makes the delimiter detection smarter and is 100% backward-compatible:
1. It first checks if the entire string corresponds to a valid existing file via `std::filesystem::exists` (handling single PCI paths safely without splitting them).
2. It falls back to checking for a semicolon (`;`) as an alternative list separator.
3. If neither is true, it defaults to the legacy colon (`:`) separator, ensuring existing configs (like `card0:card1`) do not break.
4. It adds a helpful `AQ_LOG_ERROR` message if canonicalization fails while using colons, advising the user to use semicolons instead.

### Tests done
Tested on Arch Linux with a dual-GPU setup (RX 9070 XT / Granite Ridge):
- [x] **Legacy config** (`/dev/dri/card0:/dev/dri/card1`) -> Parses correctly.
- [x] **Semicolon with PCI paths** (`/dev/dri/by-path/pci-0000:49:00.0-card;/dev/dri/by-path/pci-0000:03:00.0-card`) -> Parses correctly.
- [x] **Single PCI path without delimiter** (`/dev/dri/by-path/pci-0000:03:00.0-card`) -> Parses correctly without splitting.
- [x] **Erroneous colon usage** with PCI paths -> Fails safely with the new log message advising to use `;`.

Fixes #167