### PR TITLE
refactor: avoid repeated vector access in backend and DRM loops

### DIFF
--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -129,12 +129,13 @@ bool Aquamarine::CBackend::start() {
     };
 
     for (size_t i = 0; i < implementations.size(); ++i) {
-        const bool ok = implementations.at(i)->start();
+        const auto& impl = implementations.at(i);
+        const bool ok = impl->start();
 
         if (!ok) {
-            log(AQ_LOG_ERROR, std::format("Requested backend ({}) could not start, enabling fallbacks", backendTypeToName(implementations.at(i)->type())));
-            if (optionsForType(implementations.at(i)->type()).backendRequestMode == AQ_BACKEND_REQUEST_MANDATORY) {
-                log(AQ_LOG_CRITICAL, std::format("Requested backend ({}) could not start and it's mandatory, cannot continue!", backendTypeToName(implementations.at(i)->type())));
+            log(AQ_LOG_ERROR, std::format("Requested backend ({}) could not start, enabling fallbacks", backendTypeToName(impl->type())));
+            if (optionsForType(impl->type()).backendRequestMode == AQ_BACKEND_REQUEST_MANDATORY) {
+                log(AQ_LOG_CRITICAL, std::format("Requested backend ({}) could not start and it's mandatory, cannot continue!", backendTypeToName(impl->type())));
                 implementations.clear();
                 return false;
             }

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -720,9 +720,10 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
     }
 
     for (size_t i = 0; i < crtcs.size(); ++i) {
+        const auto& crtc = crtcs.at(i);
         bool taken = false;
         for (auto const& c : connectors) {
-            if (c->crtc != crtcs.at(i))
+            if (c->crtc != crtc)
                 continue;
 
             if (c->status != DRM_MODE_CONNECTED || c->tilingRedundant)
@@ -753,8 +754,8 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
             }
 
             backend->log(AQ_LOG_DEBUG,
-                         std::format("drm: connected slot {} crtc {} assigned to {}{}", i, crtcs.at(i)->id, c->szName, c->crtc ? std::format(" (old {})", c->crtc->id) : ""));
-            c->crtc  = crtcs.at(i);
+                         std::format("drm: connected slot {} crtc {} assigned to {}{}", i, crtc->id, c->szName, c->crtc ? std::format(" (old {})", c->crtc->id) : ""));
+            c->crtc  = crtc;
             assigned = true;
             changed.emplace_back(c);
             std::erase(recheck, c);
@@ -762,7 +763,7 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
         }
 
         if (!assigned)
-            backend->log(AQ_LOG_DEBUG, std::format("drm: slot {} crtc {} unassigned", i, crtcs.at(i)->id));
+            backend->log(AQ_LOG_DEBUG, std::format("drm: slot {} crtc {} unassigned", i, crtc->id));
     }
 
     for (auto const& c : connectors) {


### PR DESCRIPTION
This removes a bit of repetition in a couple of loops by caching
implementations.at(i) and  crtcs.at(i) into local references.
No functional changes, just makes the code a bit cleaner and avoids
repeated  .at(i)  calls.
Touched:
-backend init loop in Backend.cpp
-CRTC assignment loop in DRM.cpp (recheckCRTCs)
Builds fine, logs look normal.