### PR TITLE
drm: fix evdi outputs by adding CPU-copy fallback

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -440,6 +440,8 @@ namespace Aquamarine {
         std::vector<SDRMFormat>                                       glFormats;
 
         Hyprutils::Memory::CSharedPointer<CDRMDumbAllocator>          dumbAllocator;
+        bool                                                          sinkOnly    = false;
+        bool                                                          sinkCpuCopy = false;
 
         bool                                                          atomic = false;
 

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -498,6 +498,7 @@ namespace Aquamarine {
         uintptr_t                                                     nextPageFlipID();
 
         Hyprutils::Memory::CSharedPointer<CDRMDumbAllocator>          dumbAllocator;
+        bool                                                          cpuCopyFallback  = false;
 
         bool                                                          atomic = false;
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1978,7 +1978,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
 
             drmFB = CDRMFB::create(NEWAQBUF, backend, nullptr); // will return attachment if present
         } else {
-            if (!(backend->sinkOnly && backend->sinkCpuCopy))
+            if (!backend->sinkOnly || !backend->sinkCpuCopy)
                 drmFB = CDRMFB::create(STATE.buffer, backend, nullptr); // will return attachment if present
 
             if (!drmFB && backend->sinkOnly && backend->dumbAllocator) {
@@ -1998,12 +1998,10 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
                     mgpu.swapchain = CSwapchain::create(backend->dumbAllocator, backend.lock());
 
                 auto bufDma  = STATE.buffer->dmabuf();
-                auto OPTIONS = mgpu.swapchain->currentOptions();
+                auto OPTIONS = swapchain->currentOptions();
                 OPTIONS.size = STATE.buffer->size;
                 if (OPTIONS.format == DRM_FORMAT_INVALID)
                     OPTIONS.format = bufDma.format;
-                if (OPTIONS.length == 0)
-                    OPTIONS.length = 2;
                 OPTIONS.multigpu = false;
                 OPTIONS.cursor   = false;
                 OPTIONS.scanout  = true;
@@ -2018,12 +2016,16 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
                     return false;
                 }
 
-                if (!primaryRenderer->readBufferToDumb(STATE.buffer, NEWAQBUF,
-                                                       (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE) ? STATE.explicitInFence : -1)) {
-                    backend->backend->log(AQ_LOG_ERROR, "drm: sink-only CPU copy failed");
+                auto blitResult = primaryRenderer->blit(STATE.buffer, NEWAQBUF, nullptr,
+                                                        (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE) ? STATE.explicitInFence : -1);
+                if (!blitResult.success) {
+                    backend->backend->log(AQ_LOG_ERROR, "drm: sink-only: primary blit into dumb buffer failed");
                     return false;
                 }
-                state->setExplicitInFence(-1);
+                if (blitResult.syncFD.has_value() && (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE))
+                    state->setExplicitInFence(blitResult.syncFD.value());
+                else
+                    state->setExplicitInFence(-1);
 
                 drmFB = CDRMFB::create(NEWAQBUF, backend, nullptr);
             }

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -601,44 +601,53 @@ bool Aquamarine::CDRMBackend::initResources() {
 }
 
 bool Aquamarine::CDRMBackend::shouldBlit() {
-    return primary;
+    return primary && !sinkOnly;
 }
 
 bool Aquamarine::CDRMBackend::initMgpu() {
     SP<CGBMAllocator> newAllocator;
     if (primary || backend->primaryAllocator->type() != AQ_ALLOCATOR_TYPE_GBM) {
-        newAllocator            = CGBMAllocator::create(backend->reopenDRMNode(gpu->fd), backend);
-        rendererState.allocator = newAllocator;
-    } else {
-        newAllocator            = ((CGBMAllocator*)backend->primaryAllocator.get())->self.lock();
-        rendererState.allocator = newAllocator;
+        int newFd = backend->reopenDRMNode(gpu->fd);
+        if (newFd >= 0)
+            newAllocator = CGBMAllocator::create(newFd, backend);
+    } else
+        newAllocator = ((CGBMAllocator*)backend->primaryAllocator.get())->self.lock();
+
+    if (newAllocator) {
+        auto r = CDRMRenderer::attempt(backend.lock(), gpu->renderNodeFd >= 0 ? gpu->renderNodeFd : gpu->fd);
+        if (r) {
+            rendererState.allocator      = newAllocator;
+            rendererState.renderer       = r;
+            rendererState.renderer->self = r;
+            sinkOnly                     = false;
+            buildGlFormats(r->formats);
+            return true;
+        }
     }
 
-    if (!rendererState.allocator) {
-        backend->log(AQ_LOG_ERROR, "drm: initMgpu: no allocator");
-        return false;
+    if (primary) {
+        backend->log(AQ_LOG_DEBUG, std::format("drm: initMgpu: {} has no EGL-capable rendering, scanning out primary buffers directly", gpuName));
+        rendererState.allocator.reset();
+        rendererState.renderer.reset();
+        sinkOnly  = true;
+        glFormats = primary->glFormats;
+        return true;
     }
 
-    rendererState.renderer = CDRMRenderer::attempt(backend.lock(), gpu->renderNodeFd >= 0 ? gpu->renderNodeFd : gpu->fd);
-
-    if (!rendererState.renderer) {
-        backend->log(AQ_LOG_ERROR, "drm: initMgpu: no renderer");
-        return false;
-    }
-
-    rendererState.renderer->self = rendererState.renderer;
-
-    buildGlFormats(rendererState.renderer->formats);
-
-    return true;
+    backend->log(AQ_LOG_ERROR, "drm: initMgpu: no allocator/renderer");
+    rendererState.allocator.reset();
+    rendererState.renderer.reset();
+    return false;
 }
 
 bool Aquamarine::CDRMBackend::updateSecondaryRendererState() {
     if (!backend->ready)
         return true;
 
+    const auto haveRenderState = [this] { return sinkOnly || (rendererState.allocator && rendererState.renderer); };
+
     if (!primary) {
-        if (rendererState.renderer && rendererState.allocator)
+        if (haveRenderState())
             return true;
 
         return initMgpu();
@@ -648,12 +657,15 @@ bool Aquamarine::CDRMBackend::updateSecondaryRendererState() {
         std::ranges::any_of(connectors, [](const auto& c) { return c->status == DRM_MODE_CONNECTED && c->output && c->output->state && c->output->state->state().enabled; });
 
     if (hasEnabledOutputs) {
-        if (rendererState.renderer && rendererState.allocator)
+        if (haveRenderState())
             return true;
 
         backend->log(AQ_LOG_DEBUG, std::format("drm: Initializing secondary renderer on {}, has enabled outputs", gpu->path));
         return initMgpu();
     }
+
+    if (sinkOnly)
+        return true;
 
     if (!rendererState.renderer && !rendererState.allocator)
         return true;
@@ -794,8 +806,6 @@ bool Aquamarine::CDRMBackend::registerGPU(SP<CSessionDevice> gpu_, SP<CDRMBacken
     gpuName = drmName;
 
     auto drmVerName = drmVer->name ? drmVer->name : "unknown";
-    if (std::string_view(drmVerName) == "evdi")
-        primary = {};
 
     backend->log(AQ_LOG_DEBUG,
                  std::format("drm: Starting backend for {}, with driver {}{}", drmName ? drmName : "unknown", drmVerName,
@@ -1967,8 +1977,57 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
                 state->setExplicitInFence(-1);
 
             drmFB = CDRMFB::create(NEWAQBUF, backend, nullptr); // will return attachment if present
-        } else
-            drmFB = CDRMFB::create(STATE.buffer, backend, nullptr); // will return attachment if present
+        } else {
+            if (!(backend->sinkOnly && backend->sinkCpuCopy))
+                drmFB = CDRMFB::create(STATE.buffer, backend, nullptr); // will return attachment if present
+
+            if (!drmFB && backend->sinkOnly && backend->dumbAllocator) {
+                if (!backend->sinkCpuCopy) {
+                    backend->backend->log(AQ_LOG_DEBUG,
+                                          std::format("drm: sink-only: direct KMS import of primary buffer failed on {}, switching to dumb-buffer CPU copy", backend->gpuName));
+                    backend->sinkCpuCopy = true;
+                }
+
+                SP<CDRMRenderer> primaryRenderer = backend->primary ? backend->primary->rendererState.renderer : nullptr;
+                if (!primaryRenderer) {
+                    backend->backend->log(AQ_LOG_ERROR, "drm: sink-only CPU copy requires a primary renderer");
+                    return false;
+                }
+
+                if (!mgpu.swapchain)
+                    mgpu.swapchain = CSwapchain::create(backend->dumbAllocator, backend.lock());
+
+                auto bufDma  = STATE.buffer->dmabuf();
+                auto OPTIONS = mgpu.swapchain->currentOptions();
+                OPTIONS.size = STATE.buffer->size;
+                if (OPTIONS.format == DRM_FORMAT_INVALID)
+                    OPTIONS.format = bufDma.format;
+                if (OPTIONS.length == 0)
+                    OPTIONS.length = 2;
+                OPTIONS.multigpu = false;
+                OPTIONS.cursor   = false;
+                OPTIONS.scanout  = true;
+                if (!mgpu.swapchain->reconfigure(OPTIONS)) {
+                    backend->backend->log(AQ_LOG_ERROR, "drm: sink-only CPU copy: mgpu swapchain reconfigure failed");
+                    return false;
+                }
+
+                auto NEWAQBUF = mgpu.swapchain->next(nullptr);
+                if (!NEWAQBUF) {
+                    backend->backend->log(AQ_LOG_ERROR, "drm: sink-only CPU copy: no dumb buffer from swapchain");
+                    return false;
+                }
+
+                if (!primaryRenderer->readBufferToDumb(STATE.buffer, NEWAQBUF,
+                                                       (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE) ? STATE.explicitInFence : -1)) {
+                    backend->backend->log(AQ_LOG_ERROR, "drm: sink-only CPU copy failed");
+                    return false;
+                }
+                state->setExplicitInFence(-1);
+
+                drmFB = CDRMFB::create(NEWAQBUF, backend, nullptr);
+            }
+        }
 
         if (!drmFB) {
             backend->backend->log(AQ_LOG_ERROR, "drm: Buffer failed to import to KMS");
@@ -2107,6 +2166,12 @@ bool Aquamarine::CDRMOutput::setCursor(SP<IBuffer> buffer, const Vector2D& hotsp
         SP<CDRMFB> fb;
 
         if (backend->primary) {
+            if (backend->sinkOnly) {
+                TRACE(backend->backend->log(AQ_LOG_TRACE, "drm: sink-only backend, no cursor plane"));
+                setCursorVisible(false);
+                return false;
+            }
+
             TRACE(backend->backend->log(AQ_LOG_TRACE, "drm: Backend requires cursor blit, blitting"));
 
             if (!backend->rendererState.renderer || !backend->rendererState.allocator) {

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -646,7 +646,7 @@ bool Aquamarine::CDRMBackend::initResources() {
 }
 
 bool Aquamarine::CDRMBackend::shouldBlit() {
-    return !!primary;
+    return primary && rendererRequired;
 }
 
 bool Aquamarine::CDRMBackend::initMgpu() {
@@ -897,8 +897,9 @@ bool Aquamarine::CDRMBackend::registerGPU(SP<CSessionDevice> gpu_, SP<CDRMBacken
     auto drmVerName = drmVer && drmVer->name ? drmVer->name : "unknown";
     driver          = driverFromName(drmVerName);
     if (driver == AQ_BACKEND_GPU_DRIVER_EVDI) {
-        // DisplayLink/evdi exposes KMS without a usable EGL renderer.
-        primary          = {};
+        // DisplayLink/evdi exposes KMS without a usable EGL renderer. Keep primary set so its output
+        // swapchain is allocated against the primary GPU; rendererRequired stays false so no renderer
+        // is created on evdi and shouldBlit() (primary && rendererRequired) returns false.
         rendererRequired = false;
     }
 
@@ -2211,8 +2212,63 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
                 state->setExplicitInFence(-1);
 
             drmFB = CDRMFB::create(NEWAQBUF, backend, nullptr); // will return attachment if present
-        } else
-            drmFB = CDRMFB::create(STATE.buffer, backend, nullptr); // will return attachment if present
+        } else {
+            const bool evdiCpuCopy = backend->driver == AQ_BACKEND_GPU_DRIVER_EVDI;
+
+            // skip the direct import attempt once we've latched onto the CPU copy path
+            if (!(evdiCpuCopy && backend->cpuCopyFallback))
+                drmFB = CDRMFB::create(STATE.buffer, backend, nullptr); // will return attachment if present
+
+            if (!drmFB && evdiCpuCopy && backend->dumbAllocator) {
+                if (!backend->cpuCopyFallback) {
+                    backend->backend->log(AQ_LOG_DEBUG,
+                                          std::format("drm: direct KMS import of primary buffer failed on {}, switching to dumb-buffer CPU copy", backend->gpuName));
+                    backend->cpuCopyFallback = true;
+                }
+
+                // evdi has no EGL renderer of its own; use the primary GPU's renderer for readback.
+                SP<CDRMRenderer> primaryRenderer = backend->primary ? backend->primary->rendererState.renderer : nullptr;
+                if (!primaryRenderer) {
+                    backend->backend->log(AQ_LOG_ERROR, "drm: evdi CPU copy requires a primary renderer");
+                    return false;
+                }
+
+                if (!mgpu.swapchain)
+                    mgpu.swapchain = CSwapchain::create(backend->dumbAllocator, backend.lock());
+
+                auto bufDma  = STATE.buffer->dmabuf();
+                auto OPTIONS = swapchain->currentOptions();
+                OPTIONS.size = STATE.buffer->size;
+                if (OPTIONS.format == DRM_FORMAT_INVALID)
+                    OPTIONS.format = bufDma.format;
+                OPTIONS.multigpu = false;
+                OPTIONS.cursor   = false;
+                OPTIONS.scanout  = true;
+                if (!mgpu.swapchain->reconfigure(OPTIONS)) {
+                    backend->backend->log(AQ_LOG_ERROR, "drm: evdi CPU copy: mgpu swapchain reconfigure failed");
+                    return false;
+                }
+
+                auto NEWAQBUF = mgpu.swapchain->next(nullptr);
+                if (!NEWAQBUF) {
+                    backend->backend->log(AQ_LOG_ERROR, "drm: evdi CPU copy: no dumb buffer from swapchain");
+                    return false;
+                }
+
+                auto blitResult = primaryRenderer->blit(STATE.buffer, NEWAQBUF, nullptr,
+                                                        (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE) ? STATE.explicitInFence : -1);
+                if (!blitResult.success) {
+                    backend->backend->log(AQ_LOG_ERROR, "drm: evdi: primary blit into dumb buffer failed");
+                    return false;
+                }
+                if (blitResult.syncFD.has_value() && (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE))
+                    state->setExplicitInFence(blitResult.syncFD.value());
+                else
+                    state->setExplicitInFence(-1);
+
+                drmFB = CDRMFB::create(NEWAQBUF, backend, nullptr);
+            }
+        }
 
         if (!drmFB) {
             backend->backend->log(AQ_LOG_ERROR, "drm: Buffer failed to import to KMS");
@@ -2383,6 +2439,12 @@ bool Aquamarine::CDRMOutput::setCursor(SP<IBuffer> buffer, const Vector2D& hotsp
         SP<CDRMFB> fb;
 
         if (backend->primary) {
+            if (!backend->rendererRequired) {
+                TRACE(backend->backend->log(AQ_LOG_TRACE, "drm: backend has no renderer, no cursor plane"));
+                setCursorVisible(false);
+                return false;
+            }
+
             TRACE(backend->backend->log(AQ_LOG_TRACE, "drm: Backend requires cursor blit, blitting"));
 
             if (!backend->rendererState.renderer || !backend->rendererState.allocator) {

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -926,6 +926,75 @@ void CDRMRenderer::clearBuffer(IBuffer* buf) {
     proc.eglDestroyImageKHR(egl.display, rboImage);
 }
 
+bool CDRMRenderer::readBufferToDumb(SP<IBuffer> from, SP<IBuffer> toDumb, int waitFD) {
+    if (!from || !toDumb)
+        return false;
+
+    const auto& fromDma = from->dmabuf();
+    const auto& toDma   = toDumb->dmabuf();
+    if (!fromDma.success || !toDma.success)
+        return false;
+
+    if (fromDma.size != toDma.size) {
+        backend->log(AQ_LOG_ERROR, std::format("EGL (readBufferToDumb): size mismatch from {} to {}", fromDma.size, toDma.size));
+        return false;
+    }
+
+    if (!(toDumb->caps() & BUFFER_CAPABILITY_DATAPTR)) {
+        backend->log(AQ_LOG_ERROR, "EGL (readBufferToDumb): destination has no data ptr capability");
+        return false;
+    }
+
+    if (waitFD >= 0 && !CFileDescriptor::isReadable(waitFD)) {
+        CEglContextGuard eglContext(*this);
+        waitOnSync(waitFD);
+    }
+
+    const int W = (int)fromDma.size.x;
+    const int H = (int)fromDma.size.y;
+
+    std::vector<uint8_t> intermediate((size_t)W * H * 4);
+    readBuffer(from, intermediate);
+
+    auto [dst, fmt, len] = toDumb->beginDataPtr(0);
+    if (!dst) {
+        backend->log(AQ_LOG_ERROR, "EGL (readBufferToDumb): beginDataPtr returned null");
+        return false;
+    }
+
+    const size_t dstStride = toDma.strides.at(0);
+
+    switch (fmt) {
+        case DRM_FORMAT_XRGB8888:
+        case DRM_FORMAT_ARGB8888: {
+            for (int y = 0; y < H; ++y) {
+                const uint8_t* src = intermediate.data() + (size_t)y * W * 4;
+                uint8_t*       d   = dst + (size_t)y * dstStride;
+                for (int x = 0; x < W; ++x) {
+                    d[x * 4 + 0] = src[x * 4 + 2];
+                    d[x * 4 + 1] = src[x * 4 + 1];
+                    d[x * 4 + 2] = src[x * 4 + 0];
+                    d[x * 4 + 3] = src[x * 4 + 3];
+                }
+            }
+            break;
+        }
+        case DRM_FORMAT_XBGR8888:
+        case DRM_FORMAT_ABGR8888: {
+            for (int y = 0; y < H; ++y)
+                memcpy(dst + (size_t)y * dstStride, intermediate.data() + (size_t)y * W * 4, (size_t)W * 4);
+            break;
+        }
+        default:
+            backend->log(AQ_LOG_ERROR, std::format("EGL (readBufferToDumb): unsupported destination format {}", fourccToName(fmt)));
+            toDumb->endDataPtr();
+            return false;
+    }
+
+    toDumb->endDataPtr();
+    return true;
+}
+
 CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, SP<CDRMRenderer> primaryRenderer, int waitFD) {
     CEglContextGuard eglContext(*this);
 

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -926,75 +926,6 @@ void CDRMRenderer::clearBuffer(IBuffer* buf) {
     proc.eglDestroyImageKHR(egl.display, rboImage);
 }
 
-bool CDRMRenderer::readBufferToDumb(SP<IBuffer> from, SP<IBuffer> toDumb, int waitFD) {
-    if (!from || !toDumb)
-        return false;
-
-    const auto& fromDma = from->dmabuf();
-    const auto& toDma   = toDumb->dmabuf();
-    if (!fromDma.success || !toDma.success)
-        return false;
-
-    if (fromDma.size != toDma.size) {
-        backend->log(AQ_LOG_ERROR, std::format("EGL (readBufferToDumb): size mismatch from {} to {}", fromDma.size, toDma.size));
-        return false;
-    }
-
-    if (!(toDumb->caps() & BUFFER_CAPABILITY_DATAPTR)) {
-        backend->log(AQ_LOG_ERROR, "EGL (readBufferToDumb): destination has no data ptr capability");
-        return false;
-    }
-
-    if (waitFD >= 0 && !CFileDescriptor::isReadable(waitFD)) {
-        CEglContextGuard eglContext(*this);
-        waitOnSync(waitFD);
-    }
-
-    const int W = (int)fromDma.size.x;
-    const int H = (int)fromDma.size.y;
-
-    std::vector<uint8_t> intermediate((size_t)W * H * 4);
-    readBuffer(from, intermediate);
-
-    auto [dst, fmt, len] = toDumb->beginDataPtr(0);
-    if (!dst) {
-        backend->log(AQ_LOG_ERROR, "EGL (readBufferToDumb): beginDataPtr returned null");
-        return false;
-    }
-
-    const size_t dstStride = toDma.strides.at(0);
-
-    switch (fmt) {
-        case DRM_FORMAT_XRGB8888:
-        case DRM_FORMAT_ARGB8888: {
-            for (int y = 0; y < H; ++y) {
-                const uint8_t* src = intermediate.data() + (size_t)y * W * 4;
-                uint8_t*       d   = dst + (size_t)y * dstStride;
-                for (int x = 0; x < W; ++x) {
-                    d[x * 4 + 0] = src[x * 4 + 2];
-                    d[x * 4 + 1] = src[x * 4 + 1];
-                    d[x * 4 + 2] = src[x * 4 + 0];
-                    d[x * 4 + 3] = src[x * 4 + 3];
-                }
-            }
-            break;
-        }
-        case DRM_FORMAT_XBGR8888:
-        case DRM_FORMAT_ABGR8888: {
-            for (int y = 0; y < H; ++y)
-                memcpy(dst + (size_t)y * dstStride, intermediate.data() + (size_t)y * W * 4, (size_t)W * 4);
-            break;
-        }
-        default:
-            backend->log(AQ_LOG_ERROR, std::format("EGL (readBufferToDumb): unsupported destination format {}", fourccToName(fmt)));
-            toDumb->endDataPtr();
-            return false;
-    }
-
-    toDumb->endDataPtr();
-    return true;
-}
-
 CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, SP<CDRMRenderer> primaryRenderer, int waitFD) {
     CEglContextGuard eglContext(*this);
 
@@ -1059,12 +990,9 @@ CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, S
     GLuint      rboID = 0, fboID = 0;
     const auto& toDma = to->dmabuf();
 
-    if (!verifyDestinationDMABUF(toDma)) {
-        backend->log(AQ_LOG_ERROR, "EGL (blit): failed to blit: destination dmabuf unsupported");
-        return {};
-    }
+    bool        destImportable = verifyDestinationDMABUF(toDma);
 
-    {
+    if (destImportable) {
         auto attachment = to->attachments.get<CDRMRendererBufferOutputAttachment>();
         if (attachment && attachment->renderer == self) {
             TRACE(backend->log(AQ_LOG_TRACE, "EGL (blit): To attachment found"));
@@ -1078,26 +1006,86 @@ CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, S
 
             rboImage = createEGLImage(toDma);
             if (rboImage == EGL_NO_IMAGE_KHR) {
-                backend->log(AQ_LOG_ERROR, std::format("EGL (blit): createEGLImage failed: {}", eglGetError()));
-                return {};
+                backend->log(AQ_LOG_DEBUG, std::format("EGL (blit): createEGLImage failed: {}, will try CPU fallback", eglGetError()));
+                destImportable = false;
+            } else {
+                GLCALL(glGenRenderbuffers(1, &rboID));
+                GLCALL(glBindRenderbuffer(GL_RENDERBUFFER, rboID));
+                GLCALL(proc.glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, (GLeglImageOES)rboImage));
+                GLCALL(glBindRenderbuffer(GL_RENDERBUFFER, 0));
+
+                GLCALL(glGenFramebuffers(1, &fboID));
+                GLCALL(glBindFramebuffer(GL_FRAMEBUFFER, fboID));
+                GLCALL(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rboID));
+
+                if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+                    backend->log(AQ_LOG_DEBUG, std::format("EGL (blit): glCheckFramebufferStatus failed: {}, will try CPU fallback", glGetError()));
+                    glDeleteFramebuffers(1, &fboID);
+                    glDeleteRenderbuffers(1, &rboID);
+                    proc.eglDestroyImageKHR(egl.display, rboImage);
+                    rboImage       = nullptr;
+                    rboID          = 0;
+                    fboID          = 0;
+                    destImportable = false;
+                } else
+                    to->attachments.add(makeShared<CDRMRendererBufferOutputAttachment>(self, rboImage, fboID, rboID));
             }
-
-            GLCALL(glGenRenderbuffers(1, &rboID));
-            GLCALL(glBindRenderbuffer(GL_RENDERBUFFER, rboID));
-            GLCALL(proc.glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, (GLeglImageOES)rboImage));
-            GLCALL(glBindRenderbuffer(GL_RENDERBUFFER, 0));
-
-            GLCALL(glGenFramebuffers(1, &fboID));
-            GLCALL(glBindFramebuffer(GL_FRAMEBUFFER, fboID));
-            GLCALL(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rboID));
-
-            if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-                backend->log(AQ_LOG_ERROR, std::format("EGL (blit): glCheckFramebufferStatus failed: {}", glGetError()));
-                return {};
-            }
-
-            to->attachments.add(makeShared<CDRMRendererBufferOutputAttachment>(self, rboImage, fboID, rboID));
         }
+    }
+
+    if (!destImportable) {
+        if (!(to->caps() & BUFFER_CAPABILITY_DATAPTR)) {
+            backend->log(AQ_LOG_ERROR, "EGL (blit): destination cannot be imported and has no CPU mapping");
+            return {};
+        }
+
+        std::vector<uint8_t> localPixels;
+        std::span<uint8_t>   srcPixels = intermediateBuf;
+        if (srcPixels.empty()) {
+            localPixels.resize((size_t)fromDma.size.x * fromDma.size.y * 4);
+            readBuffer(from, localPixels);
+            srcPixels = localPixels;
+        }
+
+        auto [dst, dstFmt, dstLen] = to->beginDataPtr(0);
+        if (!dst) {
+            backend->log(AQ_LOG_ERROR, "EGL (blit): destination beginDataPtr returned null");
+            return {};
+        }
+
+        const int    W         = (int)fromDma.size.x;
+        const int    H         = (int)fromDma.size.y;
+        const size_t dstStride = toDma.strides.at(0);
+
+        switch (dstFmt) {
+            case DRM_FORMAT_XRGB8888:
+            case DRM_FORMAT_ARGB8888: {
+                for (int y = 0; y < H; ++y) {
+                    const uint8_t* src = srcPixels.data() + (size_t)y * W * 4;
+                    uint8_t*       d   = dst + (size_t)y * dstStride;
+                    for (int x = 0; x < W; ++x) {
+                        d[x * 4 + 0] = src[x * 4 + 2];
+                        d[x * 4 + 1] = src[x * 4 + 1];
+                        d[x * 4 + 2] = src[x * 4 + 0];
+                        d[x * 4 + 3] = src[x * 4 + 3];
+                    }
+                }
+                break;
+            }
+            case DRM_FORMAT_XBGR8888:
+            case DRM_FORMAT_ABGR8888: {
+                for (int y = 0; y < H; ++y)
+                    memcpy(dst + (size_t)y * dstStride, srcPixels.data() + (size_t)y * W * 4, (size_t)W * 4);
+                break;
+            }
+            default:
+                backend->log(AQ_LOG_ERROR, std::format("EGL (blit): destination format {} not supported for CPU fallback", fourccToName(dstFmt)));
+                to->endDataPtr();
+                return {};
+        }
+
+        to->endDataPtr();
+        return {.success = true};
     }
 
     TRACE(backend->log(AQ_LOG_TRACE, std::format("EGL (blit): rboImage 0x{:x}", (uintptr_t)rboImage)));

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -1002,12 +1002,9 @@ CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, S
     GLuint      rboID = 0, fboID = 0;
     const auto& toDma = to->dmabuf();
 
-    if (!verifyDestinationDMABUF(toDma)) {
-        backend->log(AQ_LOG_ERROR, "EGL (blit): failed to blit: destination dmabuf unsupported");
-        return {};
-    }
+    bool        destImportable = verifyDestinationDMABUF(toDma);
 
-    {
+    if (destImportable) {
         auto attachment = to->attachments.get<CDRMRendererBufferOutputAttachment>();
         if (attachment && attachment->renderer == self) {
             TRACE(backend->log(AQ_LOG_TRACE, "EGL (blit): To attachment found"));
@@ -1021,26 +1018,86 @@ CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, S
 
             rboImage = createEGLImage(toDma);
             if (rboImage == EGL_NO_IMAGE_KHR) {
-                backend->log(AQ_LOG_ERROR, std::format("EGL (blit): createEGLImage failed: {}", eglGetError()));
-                return {};
+                backend->log(AQ_LOG_DEBUG, std::format("EGL (blit): createEGLImage failed: {}, will try CPU fallback", eglGetError()));
+                destImportable = false;
+            } else {
+                GLCALL(glGenRenderbuffers(1, &rboID));
+                GLCALL(glBindRenderbuffer(GL_RENDERBUFFER, rboID));
+                GLCALL(proc.glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, (GLeglImageOES)rboImage));
+                GLCALL(glBindRenderbuffer(GL_RENDERBUFFER, 0));
+
+                GLCALL(glGenFramebuffers(1, &fboID));
+                GLCALL(glBindFramebuffer(GL_FRAMEBUFFER, fboID));
+                GLCALL(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rboID));
+
+                if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+                    backend->log(AQ_LOG_DEBUG, std::format("EGL (blit): glCheckFramebufferStatus failed: {}, will try CPU fallback", glGetError()));
+                    glDeleteFramebuffers(1, &fboID);
+                    glDeleteRenderbuffers(1, &rboID);
+                    proc.eglDestroyImageKHR(egl.display, rboImage);
+                    rboImage       = nullptr;
+                    rboID          = 0;
+                    fboID          = 0;
+                    destImportable = false;
+                } else
+                    to->attachments.add(makeShared<CDRMRendererBufferOutputAttachment>(self, rboImage, fboID, rboID));
             }
-
-            GLCALL(glGenRenderbuffers(1, &rboID));
-            GLCALL(glBindRenderbuffer(GL_RENDERBUFFER, rboID));
-            GLCALL(proc.glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, (GLeglImageOES)rboImage));
-            GLCALL(glBindRenderbuffer(GL_RENDERBUFFER, 0));
-
-            GLCALL(glGenFramebuffers(1, &fboID));
-            GLCALL(glBindFramebuffer(GL_FRAMEBUFFER, fboID));
-            GLCALL(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rboID));
-
-            if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-                backend->log(AQ_LOG_ERROR, std::format("EGL (blit): glCheckFramebufferStatus failed: {}", glGetError()));
-                return {};
-            }
-
-            to->attachments.add(makeShared<CDRMRendererBufferOutputAttachment>(self, rboImage, fboID, rboID));
         }
+    }
+
+    if (!destImportable) {
+        if (!(to->caps() & BUFFER_CAPABILITY_DATAPTR)) {
+            backend->log(AQ_LOG_ERROR, "EGL (blit): destination cannot be imported and has no CPU mapping");
+            return {};
+        }
+
+        std::vector<uint8_t> localPixels;
+        std::span<uint8_t>   srcPixels = intermediateBuf;
+        if (srcPixels.empty()) {
+            localPixels.resize((size_t)fromDma.size.x * fromDma.size.y * 4);
+            readBuffer(from, localPixels);
+            srcPixels = localPixels;
+        }
+
+        auto [dst, dstFmt, dstLen] = to->beginDataPtr(0);
+        if (!dst) {
+            backend->log(AQ_LOG_ERROR, "EGL (blit): destination beginDataPtr returned null");
+            return {};
+        }
+
+        const int    W         = (int)fromDma.size.x;
+        const int    H         = (int)fromDma.size.y;
+        const size_t dstStride = toDma.strides.at(0);
+
+        switch (dstFmt) {
+            case DRM_FORMAT_XRGB8888:
+            case DRM_FORMAT_ARGB8888: {
+                for (int y = 0; y < H; ++y) {
+                    const uint8_t* src = srcPixels.data() + (size_t)y * W * 4;
+                    uint8_t*       d   = dst + (size_t)y * dstStride;
+                    for (int x = 0; x < W; ++x) {
+                        d[x * 4 + 0] = src[x * 4 + 2];
+                        d[x * 4 + 1] = src[x * 4 + 1];
+                        d[x * 4 + 2] = src[x * 4 + 0];
+                        d[x * 4 + 3] = src[x * 4 + 3];
+                    }
+                }
+                break;
+            }
+            case DRM_FORMAT_XBGR8888:
+            case DRM_FORMAT_ABGR8888: {
+                for (int y = 0; y < H; ++y)
+                    memcpy(dst + (size_t)y * dstStride, srcPixels.data() + (size_t)y * W * 4, (size_t)W * 4);
+                break;
+            }
+            default:
+                backend->log(AQ_LOG_ERROR, std::format("EGL (blit): destination format {} not supported for CPU fallback", fourccToName(dstFmt)));
+                to->endDataPtr();
+                return {};
+        }
+
+        to->endDataPtr();
+        return {.success = true};
     }
 
     TRACE(backend->log(AQ_LOG_TRACE, std::format("EGL (blit): rboImage 0x{:x}", (uintptr_t)rboImage)));

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -103,8 +103,6 @@ namespace Aquamarine {
 
         SBlitResult blit(Hyprutils::Memory::CSharedPointer<IBuffer> from, Hyprutils::Memory::CSharedPointer<IBuffer> to,
                          Hyprutils::Memory::CSharedPointer<CDRMRenderer> primaryRenderer, int waitFD = -1);
-
-        bool        readBufferToDumb(Hyprutils::Memory::CSharedPointer<IBuffer> from, Hyprutils::Memory::CSharedPointer<IBuffer> toDumb, int waitFD = -1);
         // can't be a SP<> because we call it from buf's ctor...
         void clearBuffer(IBuffer* buf);
 

--- a/src/backend/drm/Renderer.hpp
+++ b/src/backend/drm/Renderer.hpp
@@ -103,6 +103,8 @@ namespace Aquamarine {
 
         SBlitResult blit(Hyprutils::Memory::CSharedPointer<IBuffer> from, Hyprutils::Memory::CSharedPointer<IBuffer> to,
                          Hyprutils::Memory::CSharedPointer<CDRMRenderer> primaryRenderer, int waitFD = -1);
+
+        bool        readBufferToDumb(Hyprutils::Memory::CSharedPointer<IBuffer> from, Hyprutils::Memory::CSharedPointer<IBuffer> toDumb, int waitFD = -1);
         // can't be a SP<> because we call it from buf's ctor...
         void clearBuffer(IBuffer* buf);
 


### PR DESCRIPTION
evdi outputs never get a modeset on NVIDIA cards. Connector shows up and modes list, but drmModeAtomicCommit never runs. Reproducible on NVIDIA systems, using evdi's pyevdi `test_mode_changed_handler_called_after_connect` test, which passes in under 0.1s on KDE but times out at 60s here.
Supersedes #25, probably fixes #169.

evdi has no render device, so `CDRMRenderer::attempt` fails on it. The old workaround in `registerGPU` cleared primary for evdi so commits would skip the blit path and try a direct KMS import of the primary's buffer. That works for AMD/Intel (LINEAR dmabufs cross-import fine), but clearing primary also drops the multigpu LINEAR hint in the allocator, so on NVIDIA the primary buffer comes back `BLOCK_LINEAR_2D` and `drmModeAddFB2` on evdi refuses it.

Keeps primary set for evdi so output swapchains stay LINEAR, and adds a sink-only path. When CDRMRenderer::attempt fails on a secondary, mark it `sinkOnly`, leave `rendererState.renderer` null, and have `shouldBlit()` return false. Commits then fall into the existing direct-import branch. On AMD/Intel primaries that's enough.

On NVIDIA primaries `drmPrimeFDToHandle` on evdi fails because NVIDIA's dmabuf exporter refuses `dma_buf_attach` from foreign drivers. When that happens on a sink-only secondary, fall back to a CPU copy, allocate a dumb buffer on evdi via the existing `CDRMDumbAllocator`, have the primary renderer `glReadnPixels` into an intermediate, swizzle R to B for XRGB/ARGB destinations, write it into the dumb buffer's scanline, and build the FB from the dumb buffer. A `sinkCpuCopy` flag latches so subsequent commits skip the failed direct attempt.

I observed same last-resort method in other compositors as well, including KWin. The existing GBM-renderer mgpu blit path is untouched.

Tested on NVIDIA RTX 5090 + evdi with the test script bundled with pyevdi in the evdi repository.
Before: `AssertionError: Expected 'my_mode_changed_handler' to have been called` at 60.04s.
After: passes in under a 0.1s (0.04s average on my system).