### PR TITLE
Overlay plane

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -4,7 +4,9 @@
 #include "../allocator/Swapchain.hpp"
 #include "../output/Output.hpp"
 #include "../input/Input.hpp"
+#include <cstdint>
 #include <hyprutils/memory/WeakPtr.hpp>
+#include <vector>
 #include <wayland-client.h>
 #include <xf86drmMode.h>
 #include <optional>
@@ -143,7 +145,8 @@ namespace Aquamarine {
             } values;
             uint32_t props[18] = {0};
         };
-        UDRMPlaneProps props;
+        UDRMPlaneProps        props;
+        std::vector<uint32_t> unknownProperies;
 
         union UDRMPlanePropsColorRange {
             struct {
@@ -198,7 +201,8 @@ namespace Aquamarine {
             } values;
             uint32_t props[9] = {0};
         };
-        UDRMCRTCProps props;
+        UDRMCRTCProps         props;
+        std::vector<uint32_t> unknownProperies;
     };
 
     class CDRMOutput : public IOutput {
@@ -384,7 +388,8 @@ namespace Aquamarine {
             } values;
             uint32_t props[15] = {0};
         };
-        UDRMConnectorProps props;
+        UDRMConnectorProps    props;
+        std::vector<uint32_t> unknownProperies;
 
         union UDRMConnectorColorspace {
             struct {

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -362,6 +362,7 @@ namespace Aquamarine {
                 uint32_t content_type;        // not guaranteed to exist
                 uint32_t max_bpc;             // not guaranteed to exist
                 uint32_t Colorspace;          // not guaranteed to exist
+                uint32_t BroadcastRGB;        // not guaranteed to exist
                 uint32_t hdr_output_metadata; // not guaranteed to exist
                 uint32_t tile;                // not guaranteed to exist
 
@@ -382,6 +383,16 @@ namespace Aquamarine {
             uint32_t props[3] = {0};
         };
         UDRMConnectorColorspace colorspace;
+
+        union UDRMConnectorBroadcastRGB {
+            struct {
+                uint32_t Automatic;
+                uint32_t Full;
+                uint32_t Limited;
+            } values;
+            uint32_t props[3] = {0};
+        };
+        UDRMConnectorBroadcastRGB broadcastRGB;
     };
 
     class IDRMImplementation {

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -164,10 +164,11 @@ namespace Aquamarine {
             bool ctmStateKnown = false;
         } atomic;
 
-        Hyprutils::Memory::CSharedPointer<SDRMPlane> primary;
-        Hyprutils::Memory::CSharedPointer<SDRMPlane> cursor;
-        Hyprutils::Memory::CWeakPointer<CDRMBackend> backend;
-        Hyprutils::Memory::CSharedPointer<CDRMFB>    pendingCursor;
+        Hyprutils::Memory::CSharedPointer<SDRMPlane>              primary;
+        Hyprutils::Memory::CSharedPointer<SDRMPlane>              cursor;
+        std::vector<Hyprutils::Memory::CSharedPointer<SDRMPlane>> planes; // other planes go here
+        Hyprutils::Memory::CWeakPointer<CDRMBackend>              backend;
+        Hyprutils::Memory::CSharedPointer<CDRMFB>                 pendingCursor;
 
         union UDRMCRTCProps {
             struct {

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -120,8 +120,9 @@ namespace Aquamarine {
         union UDRMPlaneProps {
             struct {
                 uint32_t type;
-                uint32_t rotation;   // Not guaranteed to exist
-                uint32_t in_formats; // Not guaranteed to exist
+                uint32_t rotation;    // Not guaranteed to exist
+                uint32_t in_formats;  // Not guaranteed to exist
+                uint32_t color_range; // Not guaranteed to exist
 
                 // atomic-modesetting only
 
@@ -140,9 +141,18 @@ namespace Aquamarine {
                 uint32_t hotspot_y;
                 uint32_t in_fence_fd;
             } values;
-            uint32_t props[17] = {0};
+            uint32_t props[18] = {0};
         };
         UDRMPlaneProps props;
+
+        union UDRMPlanePropsColorRange {
+            struct {
+                uint32_t limited;
+                uint32_t full;
+            } values;
+            uint32_t props[2] = {0};
+        };
+        UDRMPlanePropsColorRange colorRange;
     };
 
     struct SDRMCRTC {
@@ -207,6 +217,8 @@ namespace Aquamarine {
         virtual std::vector<SDRMFormat>                                   getRenderFormats();
         virtual bool                                                      pendingPageFlip();
         virtual bool                                                      pendingIdleFrame();
+        virtual std::vector<SPlaneData>                                   getPlanes();
+        virtual std::optional<SPlaneData>                                 getOverlayPlane();
         void                                                              releaseMgpuResources();
 
         int                                                               getConnectorID();
@@ -370,7 +382,7 @@ namespace Aquamarine {
 
                 uint32_t crtc_id;
             } values;
-            uint32_t props[14] = {0};
+            uint32_t props[15] = {0};
         };
         UDRMConnectorProps props;
 

--- a/include/aquamarine/backend/drm/Atomic.hpp
+++ b/include/aquamarine/backend/drm/Atomic.hpp
@@ -32,6 +32,11 @@ namespace Aquamarine {
         void planeProps(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane, Hyprutils::Memory::CSharedPointer<CDRMFB> fb, uint32_t crtc, Hyprutils::Math::Vector2D pos);
         void planePropsPos(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane, Hyprutils::Math::Vector2D pos);
 
+        void resetProps(uint32_t id, const std::vector<uint32_t>& props);
+        void resetUnknownProps(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector);
+        void resetUnknownProps(Hyprutils::Memory::CSharedPointer<SDRMCRTC> crtc);
+        void resetUnknownProps(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane);
+
         void rollback(SDRMConnectorCommitData& data);
         void apply(SDRMConnectorCommitData& data);
 

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -183,10 +183,11 @@ namespace Aquamarine {
         };
 
         struct SPlaneData {
-            std::vector<SDRMFormat> renderFormats; // empty if unknown / not specified -> use getRenderFormats()
-            ePlaneType              type  = AQ_PLANE_UNKNOWN;
-            uint32_t                id    = 0;
-            uint32_t                index = 0;
+            std::vector<SDRMFormat>                       renderFormats; // empty if unknown / not specified -> use getRenderFormats()
+            ePlaneType                                    type  = AQ_PLANE_UNKNOWN;
+            uint32_t                                      id    = 0;
+            uint32_t                                      index = 0;
+            Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain;
         };
 
         virtual bool                                                      commit()           = 0;
@@ -222,6 +223,7 @@ namespace Aquamarine {
         Hyprutils::Memory::CSharedPointer<COutputState>             state = Hyprutils::Memory::makeShared<COutputState>();
 
         Hyprutils::Memory::CSharedPointer<CSwapchain>               swapchain;
+        Hyprutils::Memory::CSharedPointer<CSwapchain>               overlaySwapchain;
 
         //
 

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -203,6 +203,7 @@ namespace Aquamarine {
         virtual bool                                                      pendingPageFlip()  = 0;
         virtual bool                                                      pendingIdleFrame() = 0;
         virtual std::vector<SPlaneData>                                   getPlanes();
+        virtual std::optional<SPlaneData>                                 getOverlayPlane();
 
         std::string                                                       name, description, make, model, serial;
         SParsedEDID                                                       parsedEDID;

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 #include <optional>
 #include <hyprutils/signal/Signal.hpp>
@@ -58,6 +59,16 @@ namespace Aquamarine {
             AQ_OUTPUT_STATE_WCG                = (1 << 13),
             AQ_OUTPUT_STATE_CURSOR_SHAPE       = (1 << 14),
             AQ_OUTPUT_STATE_CURSOR_POS         = (1 << 15),
+            AQ_OUTPUT_STATE_PLANE_STATE        = (1 << 16),
+        };
+
+        struct SPlaneState {
+            bool                                       updated = false;
+
+            bool                                       enabled = false;
+            Hyprutils::Math::CRegion                   damage;
+            Hyprutils::Math::CBox                      geometry;
+            Hyprutils::Memory::CSharedPointer<IBuffer> buffer;
         };
 
         struct SInternalState {
@@ -79,6 +90,7 @@ namespace Aquamarine {
             bool                                           wideColorGamut = false;
             hdr_output_metadata                            hdrMetadata;
             uint16_t                                       contentType = DRM_MODE_CONTENT_TYPE_GRAPHICS;
+            std::vector<SPlaneState>                       planeStates;
         };
 
         const SInternalState& state();
@@ -101,6 +113,11 @@ namespace Aquamarine {
         void                  setWideColorGamut(bool wcg);
         void                  setHDRMetadata(const hdr_output_metadata& metadata);
         void                  setContentType(const uint16_t drmContentType);
+
+        void                  setPlaneEnabled(uint32_t planeIdx, bool enabled);
+        void                  setPlaneBuffer(uint32_t planeIdx, Hyprutils::Memory::CSharedPointer<IBuffer> buffer);
+        void                  setPlaneGeometry(uint32_t planeIdx, const Hyprutils::Math::CBox& box);
+        void                  addPlaneDamage(uint32_t planeIdx, const Hyprutils::Math::CRegion& region);
 
       private:
         SInternalState internalState;
@@ -158,6 +175,18 @@ namespace Aquamarine {
             bool                               supportsBT2020 = false;
         };
 
+        enum ePlaneType : uint32_t {
+            AQ_PLANE_UNKNOWN = 0,
+            AQ_PLANE_PRIMARY,
+            AQ_PLANE_GENERIC,
+            AQ_PLANE_CURSOR,
+        };
+
+        struct SPlaneData {
+            std::vector<SDRMFormat> renderFormats; // empty if unknown / not specified -> use getRenderFormats()
+            ePlaneType              type = AQ_PLANE_UNKNOWN;
+        };
+
         virtual bool                                                      commit()           = 0;
         virtual bool                                                      test()             = 0;
         virtual Hyprutils::Memory::CSharedPointer<IBackendImplementation> getBackend()       = 0;
@@ -173,6 +202,7 @@ namespace Aquamarine {
         virtual bool                                                      destroy(); // not all backends allow this!!!
         virtual bool                                                      pendingPageFlip()  = 0;
         virtual bool                                                      pendingIdleFrame() = 0;
+        virtual std::vector<SPlaneData>                                   getPlanes();
 
         std::string                                                       name, description, make, model, serial;
         SParsedEDID                                                       parsedEDID;

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -184,7 +184,9 @@ namespace Aquamarine {
 
         struct SPlaneData {
             std::vector<SDRMFormat> renderFormats; // empty if unknown / not specified -> use getRenderFormats()
-            ePlaneType              type = AQ_PLANE_UNKNOWN;
+            ePlaneType              type  = AQ_PLANE_UNKNOWN;
+            uint32_t                id    = 0;
+            uint32_t                index = 0;
         };
 
         virtual bool                                                      commit()           = 0;

--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -240,7 +240,7 @@ int Aquamarine::CBackend::drmRenderNodeFD() {
 }
 
 bool Aquamarine::CBackend::hasSession() {
-    return session;
+    return (bool)session;
 }
 
 std::vector<SDRMFormat> Aquamarine::CBackend::getPrimaryRenderFormats() {

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -530,6 +530,11 @@ bool Aquamarine::CDRMBackend::checkFeatures() {
         return false;
     }
 
+#ifdef DRM_CLIENT_CAP_PLANE_COLOR_PIPELINE
+    if (drmSetClientCap(gpu->fd, DRM_CLIENT_CAP_PLANE_COLOR_PIPELINE, 1))
+        backend->log(AQ_LOG_WARNING, std::format("drm: DRM_CLIENT_CAP_PLANE_COLOR_PIPELINE unsupported"));
+#endif
+
     drmProps.supportsAsyncCommit = drmGetCap(gpu->fd, DRM_CAP_ASYNC_PAGE_FLIP, &cap) == 0 && cap == 1;
     drmProps.supportsTimelines   = drmGetCap(gpu->fd, DRM_CAP_SYNCOBJ_TIMELINE, &cap) == 0 && cap == 1;
 
@@ -1330,6 +1335,15 @@ bool Aquamarine::SDRMPlane::init(drmModePlane* plane) {
 
     if (!getDRMPlaneProps(backend->gpu->fd, id, &props, unknownProperies))
         return false;
+
+    for (const auto& id : unknownProperies) {
+        drmModePropertyRes* prop = drmModeGetProperty(backend->gpu->fd, id);
+        if (!prop)
+            continue;
+
+        backend->backend->log(AQ_LOG_DEBUG, std::format("drm: unknown prop {} ({})", id, prop->name));
+        drmModeFreeProperty(prop);
+    }
 
     if (!getDRMProp(backend->gpu->fd, id, props.values.type, &type))
         return false;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1447,6 +1447,8 @@ bool Aquamarine::SDRMConnector::init(drmModeConnector* connector) {
         return false;
     if (props.values.Colorspace)
         getDRMConnectorColorspace(backend->gpu->fd, props.values.Colorspace, &colorspace);
+    if (props.values.BroadcastRGB)
+        getDRMConnectorBroadcastRGB(backend->gpu->fd, props.values.BroadcastRGB, &broadcastRGB);
 
     auto name = drmModeGetConnectorTypeName(connector->connector_type);
     if (!name)
@@ -1690,6 +1692,9 @@ void Aquamarine::SDRMConnector::recheckCRTCProps() {
 
     backend->backend->log(AQ_LOG_DEBUG,
                           std::format("drm: connector {} crtc {} Colorspace ({})", szName, (props.values.Colorspace ? "supports" : "doesn't support"), props.values.Colorspace));
+
+    backend->backend->log(
+        AQ_LOG_DEBUG, std::format("drm: connector {} crtc {} Broadcast RGB ({})", szName, (props.values.BroadcastRGB ? "supports" : "doesn't support"), props.values.BroadcastRGB));
 }
 
 void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1381,11 +1381,19 @@ bool Aquamarine::SDRMPlane::init(drmModePlane* plane) {
         auto CRTC = backend->crtcs.at(i);
         if (type == DRM_PLANE_TYPE_PRIMARY && !CRTC->primary) {
             CRTC->primary = self.lock();
+            TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("drm: CRTC {} gets assigned plane {} as primary", CRTC->id, id)));
             break;
         }
 
         if (type == DRM_PLANE_TYPE_CURSOR && !CRTC->cursor) {
             CRTC->cursor = self.lock();
+            TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("drm: CRTC {} gets assigned plane {} as cursor", CRTC->id, id)));
+            break;
+        }
+
+        if (std::find(CRTC->planes.begin(), CRTC->planes.end(), self) == CRTC->planes.end()) {
+            CRTC->planes.emplace_back(self.lock());
+            TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("drm: CRTC {} gets added plane {} as general-purpose misc", CRTC->id, id)));
             break;
         }
     }

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -2437,11 +2437,17 @@ std::optional<Aquamarine::IOutput::SPlaneData> Aquamarine::CDRMOutput::getOverla
         return {};
     const auto& overlay = connector->crtc->planes.back();
     ASSERT(overlay->type == DRM_PLANE_TYPE_OVERLAY);
+    if (!overlaySwapchain) {
+        auto primaryBackend = backend->primary ? backend->primary : backend;
+        swapchain           = CSwapchain::create(backend->backend->primaryAllocator, primaryBackend.lock());
+        overlaySwapchain->reconfigure(SSwapchainOptions{.length = 0, .scanout = true, .multigpu = !!backend->primary, .scanoutOutput = self});
+    }
     return Aquamarine::IOutput::SPlaneData{
         .renderFormats = overlay->formats,
         .type          = AQ_PLANE_GENERIC,
         .id            = overlay->id,
         .index         = (uint32_t)(connector->crtc->planes.size() - 1),
+        .swapchain     = overlaySwapchain,
     };
 }
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -647,16 +647,16 @@ bool Aquamarine::CDRMBackend::initResources() {
 
     success = true;
 
-    for (const auto& crtc : crtcs) {}
+    //for (const auto& crtc : crtcs) {}
 
-    drmModeFreePlaneResources(planeResources);
-    drmModeFreeResources(resources);
+    //drmModeFreePlaneResources(planeResources);
+    //drmModeFreeResources(resources);
 
     return success;
 }
 
 bool Aquamarine::CDRMBackend::shouldBlit() {
-    return primary;
+    return (bool)primary;
 }
 
 bool Aquamarine::CDRMBackend::initMgpu() {

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -641,7 +641,13 @@ bool Aquamarine::CDRMBackend::initResources() {
     }
 
     success = true;
-    return true;
+
+    for (const auto& crtc : crtcs) {}
+
+    drmModeFreePlaneResources(planeResources);
+    drmModeFreeResources(resources);
+
+    return success;
 }
 
 bool Aquamarine::CDRMBackend::shouldBlit() {
@@ -1327,6 +1333,9 @@ bool Aquamarine::SDRMPlane::init(drmModePlane* plane) {
 
     if (!getDRMProp(backend->gpu->fd, id, props.values.type, &type))
         return false;
+
+    if (props.values.color_range)
+        getDRMPlaneColorRange(backend->gpu->fd, props.values.color_range, &colorRange);
 
     initialID = id;
 
@@ -2409,6 +2418,33 @@ bool Aquamarine::CDRMOutput::pendingIdleFrame() {
     return connector->frameEventScheduled;
 }
 
+std::vector<Aquamarine::IOutput::SPlaneData> Aquamarine::CDRMOutput::getPlanes() {
+    std::vector<Aquamarine::IOutput::SPlaneData> result(connector->crtc->planes.size());
+    uint32_t                                     i = 0;
+    for (const auto& p : connector->crtc->planes) {
+        result.push_back(Aquamarine::IOutput::SPlaneData{
+            .renderFormats = p->formats,
+            .type          = AQ_PLANE_GENERIC,
+            .id            = p->id,
+            .index         = i++,
+        });
+    }
+    return result;
+}
+
+std::optional<Aquamarine::IOutput::SPlaneData> Aquamarine::CDRMOutput::getOverlayPlane() {
+    if (!connector || !connector->crtc || !connector->crtc->planes.size())
+        return {};
+    const auto& overlay = connector->crtc->planes.back();
+    ASSERT(overlay->type == DRM_PLANE_TYPE_OVERLAY);
+    return Aquamarine::IOutput::SPlaneData{
+        .renderFormats = overlay->formats,
+        .type          = AQ_PLANE_GENERIC,
+        .id            = overlay->id,
+        .index         = (uint32_t)(connector->crtc->planes.size() - 1),
+    };
+}
+
 int Aquamarine::CDRMOutput::getConnectorID() {
     return connector->id;
 }
@@ -2431,6 +2467,8 @@ Aquamarine::CDRMOutput::CDRMOutput(const std::string& name_, Hyprutils::Memory::
             connector->frameEventScheduled = false;
         }
     });
+
+    state->internalState.planeStates.resize(connector->crtc->planes.size());
 }
 
 SP<CDRMFB> Aquamarine::CDRMFB::create(SP<IBuffer> buffer_, Hyprutils::Memory::CWeakPointer<CDRMBackend> backend_, bool* isNew) {

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -2453,7 +2453,7 @@ std::optional<Aquamarine::IOutput::SPlaneData> Aquamarine::CDRMOutput::getOverla
     ASSERT(overlay->type == DRM_PLANE_TYPE_OVERLAY);
     if (!overlaySwapchain) {
         auto primaryBackend = backend->primary ? backend->primary : backend;
-        swapchain           = CSwapchain::create(backend->backend->primaryAllocator, primaryBackend.lock());
+        overlaySwapchain    = CSwapchain::create(backend->backend->primaryAllocator, primaryBackend.lock());
         overlaySwapchain->reconfigure(SSwapchainOptions{.length = 0, .scanout = true, .multigpu = !!backend->primary, .scanoutOutput = self});
     }
     return Aquamarine::IOutput::SPlaneData{

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -596,7 +596,7 @@ bool Aquamarine::CDRMBackend::initResources() {
 
         CRTC->legacy.gammaSize = drmCRTC->gamma_size;
 
-        if (!getDRMCRTCProps(gpu->fd, CRTC->id, &CRTC->props)) {
+        if (!getDRMCRTCProps(gpu->fd, CRTC->id, &CRTC->props, CRTC->unknownProperies)) {
             backend->log(AQ_LOG_ERROR, std::format("drm: getDRMCRTCProps for crtc {} failed", CRTC->id));
             return false;
         }
@@ -1328,7 +1328,7 @@ Hyprutils::Memory::CWeakPointer<IBackendImplementation> Aquamarine::CDRMBackend:
 bool Aquamarine::SDRMPlane::init(drmModePlane* plane) {
     id = plane->plane_id;
 
-    if (!getDRMPlaneProps(backend->gpu->fd, id, &props))
+    if (!getDRMPlaneProps(backend->gpu->fd, id, &props, unknownProperies))
         return false;
 
     if (!getDRMProp(backend->gpu->fd, id, props.values.type, &type))
@@ -1452,7 +1452,7 @@ SP<SDRMCRTC> Aquamarine::SDRMConnector::getCurrentCRTC(const drmModeConnector* c
 bool Aquamarine::SDRMConnector::init(drmModeConnector* connector) {
     pendingPageFlip.connector = self.lock();
 
-    if (!getDRMConnectorProps(backend->gpu->fd, id, &props))
+    if (!getDRMConnectorProps(backend->gpu->fd, id, &props, unknownProperies))
         return false;
     if (props.values.Colorspace)
         getDRMConnectorColorspace(backend->gpu->fd, props.values.Colorspace, &colorspace);

--- a/src/backend/drm/Props.cpp
+++ b/src/backend/drm/Props.cpp
@@ -22,6 +22,7 @@ static const struct prop_info connector_info[] = {
 #define INDEX(name) (offsetof(SDRMConnector::UDRMConnectorProps, values.name) / sizeof(uint32_t))
     {.name = "CRTC_ID", .index = INDEX(crtc_id)},
     {.name = "Colorspace", .index = INDEX(Colorspace)},
+    {.name = "Broadcast RGB", .index = INDEX(BroadcastRGB)},
     {.name = "DPMS", .index = INDEX(dpms)},
     {.name = "EDID", .index = INDEX(edid)},
     {.name = "HDR_OUTPUT_METADATA", .index = INDEX(hdr_output_metadata)},
@@ -42,6 +43,14 @@ static const struct prop_info colorspace_info[] = {
     {.name = "BT2020_RGB", .index = INDEX(BT2020_RGB)},
     {.name = "BT2020_YCC", .index = INDEX(BT2020_YCC)},
     {.name = "Default", .index = INDEX(Default)},
+#undef INDEX
+};
+
+static const struct prop_info broadcast_rgb_info[] = {
+#define INDEX(name) (offsetof(SDRMConnector::UDRMConnectorBroadcastRGB, values.name) / sizeof(uint32_t))
+    {.name = "Automatic", .index = INDEX(Automatic)},
+    {.name = "Full", .index = INDEX(Full)},
+    {.name = "Limited 16:235", .index = INDEX(Limited)},
 #undef INDEX
 };
 
@@ -129,6 +138,10 @@ namespace Aquamarine {
 
     bool getDRMConnectorColorspace(int fd, uint32_t id, SDRMConnector::UDRMConnectorColorspace* out) {
         return scanPropertyEnum(fd, id, out->props, colorspace_info, sizeof(colorspace_info) / sizeof(colorspace_info[0]));
+    }
+
+    bool getDRMConnectorBroadcastRGB(int fd, uint32_t id, SDRMConnector::UDRMConnectorBroadcastRGB* out) {
+        return scanPropertyEnum(fd, id, out->props, broadcast_rgb_info, sizeof(broadcast_rgb_info) / sizeof(broadcast_rgb_info[0]));
     }
 
     bool getDRMCRTCProps(int fd, uint32_t id, SDRMCRTC::UDRMCRTCProps* out) {

--- a/src/backend/drm/Props.cpp
+++ b/src/backend/drm/Props.cpp
@@ -103,7 +103,7 @@ namespace Aquamarine {
         return strcmp(key, elem->name);
     }
 
-    static bool scanProperties(int fd, uint32_t id, uint32_t type, uint32_t* result, const prop_info* info, size_t info_len) {
+    static bool scanProperties(int fd, uint32_t id, uint32_t type, uint32_t* result, const prop_info* info, size_t info_len, std::vector<uint32_t>& unknownProperies) {
         drmModeObjectProperties* props = drmModeObjectGetProperties(fd, id, type);
         if (!props)
             return false;
@@ -116,6 +116,8 @@ namespace Aquamarine {
             const prop_info* p = (prop_info*)bsearch(prop->name, info, info_len, sizeof(info[0]), comparePropInfo);
             if (p)
                 result[p->index] = prop->prop_id;
+            else
+                unknownProperies.push_back(prop->prop_id);
 
             drmModeFreeProperty(prop);
         }
@@ -140,8 +142,8 @@ namespace Aquamarine {
         return true;
     }
 
-    bool getDRMConnectorProps(int fd, uint32_t id, SDRMConnector::UDRMConnectorProps* out) {
-        return scanProperties(fd, id, DRM_MODE_OBJECT_CONNECTOR, out->props, connector_info, sizeof(connector_info) / sizeof(connector_info[0]));
+    bool getDRMConnectorProps(int fd, uint32_t id, SDRMConnector::UDRMConnectorProps* out, std::vector<uint32_t>& unknownProperies) {
+        return scanProperties(fd, id, DRM_MODE_OBJECT_CONNECTOR, out->props, connector_info, sizeof(connector_info) / sizeof(connector_info[0]), unknownProperies);
     }
 
     bool getDRMConnectorColorspace(int fd, uint32_t id, SDRMConnector::UDRMConnectorColorspace* out) {
@@ -152,12 +154,12 @@ namespace Aquamarine {
         return scanPropertyEnum(fd, id, out->props, broadcast_rgb_info, sizeof(broadcast_rgb_info) / sizeof(broadcast_rgb_info[0]));
     }
 
-    bool getDRMCRTCProps(int fd, uint32_t id, SDRMCRTC::UDRMCRTCProps* out) {
-        return scanProperties(fd, id, DRM_MODE_OBJECT_CRTC, out->props, crtc_info, sizeof(crtc_info) / sizeof(crtc_info[0]));
+    bool getDRMCRTCProps(int fd, uint32_t id, SDRMCRTC::UDRMCRTCProps* out, std::vector<uint32_t>& unknownProperies) {
+        return scanProperties(fd, id, DRM_MODE_OBJECT_CRTC, out->props, crtc_info, sizeof(crtc_info) / sizeof(crtc_info[0]), unknownProperies);
     }
 
-    bool getDRMPlaneProps(int fd, uint32_t id, SDRMPlane::UDRMPlaneProps* out) {
-        return scanProperties(fd, id, DRM_MODE_OBJECT_PLANE, out->props, plane_info, sizeof(plane_info) / sizeof(plane_info[0]));
+    bool getDRMPlaneProps(int fd, uint32_t id, SDRMPlane::UDRMPlaneProps* out, std::vector<uint32_t>& unknownProperies) {
+        return scanProperties(fd, id, DRM_MODE_OBJECT_PLANE, out->props, plane_info, sizeof(plane_info) / sizeof(plane_info[0]), unknownProperies);
     }
 
     bool getDRMPlaneColorRange(int fd, uint32_t id, SDRMPlane::UDRMPlanePropsColorRange* out) {

--- a/src/backend/drm/Props.cpp
+++ b/src/backend/drm/Props.cpp
@@ -66,6 +66,7 @@ static const struct prop_info crtc_info[] = {
 
 static const struct prop_info plane_info[] = {
 #define INDEX(name) (offsetof(SDRMPlane::UDRMPlaneProps, values.name) / sizeof(uint32_t))
+    {.name = "COLOR_RANGE", .index = INDEX(color_range)},
     {.name = "CRTC_H", .index = INDEX(crtc_h)},
     {.name = "CRTC_ID", .index = INDEX(crtc_id)},
     {.name = "CRTC_W", .index = INDEX(crtc_w)},
@@ -83,6 +84,13 @@ static const struct prop_info plane_info[] = {
     {.name = "SRC_Y", .index = INDEX(src_y)},
     {.name = "rotation", .index = INDEX(rotation)},
     {.name = "type", .index = INDEX(type)},
+#undef INDEX
+};
+
+static const struct prop_info color_range_info[] = {
+#define INDEX(name) (offsetof(SDRMPlane::UDRMPlanePropsColorRange, values.name) / sizeof(uint32_t))
+    {.name = "YCbCr limited range", .index = INDEX(limited)},
+    {.name = "YCbCr full range", .index = INDEX(full)},
 #undef INDEX
 };
 
@@ -150,6 +158,10 @@ namespace Aquamarine {
 
     bool getDRMPlaneProps(int fd, uint32_t id, SDRMPlane::UDRMPlaneProps* out) {
         return scanProperties(fd, id, DRM_MODE_OBJECT_PLANE, out->props, plane_info, sizeof(plane_info) / sizeof(plane_info[0]));
+    }
+
+    bool getDRMPlaneColorRange(int fd, uint32_t id, SDRMPlane::UDRMPlanePropsColorRange* out) {
+        return scanPropertyEnum(fd, id, out->props, color_range_info, sizeof(color_range_info) / sizeof(color_range_info[0]));
     }
 
     bool getDRMProp(int fd, uint32_t obj, uint32_t prop, uint64_t* ret) {

--- a/src/backend/drm/Props.hpp
+++ b/src/backend/drm/Props.hpp
@@ -8,6 +8,7 @@ namespace Aquamarine {
     bool  getDRMConnectorBroadcastRGB(int fd, uint32_t id, SDRMConnector::UDRMConnectorBroadcastRGB* out);
     bool  getDRMCRTCProps(int fd, uint32_t id, SDRMCRTC::UDRMCRTCProps* out);
     bool  getDRMPlaneProps(int fd, uint32_t id, SDRMPlane::UDRMPlaneProps* out);
+    bool  getDRMPlaneColorRange(int fd, uint32_t id, SDRMPlane::UDRMPlanePropsColorRange* out);
     bool  getDRMProp(int fd, uint32_t obj, uint32_t prop, uint64_t* ret);
     void* getDRMPropBlob(int fd, uint32_t obj, uint32_t prop, size_t* ret_len);
     char* getDRMPropEnum(int fd, uint32_t obj, uint32_t prop_id);

--- a/src/backend/drm/Props.hpp
+++ b/src/backend/drm/Props.hpp
@@ -3,11 +3,11 @@
 #include <aquamarine/backend/DRM.hpp>
 
 namespace Aquamarine {
-    bool  getDRMConnectorProps(int fd, uint32_t id, SDRMConnector::UDRMConnectorProps* out);
+    bool  getDRMConnectorProps(int fd, uint32_t id, SDRMConnector::UDRMConnectorProps* out, std::vector<uint32_t>& unknownProperies);
     bool  getDRMConnectorColorspace(int fd, uint32_t id, SDRMConnector::UDRMConnectorColorspace* out);
     bool  getDRMConnectorBroadcastRGB(int fd, uint32_t id, SDRMConnector::UDRMConnectorBroadcastRGB* out);
-    bool  getDRMCRTCProps(int fd, uint32_t id, SDRMCRTC::UDRMCRTCProps* out);
-    bool  getDRMPlaneProps(int fd, uint32_t id, SDRMPlane::UDRMPlaneProps* out);
+    bool  getDRMCRTCProps(int fd, uint32_t id, SDRMCRTC::UDRMCRTCProps* out, std::vector<uint32_t>& unknownProperies);
+    bool  getDRMPlaneProps(int fd, uint32_t id, SDRMPlane::UDRMPlaneProps* out, std::vector<uint32_t>& unknownProperies);
     bool  getDRMPlaneColorRange(int fd, uint32_t id, SDRMPlane::UDRMPlanePropsColorRange* out);
     bool  getDRMProp(int fd, uint32_t obj, uint32_t prop, uint64_t* ret);
     void* getDRMPropBlob(int fd, uint32_t obj, uint32_t prop, size_t* ret_len);

--- a/src/backend/drm/Props.hpp
+++ b/src/backend/drm/Props.hpp
@@ -5,6 +5,7 @@
 namespace Aquamarine {
     bool  getDRMConnectorProps(int fd, uint32_t id, SDRMConnector::UDRMConnectorProps* out);
     bool  getDRMConnectorColorspace(int fd, uint32_t id, SDRMConnector::UDRMConnectorColorspace* out);
+    bool  getDRMConnectorBroadcastRGB(int fd, uint32_t id, SDRMConnector::UDRMConnectorBroadcastRGB* out);
     bool  getDRMCRTCProps(int fd, uint32_t id, SDRMCRTC::UDRMCRTCProps* out);
     bool  getDRMPlaneProps(int fd, uint32_t id, SDRMPlane::UDRMPlaneProps* out);
     bool  getDRMProp(int fd, uint32_t obj, uint32_t prop, uint64_t* ret);

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -107,6 +107,8 @@ void Aquamarine::CDRMAtomicRequest::planeProps(Hyprutils::Memory::CSharedPointer
     add(plane->id, plane->props.values.crtc_h, (uint32_t)fb->buffer->size.y);
     add(plane->id, plane->props.values.fb_id, fb->id);
     add(plane->id, plane->props.values.crtc_id, crtc);
+    if (plane->props.values.color_range && plane->colorRange.values.full)
+        add(plane->id, plane->props.values.color_range, plane->colorRange.values.full);
     planePropsPos(plane, pos);
 }
 
@@ -215,6 +217,11 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
             add(connector->crtc->id, connector->crtc->props.values.vrr_enabled, (uint64_t)STATE.adaptiveSync);
 
         planeProps(connector->crtc->primary, data.mainFB, connector->crtc->id, {});
+        int i = 0;
+        for (const auto& state : connector->output->state->state().planeStates) {
+            const auto& plane = connector->crtc->planes.at(i);
+            // TODO
+        }
 
         if (connector->output->supportsExplicit && STATE.explicitInFence >= 0)
             add(connector->crtc->primary->id, connector->crtc->primary->props.values.in_fence_fd, STATE.explicitInFence);
@@ -223,6 +230,9 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
             add(connector->crtc->primary->id, connector->crtc->primary->props.values.fb_damage_clips, data.atomic.fbDamage);
     } else {
         planeProps(connector->crtc->primary, nullptr, 0, {});
+        for (const auto& plane : connector->crtc->planes) {
+            planeProps(plane, nullptr, 0, {});
+        }
     }
 }
 

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -219,8 +219,16 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
         planeProps(connector->crtc->primary, data.mainFB, connector->crtc->id, {});
         int i = 0;
         for (const auto& state : connector->output->state->state().planeStates) {
-            const auto& plane = connector->crtc->planes.at(i);
-            // TODO
+            if (state.updated) {
+                const auto& plane = connector->crtc->planes.at(i);
+                if (state.enabled) {
+                    // TODO
+                    // planeProps(plane, , 0, {});
+                    // add(plane->id, plane->props.values.fb_damage_clips, );
+                } else
+                    planeProps(plane, nullptr, 0, {});
+            }
+            i++;
         }
 
         if (connector->output->supportsExplicit && STATE.explicitInFence >= 0)

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <cstring>
 #include <drm_mode.h>
+#include <vector>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <sys/mman.h>
@@ -193,10 +194,10 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
             add(connector->id, connector->props.values.content_type, newContentType);
     }
 
-    data.atomic.maxBpc       = newMaxBpc;
-    data.atomic.colorspace   = newColorspace;
-    data.atomic.contentType  = newContentType;
-    data.atomic.crtcID       = newCrtcID;
+    data.atomic.maxBpc      = newMaxBpc;
+    data.atomic.colorspace  = newColorspace;
+    data.atomic.contentType = newContentType;
+    data.atomic.crtcID      = newCrtcID;
 
     add(connector->crtc->id, connector->crtc->props.values.active, enable);
 
@@ -334,6 +335,36 @@ void Aquamarine::CDRMAtomicRequest::rollbackBlob(uint32_t* current, uint32_t nex
     if (*current == next)
         return;
     destroyBlob(next);
+}
+
+void Aquamarine::CDRMAtomicRequest::resetProps(uint32_t id, const std::vector<uint32_t>& props) {
+    for (auto prop : props) {
+        add(id, prop, 0);
+    }
+}
+
+void Aquamarine::CDRMAtomicRequest::resetUnknownProps(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector) {
+    if (!connector)
+        return;
+    resetProps(connector->id, connector->unknownProperies);
+    resetUnknownProps(connector->crtc);
+}
+
+void Aquamarine::CDRMAtomicRequest::resetUnknownProps(Hyprutils::Memory::CSharedPointer<SDRMCRTC> crtc) {
+    if (!crtc)
+        return;
+    resetProps(crtc->id, crtc->unknownProperies);
+    resetUnknownProps(crtc->primary);
+    resetUnknownProps(crtc->cursor);
+    for (const auto& plane : crtc->planes) {
+        resetUnknownProps(plane);
+    }
+}
+
+void Aquamarine::CDRMAtomicRequest::resetUnknownProps(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane) {
+    if (!plane)
+        return;
+    resetProps(plane->id, plane->unknownProperies);
 }
 
 void Aquamarine::CDRMAtomicRequest::rollback(SDRMConnectorCommitData& data) {

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -172,6 +172,9 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
                 add(connector->id, connector->props.values.Colorspace, newColorspace);
         }
 
+        if (connector->props.values.BroadcastRGB && connector->broadcastRGB.values.Full)
+            add(connector->id, connector->props.values.BroadcastRGB, connector->broadcastRGB.values.Full);
+
         if (connector->props.values.hdr_output_metadata && data.atomic.hdrd)
             add(connector->id, connector->props.values.hdr_output_metadata, data.atomic.hdrBlob);
     } else

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -51,6 +51,10 @@ std::vector<Aquamarine::IOutput::SPlaneData> Aquamarine::IOutput::getPlanes() {
     return {{.renderFormats = {}, .type = AQ_PLANE_PRIMARY}};
 }
 
+std::optional<Aquamarine::IOutput::SPlaneData> Aquamarine::IOutput::getOverlayPlane() {
+    return {};
+}
+
 const Aquamarine::COutputState::SInternalState& Aquamarine::COutputState::state() {
     return internalState;
 }

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -47,6 +47,10 @@ bool Aquamarine::IOutput::destroy() {
     return false;
 }
 
+std::vector<Aquamarine::IOutput::SPlaneData> Aquamarine::IOutput::getPlanes() {
+    return {{.renderFormats = {}, .type = AQ_PLANE_PRIMARY}};
+}
+
 const Aquamarine::COutputState::SInternalState& Aquamarine::COutputState::state() {
     return internalState;
 }
@@ -142,7 +146,52 @@ void Aquamarine::COutputState::setContentType(const uint16_t drmContentType) {
     internalState.contentType = drmContentType;
 }
 
+void Aquamarine::COutputState::setPlaneEnabled(uint32_t planeIdx, bool enabled) {
+    if (planeIdx >= internalState.planeStates.size())
+        return;
+
+    internalState.planeStates.at(planeIdx).enabled = enabled;
+    internalState.planeStates.at(planeIdx).updated = true;
+
+    internalState.committed |= AQ_OUTPUT_STATE_PLANE_STATE;
+}
+
+void Aquamarine::COutputState::setPlaneBuffer(uint32_t planeIdx, Hyprutils::Memory::CSharedPointer<IBuffer> buffer) {
+    if (planeIdx >= internalState.planeStates.size())
+        return;
+
+    internalState.planeStates.at(planeIdx).buffer  = buffer;
+    internalState.planeStates.at(planeIdx).updated = true;
+
+    internalState.committed |= AQ_OUTPUT_STATE_PLANE_STATE;
+}
+
+void Aquamarine::COutputState::setPlaneGeometry(uint32_t planeIdx, const Hyprutils::Math::CBox& box) {
+    if (planeIdx >= internalState.planeStates.size())
+        return;
+
+    internalState.planeStates.at(planeIdx).geometry = box;
+    internalState.planeStates.at(planeIdx).updated  = true;
+
+    internalState.committed |= AQ_OUTPUT_STATE_PLANE_STATE;
+}
+
+void Aquamarine::COutputState::addPlaneDamage(uint32_t planeIdx, const Hyprutils::Math::CRegion& region) {
+    if (planeIdx >= internalState.planeStates.size())
+        return;
+
+    internalState.planeStates.at(planeIdx).damage.add(region);
+    internalState.planeStates.at(planeIdx).updated = true;
+
+    internalState.committed |= AQ_OUTPUT_STATE_PLANE_STATE;
+}
+
 void Aquamarine::COutputState::onCommit() {
     internalState.committed = 0;
     internalState.damage.clear();
+
+    for (auto& p : internalState.planeStates) {
+        p.damage.clear();
+        p.updated = false;
+    }
 }


### PR DESCRIPTION
Most of the HW have at least 3 planes per crtc: primary, cursor and overlay. On nvidia it's max 3 planes. Not sure about other HW. This PR focuses on adding support for an overlay plane. It'll be used to avoid leaving DS when a notification/special workspace or something similar shows up above fullscreen window.
May include some extra features.

- [x] track extra planes states
- [x] commit extra planes states
- [ ] hl overlay PR https://github.com/hyprwm/Hyprland/pull/14655
- [ ] reset unknown properties 
- [ ] ~~handle drm color pipeline and vendor-specific CM props~~
- [ ] ~~provide an api to hide vendor-specific CM details and drm color pipeline implementation differences~~
- [ ] ~~hl CM PR~~

Includes #96