### PR TITLE
fix(drm/atomic): retry DPMS ON commit on wake to unstick deep-sleep sinks

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -219,6 +219,8 @@ namespace Aquamarine {
         CDRMOutput(const std::string& name_, Hyprutils::Memory::CWeakPointer<CDRMBackend> backend_, Hyprutils::Memory::CSharedPointer<SDRMConnector> connector_);
 
         bool                                                         commitState(bool onlyTest = false);
+        void                                                         armDpmsRetryTimer();
+        void                                                         disarmDpmsRetryTimer();
 
         Hyprutils::Memory::CWeakPointer<CDRMBackend>                 backend;
         Hyprutils::Memory::CSharedPointer<SDRMConnector>             connector;
@@ -228,6 +230,12 @@ namespace Aquamarine {
             Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain;
             Hyprutils::Memory::CSharedPointer<CSwapchain> cursorSwapchain;
         } mgpu;
+
+        struct {
+            int    fd           = -1;
+            int    retryCount   = 0;
+            Hyprutils::Memory::CSharedPointer<SPollFD> pollFD;
+        } dpmsRetry;
 
         bool lastCommitNoBuffer = true;
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1,5 +1,6 @@
 #include "aquamarine/output/Output.hpp"
 #include <algorithm>
+#include <array>
 #include <aquamarine/backend/DRM.hpp>
 #include <aquamarine/backend/drm/Legacy.hpp>
 #include <aquamarine/backend/drm/Atomic.hpp>
@@ -18,6 +19,7 @@
 #include <system_error>
 #include <unordered_set>
 #include <sys/mman.h>
+#include <sys/timerfd.h>
 #include <fcntl.h>
 
 extern "C" {
@@ -1029,7 +1031,15 @@ bool Aquamarine::CDRMBackend::start() {
 }
 
 std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>> Aquamarine::CDRMBackend::pollFDs() {
-    return {makeShared<SPollFD>(gpu->fd, [this]() { dispatchEvents(); })};
+    std::vector<SP<SPollFD>> fds;
+    fds.emplace_back(makeShared<SPollFD>(gpu->fd, [this]() { dispatchEvents(); }));
+
+    for (auto const& conn : connectors) {
+        if (conn->output && conn->output->dpmsRetry.pollFD)
+            fds.emplace_back(conn->output->dpmsRetry.pollFD);
+    }
+
+    return fds;
 }
 
 int Aquamarine::CDRMBackend::drmFD() {
@@ -1695,6 +1705,8 @@ void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
     output->swapchain->reconfigure(SSwapchainOptions{.length = 0, .scanout = true, .multigpu = !!backend->primary, .scanoutOutput = output}); // mark the swapchain for scanout
     output->needsFrame = true;
     backend->backend->events.newOutput.emit(SP<IOutput>(output));
+    if (output->dpmsRetry.fd >= 0)
+        backend->backend->events.pollFDsChanged.emit();
     output->scheduleFrame(IOutput::AQ_SCHEDULE_NEW_CONNECTOR);
 }
 
@@ -1783,6 +1795,37 @@ Aquamarine::CDRMOutput::~CDRMOutput() {
         backend->backend->removeIdleEvent(frameIdle);
     connector->isPageFlipPending   = false;
     connector->frameEventScheduled = false;
+
+    if (dpmsRetry.fd >= 0)
+        close(dpmsRetry.fd);
+}
+
+void Aquamarine::CDRMOutput::armDpmsRetryTimer() {
+    if (dpmsRetry.fd < 0)
+        return;
+
+    constexpr std::array<int, 3> BACKOFFS_MS = {100, 250, 500};
+    const int                    delayMs     = BACKOFFS_MS[std::min(dpmsRetry.retryCount, (int)BACKOFFS_MS.size() - 1)];
+
+    backend->log(AQ_LOG_DEBUG, std::format("atomic drm: DPMS ON commit failed, scheduling retry {} in {}ms", dpmsRetry.retryCount + 1, delayMs));
+
+    itimerspec ts = {};
+    ts.it_value.tv_sec  = delayMs / 1000;
+    ts.it_value.tv_nsec = (delayMs % 1000) * 1000000L;
+
+    if (timerfd_settime(dpmsRetry.fd, 0, &ts, nullptr) < 0)
+        backend->log(AQ_LOG_ERROR, std::format("drm: Failed to arm DPMS retry timer: {}", strerror(errno)));
+
+    dpmsRetry.retryCount++;
+}
+
+void Aquamarine::CDRMOutput::disarmDpmsRetryTimer() {
+    dpmsRetry.retryCount = 0;
+    if (dpmsRetry.fd < 0)
+        return;
+
+    itimerspec ts = {};
+    timerfd_settime(dpmsRetry.fd, 0, &ts, nullptr);
 }
 
 void Aquamarine::CDRMOutput::releaseMgpuResources() {
@@ -2254,6 +2297,27 @@ Aquamarine::CDRMOutput::CDRMOutput(const std::string& name_, Hyprutils::Memory::
             return;
         events.frame.emit();
     });
+
+    dpmsRetry.fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC | TFD_NONBLOCK);
+    if (dpmsRetry.fd < 0)
+        backend_->log(AQ_LOG_ERROR, std::format("drm: Failed to create DPMS retry timerfd: {}", strerror(errno)));
+    else {
+        dpmsRetry.pollFD = makeShared<SPollFD>(dpmsRetry.fd, [this]() {
+            uint64_t expirations = 0;
+            read(dpmsRetry.fd, &expirations, sizeof(expirations));
+
+            if (dpmsRetry.retryCount >= 3) {
+                disarmDpmsRetryTimer();
+                backend->log(AQ_LOG_WARNING,
+                             "atomic drm: DPMS ON failed after retries; monitor may stay black. "
+                             "Workaround: `hyprctl dispatch dpms off && sleep 1 && hyprctl dispatch dpms on`");
+                return;
+            }
+
+            backend->log(AQ_LOG_DEBUG, std::format("atomic drm: DPMS retry timer fired, sending .frame (retry {}/3)", dpmsRetry.retryCount));
+            events.frame.emit();
+        });
+    }
 }
 
 SP<CDRMFB> Aquamarine::CDRMFB::create(SP<IBuffer> buffer_, Hyprutils::Memory::CWeakPointer<CDRMBackend> backend_, bool* isNew) {

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -1,7 +1,9 @@
 #include <aquamarine/backend/drm/Atomic.hpp>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <drm_mode.h>
+#include <thread>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <sys/mman.h>
@@ -458,7 +460,22 @@ bool Aquamarine::CDRMAtomicImpl::commit(Hyprutils::Memory::CSharedPointer<SDRMCo
     if (!data.blocking && !data.test)
         flags |= DRM_MODE_ATOMIC_NONBLOCK;
 
-    const bool ok = request.commit(flags);
+    // Some sinks (Pascal @ high refresh, AMD w/ GFXOFF) drop the first commit coming out of DPMS off.
+    // Retry on wake only: enable modeset while the output was previously disabled.
+    const auto& STATE            = connector->output->state->state();
+    const bool  isDpmsOnWake     = !data.test && data.modeset && STATE.enabled && !connector->output->enabledState;
+    bool        ok               = request.commit(flags);
+    if (!ok && isDpmsOnWake) {
+        constexpr std::array<int, 3> BACKOFFS_MS = {100, 250, 500};
+        for (size_t i = 0; i < BACKOFFS_MS.size() && !ok; ++i) {
+            backend->log(AQ_LOG_DEBUG, std::format("atomic drm: DPMS ON commit failed, retry {}/{} in {}ms", i + 1, BACKOFFS_MS.size(), BACKOFFS_MS[i]));
+            std::this_thread::sleep_for(std::chrono::milliseconds(BACKOFFS_MS[i]));
+            ok = request.commit(flags);
+        }
+        if (!ok)
+            backend->log(AQ_LOG_WARNING,
+                         "atomic drm: DPMS ON failed after retries; monitor may stay black. Workaround: `hyprctl dispatch dpms off && sleep 1 && hyprctl dispatch dpms on`");
+    }
 
     if (ok) {
         request.apply(data);

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -1,9 +1,7 @@
 #include <aquamarine/backend/drm/Atomic.hpp>
-#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <drm_mode.h>
-#include <thread>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <sys/mman.h>
@@ -461,20 +459,17 @@ bool Aquamarine::CDRMAtomicImpl::commit(Hyprutils::Memory::CSharedPointer<SDRMCo
         flags |= DRM_MODE_ATOMIC_NONBLOCK;
 
     // Some sinks (Pascal @ high refresh, AMD w/ GFXOFF) drop the first commit coming out of DPMS off.
-    // Retry on wake only: enable modeset while the output was previously disabled.
-    const auto& STATE            = connector->output->state->state();
-    const bool  isDpmsOnWake     = !data.test && data.modeset && STATE.enabled && !connector->output->enabledState;
-    bool        ok               = request.commit(flags);
+    // If this is a DPMS ON wake and the commit fails, arm a timer to send a .frame
+    // event so the compositor retries the commit after the sink has had time to wake up.
+    const auto& STATE        = connector->output->state->state();
+    const bool  isDpmsOnWake = !data.test && data.modeset && STATE.enabled && !connector->output->enabledState;
+    const bool  ok           = request.commit(flags);
+
     if (!ok && isDpmsOnWake) {
-        constexpr std::array<int, 3> BACKOFFS_MS = {100, 250, 500};
-        for (size_t i = 0; i < BACKOFFS_MS.size() && !ok; ++i) {
-            backend->log(AQ_LOG_DEBUG, std::format("atomic drm: DPMS ON commit failed, retry {}/{} in {}ms", i + 1, BACKOFFS_MS.size(), BACKOFFS_MS[i]));
-            std::this_thread::sleep_for(std::chrono::milliseconds(BACKOFFS_MS[i]));
-            ok = request.commit(flags);
-        }
-        if (!ok)
-            backend->log(AQ_LOG_WARNING,
-                         "atomic drm: DPMS ON failed after retries; monitor may stay black. Workaround: `hyprctl dispatch dpms off && sleep 1 && hyprctl dispatch dpms on`");
+        connector->output->armDpmsRetryTimer();
+    } else if (ok && isDpmsOnWake && connector->output->dpmsRetry.retryCount > 0) {
+        backend->log(AQ_LOG_DEBUG, std::format("atomic drm: DPMS ON succeeded after {} retries", connector->output->dpmsRetry.retryCount));
+        connector->output->disarmDpmsRetryTimer();
     }
 
     if (ok) {


### PR DESCRIPTION
Some sinks, like NVIDIA Pascal at high refresh rates and AMD parts with GFXOFF, drop the first atomic commit that brings a connector out of DPMS off, leaving the monitor black until the user manually cycles DPMS again. This adds a bounded retry (100/250/500 ms backoff, 3 attempts) around CDRMAtomicImpl::commit that only kicks in on an actual wake transition.

If this is not ok and goes against the engineering principles of the project feel free to close this. :)