### PR TITLE
backend/drm: guard against expired backend weak pointer on teardown

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -368,6 +368,8 @@ Aquamarine::CDRMBackend::~CDRMBackend() {
 }
 
 void Aquamarine::CDRMBackend::log(eBackendLogLevel l, const std::string& s) {
+    if (!backend)
+        return;
     backend->log(l, s);
 }
 


### PR DESCRIPTION
## Summary
Centralize the null-check on `CDRMBackend::backend` (a `CWeakPointer<CBackend>`) inside `CDRMBackend::log()` itself, so the forwarding log call becomes a safe no-op when the parent `CBackend` is already destroyed.

## Relation to #274
#274 (merged Apr 11) already guards the specific `SDRMConnector::disconnect()` call site with an inline check. This PR is complementary — rather than guarding each caller individually, it defends the wrapper itself, so any future or existing caller of `CDRMBackend::log()` is safe when `backend` has expired.

Rebased on top of current `main`; the disconnect() hunk from my original patch is dropped since #274 covers it.

## Motivation
Observed in a SIGSEGV during Hyprland shutdown where a connector went away while `CBackend` was already partially destroyed. The stack ended in `SDRMConnector::disconnect()` → `backend->backend->log()` → null deref. #274 fixes the immediate crash; this PR closes the wrapper in case any other caller hits the same race path.

## Test plan
- [x] Builds cleanly against current `main`.
- [x] Patched `libaquamarine.so` has been loaded on a Framework 13 / Intel Xe / Hyprland setup since ~2026-04-03. The `disconnect()` null-deref has not recurred across a 19-day continuous uptime window and multiple suspend/resume cycles.
- [ ] Reviewer verification that no caller of `CDRMBackend::log()` relies on side effects when `backend` is null (none found in tree).