### PR TITLE
libinput: method to get `libinput_tablet_tool` from ITabletTool

### DIFF
--- a/include/aquamarine/backend/Session.hpp
+++ b/include/aquamarine/backend/Session.hpp
@@ -150,6 +150,7 @@ namespace Aquamarine {
         virtual ~CLibinputTabletTool();
 
         virtual libinput_device*   getLibinputHandle();
+        virtual libinput_tablet_tool* getLibinputTool();
         virtual const std::string& getName();
 
       private:

--- a/include/aquamarine/backend/Session.hpp
+++ b/include/aquamarine/backend/Session.hpp
@@ -149,9 +149,9 @@ namespace Aquamarine {
         CLibinputTabletTool(Hyprutils::Memory::CSharedPointer<CLibinputDevice> dev, libinput_tablet_tool* tool);
         virtual ~CLibinputTabletTool();
 
-        virtual libinput_device*   getLibinputHandle();
+        virtual libinput_device*      getLibinputHandle();
         virtual libinput_tablet_tool* getLibinputTool();
-        virtual const std::string& getName();
+        virtual const std::string&    getName();
 
       private:
         Hyprutils::Memory::CWeakPointer<CLibinputDevice> device;

--- a/include/aquamarine/input/Input.hpp
+++ b/include/aquamarine/input/Input.hpp
@@ -4,6 +4,7 @@
 #include <hyprutils/math/Vector2D.hpp>
 
 struct libinput_device;
+struct libinput_tablet_tool;
 
 namespace Aquamarine {
     class ITabletTool;
@@ -292,6 +293,7 @@ namespace Aquamarine {
         }
 
         virtual libinput_device*   getLibinputHandle();
+        virtual libinput_tablet_tool* getLibinputTool();
         virtual const std::string& getName() = 0;
 
         enum eTabletToolType : uint32_t {

--- a/include/aquamarine/input/Input.hpp
+++ b/include/aquamarine/input/Input.hpp
@@ -292,9 +292,9 @@ namespace Aquamarine {
             events.destroy.emit();
         }
 
-        virtual libinput_device*   getLibinputHandle();
+        virtual libinput_device*      getLibinputHandle();
         virtual libinput_tablet_tool* getLibinputTool();
-        virtual const std::string& getName() = 0;
+        virtual const std::string&    getName() = 0;
 
         enum eTabletToolType : uint32_t {
             AQ_TABLET_TOOL_TYPE_INVALID = 0,

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -689,7 +689,7 @@ void Aquamarine::CSession::handleLibinputEvent(libinput_event* e) {
                 case LIBINPUT_SWITCH_LID: hlDevice->switchy->type = ISwitch::AQ_SWITCH_TYPE_LID; break;
                 case LIBINPUT_SWITCH_TABLET_MODE: hlDevice->switchy->type = ISwitch::AQ_SWITCH_TYPE_TABLET_MODE; break;
                 default: break;
-            }  
+            }
 
             hlDevice->switchy->events.fire.emit(ISwitch::SFireEvent{
                 .timeMs = (uint32_t)(libinput_event_switch_get_time_usec(se) / 1000),

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -1066,6 +1066,10 @@ libinput_device* Aquamarine::CLibinputTabletTool::getLibinputHandle() {
     return device->device;
 }
 
+libinput_tablet_tool* Aquamarine::CLibinputTabletTool::getLibinputTool() {
+    return libinputTool;
+}
+
 const std::string& Aquamarine::CLibinputTabletTool::getName() {
     if (!device)
         return AQ_UNKNOWN_DEVICE_NAME;

--- a/src/input/Input.cpp
+++ b/src/input/Input.cpp
@@ -20,6 +20,10 @@ libinput_device* Aquamarine::ITabletTool::getLibinputHandle() {
     return nullptr;
 }
 
+libinput_tablet_tool* Aquamarine::ITabletTool::getLibinputTool() {
+    return nullptr;
+}
+
 libinput_device* Aquamarine::ITablet::getLibinputHandle() {
     return nullptr;
 }


### PR DESCRIPTION
Libinput has some configuration specific to the tablet tool that could be interesting to set for Tablet users. However there's currently no way of getting the required `libinput_tablet_tool` ptr from `ITabletTool`. Meaning it's not possible to build the configuration on Hyprland (or anything else using aquamarine).

This change adds the virtual function `getLibinputTool()` to `ITabletTool` as well as an implementation for `CLibInputTabletTool`

Specifically the [pressure range](https://wayland.freedesktop.org/libinput/doc/1.31.0/api/group__config.html#ga048f7f37c7ed1c433a98e52eea1b5b9f) and [eraser button mode](https://wayland.freedesktop.org/libinput/doc/1.31.0/api/group__config.html#gaf29163219be754ce97852e2976c31606) are interesting for tablet users.

Note: This is my first time contributing to the project, so I'm open for any feedback and discussion of my changes.