### PR TITLE
drm: re-read EDID on resume to detect dock port swaps

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -312,6 +312,12 @@ namespace Aquamarine {
         Hyprutils::Math::Vector2D                      cursorPos, cursorSize, cursorHotspot;
         Hyprutils::Memory::CSharedPointer<CDRMFB>      pendingCursorFB;
 
+        // raw EDID bytes last seen on this connector. used by restoreAfterVT to detect
+        // dock/MST port swaps that re-route a different display to the same connector
+        // across hibernate/resume, since recheckOutputs skips connected connectors and
+        // never re-parses EDID for them. (see #259)
+        std::vector<uint8_t>                           edidBlob;
+
         bool                                           isPageFlipPending   = false;
         uint64_t                                       pageFlipPendingAtMs = 0; // CLOCK_BOOTTIME ms when isPageFlipPending was set
         SDRMPageFlip                                   pendingPageFlip;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -399,6 +399,30 @@ void Aquamarine::CDRMBackend::restoreAfterVT() {
         }
     }
 
+    // detect EDID changes on already-connected connectors. dock/MST hubs can swap
+    // which physical port a connector is wired to across hibernate/resume; the
+    // kernel re-reads the new EDID, but recheckOutputs() will skip the connector
+    // (status is still CONNECTED, output is still alive) and never re-parse it,
+    // leaving stale make/model/parsedEDID. force a disconnect on mismatch so
+    // recheckOutputs() will reconnect and re-emit a fresh newOutput. (see #259)
+    for (auto const& c : connectors) {
+        if (!c->output || c->edidBlob.empty() || !c->props.values.edid)
+            continue;
+
+        size_t   freshLen  = 0;
+        uint8_t* freshData = (uint8_t*)getDRMPropBlob(gpu->fd, c->id, c->props.values.edid, &freshLen);
+        if (!freshData)
+            continue;
+
+        const bool changed = freshLen != c->edidBlob.size() || std::memcmp(freshData, c->edidBlob.data(), freshLen) != 0;
+        free(freshData);
+
+        if (changed) {
+            backend->log(AQ_LOG_DEBUG, std::format("drm: EDID changed for {} during resume, forcing reconnect", c->szName));
+            c->disconnect();
+        }
+    }
+
     recheckOutputs();
 
     backend->log(AQ_LOG_DEBUG, "drm: Rescanned connectors");
@@ -1729,7 +1753,7 @@ void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
     auto                 parsedEDID = parseEDID(edid);
 
     free(edidData);
-    edid = {};
+    edidBlob = std::move(edid);
 
     // TODO: subconnectors
 


### PR DESCRIPTION
After a hibernate/resume, dock and MST hubs can re-route a different
display to the same DRM connector. The kernel notices and re-reads the
new EDID via `/sys/class/drm/.../edid`, but `recheckOutputs()` skips
connectors that are still flagged CONNECTED with a live output, so
aquamarine keeps the previous parsed EDID, make/model/serial.

Save the raw EDID bytes on the connector at connect-time. In
`restoreAfterVT()`, before the `recheckOutputs()` pass, walk all connected
connectors, read fresh EDID, and bytewise compare against the cached
copy. On mismatch, force a disconnect so `recheckOutputs()` reconnects
the connector and re-emits a fresh `newOutput` with the correct EDID.

Fixes #259.