### PR TITLE
backend: handle unhandled libinput switch enum with default case

### DIFF
--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -688,7 +688,8 @@ void Aquamarine::CSession::handleLibinputEvent(libinput_event* e) {
             switch (libinput_event_switch_get_switch(se)) {
                 case LIBINPUT_SWITCH_LID: hlDevice->switchy->type = ISwitch::AQ_SWITCH_TYPE_LID; break;
                 case LIBINPUT_SWITCH_TABLET_MODE: hlDevice->switchy->type = ISwitch::AQ_SWITCH_TYPE_TABLET_MODE; break;
-            }
+                default: break;
+            }  
 
             hlDevice->switchy->events.fire.emit(ISwitch::SFireEvent{
                 .timeMs = (uint32_t)(libinput_event_switch_get_time_usec(se) / 1000),


### PR DESCRIPTION
The switch over libinput_event_switch_get_switch() does not handle all enum values,
which results in a compiler warning (-Wswitch).
Added a default case to ensure all enum values are handled without altering behavior.