### PR TITLE
drm: use libdisplay-info high-level API di_info_get_hdr_static_metadata()

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1511,39 +1511,21 @@ IOutput::SParsedEDID Aquamarine::SDRMConnector::parseEDID(std::vector<uint8_t> d
                                                 parsed.chromaticityCoords->blue.y, parsed.chromaticityCoords->white.y, parsed.chromaticityCoords->white.y)));
     }
 
-    auto exts = di_edid_get_extensions(edid);
+    const auto* hdr_static_metadata = di_info_get_hdr_static_metadata(info);
+    if (hdr_static_metadata && (hdr_static_metadata->pq || hdr_static_metadata->hlg)) {
+        TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found HDR pq={} hlg={}", hdr_static_metadata->pq, hdr_static_metadata->hlg)));
+        parsed.hdrMetadata = IOutput::SHDRMetadata{
+            .desiredContentMaxLuminance      = hdr_static_metadata->desired_content_max_luminance,
+            .desiredMaxFrameAverageLuminance = hdr_static_metadata->desired_content_max_frame_avg_luminance,
+            .desiredContentMinLuminance      = hdr_static_metadata->desired_content_min_luminance,
+            .supportsPQ                      = hdr_static_metadata->pq,
+        };
+    }
 
-    for (; *exts != nullptr; exts++) {
-        auto tag = di_edid_ext_get_tag(*exts);
-        TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: checking ext {}", (uint32_t)tag)));
-        if (tag == DI_EDID_EXT_DISPLAYID)
-            backend->backend->log(AQ_LOG_WARNING, "FIXME: support displayid blocks");
-
-        const auto cta = di_edid_ext_get_cta(*exts);
-        if (cta) {
-            TRACE(backend->backend->log(AQ_LOG_TRACE, "EDID: found CTA"));
-            const di_cta_hdr_static_metadata_block* hdr_static_metadata = nullptr;
-            const di_cta_colorimetry_block*         colorimetry         = nullptr;
-            auto                                    blocks              = di_edid_cta_get_data_blocks(cta);
-            for (; *blocks != nullptr; blocks++) {
-                if (!hdr_static_metadata && (hdr_static_metadata = di_cta_data_block_get_hdr_static_metadata(*blocks))) {
-                    TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found HDR {}", hdr_static_metadata->eotfs->pq)));
-                    parsed.hdrMetadata = IOutput::SHDRMetadata{
-                        .desiredContentMaxLuminance      = hdr_static_metadata->desired_content_max_luminance,
-                        .desiredMaxFrameAverageLuminance = hdr_static_metadata->desired_content_max_frame_avg_luminance,
-                        .desiredContentMinLuminance      = hdr_static_metadata->desired_content_min_luminance,
-                        .supportsPQ                      = hdr_static_metadata->eotfs->pq,
-                    };
-                    continue;
-                }
-                if (!colorimetry && (colorimetry = di_cta_data_block_get_colorimetry(*blocks))) {
-                    TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found colorimetry {}", colorimetry->bt2020_rgb)));
-                    parsed.supportsBT2020 = colorimetry->bt2020_rgb;
-                    continue;
-                }
-            }
-            break;
-        }
+    const auto* ssc = di_info_get_supported_signal_colorimetry(info);
+    if (ssc) {
+        TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found colorimetry bt2020_rgb={}", ssc->bt2020_rgb)));
+        parsed.supportsBT2020 = ssc->bt2020_rgb;
     }
 
     di_info_destroy(info);

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1695,41 +1695,21 @@ IOutput::SParsedEDID Aquamarine::SDRMConnector::parseEDID(std::vector<uint8_t> d
                                                 parsed.chromaticityCoords->blue.y, parsed.chromaticityCoords->white.y, parsed.chromaticityCoords->white.y)));
     }
 
-    auto exts = di_edid_get_extensions(edid);
+    const auto* hdr_static_metadata = di_info_get_hdr_static_metadata(info);
+    if (hdr_static_metadata && (hdr_static_metadata->pq || hdr_static_metadata->hlg)) {
+        TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found HDR pq={} hlg={}", hdr_static_metadata->pq, hdr_static_metadata->hlg)));
+        parsed.hdrMetadata = IOutput::SHDRMetadata{
+            .desiredContentMaxLuminance      = hdr_static_metadata->desired_content_max_luminance,
+            .desiredMaxFrameAverageLuminance = hdr_static_metadata->desired_content_max_frame_avg_luminance,
+            .desiredContentMinLuminance      = hdr_static_metadata->desired_content_min_luminance,
+            .supportsPQ                      = hdr_static_metadata->pq,
+        };
+    }
 
-    // EDID can have more than one CTA extension. First hdr_static_metadata and colorimetry win
-    const di_cta_hdr_static_metadata_block* hdr_static_metadata = nullptr;
-    const di_cta_colorimetry_block*         colorimetry         = nullptr;
-
-    for (; *exts != nullptr; exts++) {
-        auto tag = di_edid_ext_get_tag(*exts);
-        TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: checking ext {}", (uint32_t)tag)));
-        if (tag == DI_EDID_EXT_DISPLAYID)
-            backend->backend->log(AQ_LOG_WARNING, "FIXME: support displayid blocks");
-
-        const auto cta = di_edid_ext_get_cta(*exts);
-        if (!cta)
-            continue;
-
-        TRACE(backend->backend->log(AQ_LOG_TRACE, "EDID: found CTA"));
-        auto blocks = di_edid_cta_get_data_blocks(cta);
-        for (; *blocks != nullptr; blocks++) {
-            if (!hdr_static_metadata && (hdr_static_metadata = di_cta_data_block_get_hdr_static_metadata(*blocks))) {
-                TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found HDR {}", hdr_static_metadata->eotfs->pq)));
-                parsed.hdrMetadata = IOutput::SHDRMetadata{
-                    .desiredContentMaxLuminance      = hdr_static_metadata->desired_content_max_luminance,
-                    .desiredMaxFrameAverageLuminance = hdr_static_metadata->desired_content_max_frame_avg_luminance,
-                    .desiredContentMinLuminance      = hdr_static_metadata->desired_content_min_luminance,
-                    .supportsPQ                      = hdr_static_metadata->eotfs->pq,
-                };
-                continue;
-            }
-            if (!colorimetry && (colorimetry = di_cta_data_block_get_colorimetry(*blocks))) {
-                TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found colorimetry {}", colorimetry->bt2020_rgb)));
-                parsed.supportsBT2020 = colorimetry->bt2020_rgb;
-                continue;
-            }
-        }
+    const auto* ssc = di_info_get_supported_signal_colorimetry(info);
+    if (ssc) {
+        TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found colorimetry bt2020_rgb={}", ssc->bt2020_rgb)));
+        parsed.supportsBT2020 = ssc->bt2020_rgb;
     }
 
     di_info_destroy(info);


### PR DESCRIPTION
drm: use libdisplay-info high-level API which handles both top-level CTA-861 extensions and CTA-861 data blocks nested inside DisplayID v2.0 extensions.

This is to replace the low-level `di_edid_ext_get_cta()` with higher-level  `di_info_get_hdr_static_metadata()`.

In [libdisplay-info](https://gitlab.freedesktop.org/emersion/libdisplay-info) and its [73ec53d8](https://gitlab.freedesktop.org/emersion/libdisplay-info/-/commit/73ec53d800275cce4b8a4af6af03ea2aac9912fd), new parser for the nested data blocks is implemented. 

which gives di_info_get_hdr_static_metadata() better compatability for CTA-861 data blocks nested inside DisplayID v2.0 extensions
```

// Public API — called by Aquamarine after our patch
di_info_get_hdr_static_metadata(info)
    → returns info->derived.hdr_static_metadata
    // This was populated at parse time by:

di_info_parse_edid(data, size)
    → derive_edid_hdr_static_metadata(edid, &info->derived.hdr_static_metadata)

// derive calls:
derive_edid_hdr_static_metadata(edid, hsm)
    → edid_get_cta_data_block(edid, DI_CTA_DATA_BLOCK_HDR_STATIC_METADATA)

// This is the function modified by 73ec53d:
edid_get_cta_data_block(edid, tag)
    for each extension:
        switch (extension tag):
            case DI_EDID_EXT_CEA:          // top-level CTA — existed before
                → find_cta_data_block(cta_blocks, tag)

            case DI_EDID_EXT_DISPLAYID:    // ← ADDED by 73ec53d
                → di_edid_ext_get_displayid2(ext)
                → displayid2_get_cta_data_block(displayid2, tag)
                    for each DisplayID v2.0 data block:
                        → di_displayid2_data_block_get_cta_data_blocks(block)  // from 7324cca
                        → find_cta_data_block(nested_cta_blocks, tag)
```
P.S. [73ec53d8](https://gitlab.freedesktop.org/emersion/libdisplay-info/-/commit/73ec53d800275cce4b8a4af6af03ea2aac9912fd) is currently NO available in the latest libdisplay-info 0.3.0. But I've built a new version with the [73ec53d8](https://gitlab.freedesktop.org/emersion/libdisplay-info/-/commit/73ec53d800275cce4b8a4af6af03ea2aac9912fd) and my laptop's HDR works with new libdisplay-info and drm fixed with di_info_get_hdr_static_metadata()

My panel:
```
Block 0: Base EDID
Block 1: tag 0x70 (DisplayID v2.0)
           └─ DisplayID data block tag 0x81 (CTA-861 wrapper)
               ├─ Colorimetry (BT2020)
               └─ HDR Static Metadata (PQ, 616 cd/m²)
```

