### PR TITLE
Fix DisplayLink/evdi monitor hotplug

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -450,6 +450,8 @@ namespace Aquamarine {
             Hyprutils::Memory::CSharedPointer<CDRMRenderer> renderer; // may be null if creation fails
         } rendererState;
 
+        bool                                                          rendererRequired = true;
+
         Hyprutils::Memory::CWeakPointer<CBackend>                     backend;
 
         std::vector<Hyprutils::Memory::CSharedPointer<SDRMCRTC>>      crtcs;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -626,6 +626,9 @@ bool Aquamarine::CDRMBackend::shouldBlit() {
 }
 
 bool Aquamarine::CDRMBackend::initMgpu() {
+    if (!rendererRequired)
+        return true;
+
     SP<CGBMAllocator> newAllocator;
     if (primary || backend->primaryAllocator->type() != AQ_ALLOCATOR_TYPE_GBM) {
         newAllocator            = CGBMAllocator::create(backend->reopenDRMNode(gpu->fd), backend);
@@ -853,8 +856,11 @@ bool Aquamarine::CDRMBackend::registerGPU(SP<CSessionDevice> gpu_, SP<CDRMBacken
     gpuName = drmName;
 
     auto drmVerName = drmVer->name ? drmVer->name : "unknown";
-    if (std::string_view(drmVerName) == "evdi")
+    if (std::string_view(drmVerName) == "evdi") {
+        // DisplayLink/evdi exposes KMS without a usable EGL renderer.
         primary = {};
+        rendererRequired = false;
+    }
 
     backend->log(AQ_LOG_DEBUG,
                  std::format("drm: Starting backend for {}, with driver {}{}", drmName ? drmName : "unknown", drmVerName,
@@ -1171,7 +1177,7 @@ void Aquamarine::CDRMBackend::onReady() {
 
     // init a drm renderer to gather gl formats.
     // if we are secondary, initMgpu will have done that
-    if (!primary) {
+    if (!primary && rendererRequired) {
         auto a = CGBMAllocator::create(backend->reopenDRMNode(gpu->fd), backend);
         if (!a)
             backend->log(AQ_LOG_ERROR, "drm: onReady: no renderer for gl formats");


### PR DESCRIPTION
DisplayLink/evdi devices provide a KMS display device, but they do not provide a usable EGL renderer. Aquamarine already treats `evdi` as display-only, but after the secondary renderer lifetime changes, hotplugged connectors try to initialise a renderer before the output is announced. Since renderer creation failed for `evdi`, the connect path returned early and the evdi monitors never showed up.

The key logs that pointed to this were the following:

```text
CDRMRenderer(drm): drmGetDevice failed
CDRMRenderer(drm): Can't create renderer, no matching devices found
drm: initMgpu: no renderer
drm: Failed to update renderer state for DVI-I-* on connect
```

This change marks evdi backends as not needing a renderer, skips the startup renderer probe for them, and lets `initMgpu()` succeed for these display-only devices. Normal DRM GPUs still require renderer initialisation, but DisplayLink/evdi outputs can now finish connecting and be announced when hotplugged.

This fixes for me the regression, which was introduced in 0.11.