### PR TITLE
backend: avoid duplicate auto-named outputs

### DIFF
--- a/src/backend/Headless.cpp
+++ b/src/backend/Headless.cpp
@@ -175,7 +175,19 @@ std::vector<SDRMFormat> Aquamarine::CHeadlessBackend::getCursorFormats() {
 }
 
 bool Aquamarine::CHeadlessBackend::createOutput(const std::string& name) {
-    auto output = SP<CHeadlessOutput>(new CHeadlessOutput(name.empty() ? std::format("HEADLESS-{}", ++outputIDCounter) : name, self.lock()));
+    std::string outputName = name;
+    if (outputName.empty()) {
+        // skip past any auto-name slots already claimed by an explicit createOutput,
+        // so we never hand out a duplicate HEADLESS-N (see #185).
+        do {
+            outputName = std::format("HEADLESS-{}", ++outputIDCounter);
+        } while (std::ranges::any_of(outputs, [&outputName](const auto& o) { return o->name == outputName; }));
+    } else if (std::ranges::any_of(outputs, [&outputName](const auto& o) { return o->name == outputName; })) {
+        backend->log(AQ_LOG_ERROR, std::format("headless: refusing to create output {}, name already in use", outputName));
+        return false;
+    }
+
+    auto output = SP<CHeadlessOutput>(new CHeadlessOutput(outputName, self.lock()));
     outputs.emplace_back(output);
     output->modes.emplace_back(SP<SOutputMode>(new SOutputMode(Vector2D{1920, 1080}, 60000, true)));
     output->swapchain = CSwapchain::create(backend->primaryAllocator, self.lock());

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -145,7 +145,19 @@ int Aquamarine::CWaylandBackend::drmRenderNodeFD() {
 }
 
 bool Aquamarine::CWaylandBackend::createOutput(const std::string& szName) {
-    auto o  = outputs.emplace_back(SP<CWaylandOutput>(new CWaylandOutput(szName.empty() ? std::format("WAYLAND-{}", ++lastOutputID) : szName, self)));
+    std::string name = szName;
+    if (name.empty()) {
+        // skip past any auto-name slots already claimed by an explicit createOutput,
+        // so we never hand out a duplicate WAYLAND-N (see #185).
+        do {
+            name = std::format("WAYLAND-{}", ++lastOutputID);
+        } while (std::ranges::any_of(outputs, [&name](const auto& o) { return o->name == name; }));
+    } else if (std::ranges::any_of(outputs, [&name](const auto& o) { return o->name == name; })) {
+        backend->log(AQ_LOG_ERROR, std::format("Wayland: refusing to create output {}, name already in use", name));
+        return false;
+    }
+
+    auto o  = outputs.emplace_back(SP<CWaylandOutput>(new CWaylandOutput(name, self)));
     o->self = o;
     if (backend->ready)
         o->swapchain = CSwapchain::create(backend->primaryAllocator, self.lock());


### PR DESCRIPTION
Both the wayland and headless backends generated `WAYLAND-N` / `HEADLESS-N`
auto names from a monotonic counter without checking for existing
outputs. If a user creates an output with an explicit name that matches
a future counter slot (e.g. `hyprctl output create wayland WAYLAND-2`),
the next auto-named output collides on the same name.

Skip past any taken slot when generating an auto name, and reject
explicit creates whose name is already in use.

Fixes #185.