### PR TITLE
drm: clear stale color state on modeset

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -2126,7 +2126,12 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
     else
         data.calculateMode(connector);
 
-    if ((data.modeset && STATE.ctm != Mat3x3()) || (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_CTM))
+    // always re-send CTM on modeset, identity included, otherwise a stale matrix
+    // left by a previous compositor (e.g. kwin's color management) survives our
+    // session. prepareConnector builds a real identity blob when STATE.ctm is
+    // identity, so we never send blob_id=0 (which some drivers mishandle, see #256).
+    // (see #127)
+    if (data.modeset || (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_CTM))
         data.ctm = STATE.ctm;
 
     bool ok = connector->commitState(data);

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -369,10 +369,15 @@ bool Aquamarine::CDRMAtomicImpl::prepareConnector(Hyprutils::Memory::CSharedPoin
         return false;
     };
 
-    if (STATE.committed & COutputState::AQ_OUTPUT_STATE_GAMMA_LUT)
+    // re-send gamma/degamma on modeset so a previous compositor's lut does not
+    // bleed into our session. an empty STATE.gammaLut produces a zero blob, which
+    // clears the kernel state. only ride the modeset path when the prop actually
+    // exists, otherwise we'd log a spurious "no gamma_lut prop" error per modeset.
+    // (see #127)
+    if ((data.modeset && connector->crtc->props.values.gamma_lut) || (STATE.committed & COutputState::AQ_OUTPUT_STATE_GAMMA_LUT))
         data.atomic.gammad = prepareGammaBlob(connector->crtc->props.values.gamma_lut, STATE.gammaLut, &data.atomic.gammaLut);
 
-    if (STATE.committed & COutputState::AQ_OUTPUT_STATE_DEGAMMA_LUT)
+    if ((data.modeset && connector->crtc->props.values.degamma_lut) || (STATE.committed & COutputState::AQ_OUTPUT_STATE_DEGAMMA_LUT))
         data.atomic.degammad = prepareGammaBlob(connector->crtc->props.values.degamma_lut, STATE.degammaLut, &data.atomic.degammaLut);
 
     if (data.ctm.has_value() && (data.modeset || (STATE.committed & COutputState::AQ_OUTPUT_STATE_CTM))) {


### PR DESCRIPTION
A previous compositor (kwin etc.) can leave HDR, gamma, degamma and CTM
properties set on a connector when it exits. Aquamarine only re-emitted
these on user commits, so anything we don't actively manage stayed at
the previous compositor's value, manifesting as washed-out colors or
shifted saturation when starting Hyprland after kwin.

HDR (#250) and CTM-with-non-identity (#256) were already covered. Extend
the modeset path to also:

- re-send `gamma_lut` / `degamma_lut` on modeset; an empty `STATE.gammaLut`
  produces a zero blob, which clears the kernel state. only ride this
  path when the prop actually exists, otherwise we'd log a spurious
  `no gamma_lut prop` error on every modeset for connectors without
  programmable gamma.
- re-send CTM unconditionally on modeset, identity included, so the
  kernel always replaces a stale matrix with our current one. the blob
  builder produces a real identity matrix when `STATE.ctm == Mat3x3()`,
  so we never send `blob_id=0` (which #256 documented as problematic).

Fixes #127.