### PR TITLE
drm: guard logging in connector disconnect to avoid null dereference

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1700,12 +1700,9 @@ void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
 
 void Aquamarine::SDRMConnector::disconnect() {
     if (!output) {
-        if (backend) {
-            auto b = backend->backend.lock();
-            if (b)
-                b->log(AQ_LOG_DEBUG,
-                    std::format("drm: Not disconnecting connector {} because it's already disconnected", szName));
-        }
+        if (backend && backend->backend)
+            backend->backend->log(AQ_LOG_DEBUG,
+                std::format("drm: Not disconnecting connector {} because it's already disconnected", szName));
         return;
     }
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1700,7 +1700,9 @@ void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
 
 void Aquamarine::SDRMConnector::disconnect() {
     if (!output) {
-        backend->backend->log(AQ_LOG_DEBUG, std::format("drm: Not disconnecting connector {} because it's already disconnected", szName));
+        if (auto* b = backend ? backend->backend : nullptr)
+            b->log(AQ_LOG_DEBUG,
+                std::format("drm: Not disconnecting connector {} because it's already disconnected", szName));
         return;
     }
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1700,9 +1700,12 @@ void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
 
 void Aquamarine::SDRMConnector::disconnect() {
     if (!output) {
-        if (auto* b = backend ? backend->backend : nullptr)
-            b->log(AQ_LOG_DEBUG,
-                std::format("drm: Not disconnecting connector {} because it's already disconnected", szName));
+        if (backend) {
+            auto b = backend->backend.lock();
+            if (b)
+                b->log(AQ_LOG_DEBUG,
+                    std::format("drm: Not disconnecting connector {} because it's already disconnected", szName));
+        }
         return;
     }
 


### PR DESCRIPTION
Related to #272

Adds a defensive check before logging in SDRMConnector::disconnect()
to avoid a potential null pointer dereference.

In some cases (e.g. after GPU reset or hotplug events), disconnect()
may be called when the connector is already disconnected. This can
lead to invalid backend/logger state.
This may occur during backend teardown, where connector disconnect
is triggered while backend state is being destroyed.
This change ensures backend pointers are valid before calling log(),
preventing a possible crash without altering behavior.
Tested by building aquamarine with Ninja and verifying correct usage
of CWeakPointer via .lock(). The change does not alter control flow
or cleanup logic, only guards logging in an already disconnected state.