### PR TITLE
FormatUtils: null-check drmGetFormatModifierName result

### DIFF
--- a/src/utils/FormatUtils.cpp
+++ b/src/utils/FormatUtils.cpp
@@ -12,7 +12,7 @@ std::string fourccToName(uint32_t drmFormat) {
 
 std::string drmModifierToName(uint64_t drmModifier) {
     auto        n    = drmGetFormatModifierName(drmModifier);
-    std::string name = n;
+    std::string name = n ? n : "unknown";
     free(n); // NOLINT(cppcoreguidelines-no-malloc,-warnings-as-errors)
     return name;
 }


### PR DESCRIPTION
After updating this on my system, I was having complete crashes with hyprpaper. I put it through Claude who claimed this was related to a bug with this repo. I was sceptical, however, it made a tweak and rebuilt it, and now my wallpaper works again. Its explanation is below, just putting this here in case it is actually an issue that needs resolving.

---

**Environment:** Fedora Asahi Remix on Apple Silicon (aarch64), aquamarine 0.11.0, hyprpaper 0.8.3, mesa 25.3.6.

**Symptom:** hyprpaper aborts shortly after startup with:
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string: construction from null is not valid
```

**Trace** (via gdb):
```
#8  drmModifierToName                                libaquamarine.so.10
#9  Aquamarine::CGBMBuffer::CGBMBuffer               libaquamarine.so.10
#10 Aquamarine::CGBMAllocator::acquire               libaquamarine.so.10
#11 Aquamarine::CSwapchain::fullReconfigure          libaquamarine.so.10
#12 Aquamarine::CSwapchain::reconfigure              libaquamarine.so.10
#13 Hyprtoolkit::IWaylandWindow::resizeSwapchain     libhyprtoolkit.so.5
```

**Cause:** `src/utils/FormatUtils.cpp::drmModifierToName()` constructs a `std::string` directly from `drmGetFormatModifierName()`'s return value. On Asahi, libdrm doesn't have names for some Apple GPU-specific DRM format modifiers and returns NULL. The sibling `fourccToName()` in the same file already null-checks (`fmt ? fmt : "unknown"`); `drmModifierToName()` does not.

**Fix:**
```diff
 std::string drmModifierToName(uint64_t drmModifier) {
     auto        n    = drmGetFormatModifierName(drmModifier);
-    std::string name = n;
+    std::string name = n ? n : "unknown";
     free(n);
     return name;
 }
```

Rebuilt aquamarine 0.11.0 with this patch on the affected machine and hyprpaper now starts and renders correctly. No other changes were required.