### PR TITLE
drm: deterministic page-flip scheduling + coalescing (#304, #306)

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -328,6 +328,12 @@ namespace Aquamarine {
 
         SDRMPageFlip                                   pendingPageFlip;
         CFrameScheduler                                sched;
+        // Latest-wins coalesce slot: a buffer-only commit that races an in-flight
+        // page-flip is stashed here (the kernel would return -EBUSY on a second flip)
+        // and drained from handlePF once the pending flip completes. A newer stashed
+        // commit replaces an older one; the displaced buffer is released.
+        std::optional<SDRMConnectorCommitData>         nextCommit;
+        void                                           releaseStashedCommit();
 
         // the current state is invalid and won't commit, don't try to modeset.
         bool                                           commitTainted = false;

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -4,7 +4,7 @@
 #include "../allocator/Swapchain.hpp"
 #include "../output/Output.hpp"
 #include "../input/Input.hpp"
-#include "drm/FrameScheduler.hpp"
+#include "FrameScheduler.hpp"
 #include <hyprutils/memory/WeakPtr.hpp>
 #include <wayland-client.h>
 #include <xf86drmMode.h>
@@ -227,6 +227,7 @@ namespace Aquamarine {
         Hyprutils::Memory::CWeakPointer<CDRMBackend>                 backend;
         Hyprutils::Memory::CSharedPointer<SDRMConnector>             connector;
         Hyprutils::Memory::CSharedPointer<std::function<void(void)>> frameIdle;
+        Hyprutils::Signal::CHyprSignalListener                       frameReadyListener;
 
         struct {
             Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain;

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -335,6 +335,13 @@ namespace Aquamarine {
         // commit replaces an older one; the displaced buffer is released.
         std::optional<SDRMConnectorCommitData>         nextCommit;
         void                                           releaseStashedCommit();
+        // Releases the buffers held by a commit; does not touch nextCommit. Shared
+        // by releaseStashedCommit() and drainStashedCommit()'s drop path.
+        void                                           releaseCommitBuffers(SDRMConnectorCommitData& commit);
+        // Drain the coalesce slot (submit the stashed commit, or drop it if a
+        // newer flip is already in flight / the output went away). Called from
+        // handlePF once the pending flip completes.
+        void                                           drainStashedCommit();
 
         // the current state is invalid and won't commit, don't try to modeset.
         bool                                           commitTainted = false;

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -4,6 +4,7 @@
 #include "../allocator/Swapchain.hpp"
 #include "../output/Output.hpp"
 #include "../input/Input.hpp"
+#include "drm/FrameScheduler.hpp"
 #include <hyprutils/memory/WeakPtr.hpp>
 #include <wayland-client.h>
 #include <xf86drmMode.h>
@@ -325,11 +326,8 @@ namespace Aquamarine {
         Hyprutils::Math::Vector2D                      cursorPos, cursorSize, cursorHotspot;
         Hyprutils::Memory::CSharedPointer<CDRMFB>      pendingCursorFB;
 
-        bool                                           isPageFlipPending   = false;
-        uint64_t                                       pageFlipPendingAtMs = 0; // CLOCK_BOOTTIME ms when isPageFlipPending was set
         SDRMPageFlip                                   pendingPageFlip;
-        bool                                           frameEventScheduled = false;
-        bool                                           isFrameRunning      = false;
+        CFrameScheduler                                sched;
 
         // the current state is invalid and won't commit, don't try to modeset.
         bool                                           commitTainted = false;

--- a/include/aquamarine/backend/FrameScheduler.hpp
+++ b/include/aquamarine/backend/FrameScheduler.hpp
@@ -13,51 +13,31 @@ namespace Aquamarine {
         // a frame was submitted to the host with a completion event requested.
         // DRM: page-flip submitted with PAGE_FLIP_EVENT. Wayland: sendCommit followed
         // by a wl_surface.frame whose done is wired to onFrameComplete.
-        void onFrameSubmitted() {
-            m_pending = true;
-        }
+        void onFrameSubmitted();
 
         // the host delivered the frame completion event.
         // DRM: kernel page-flip handler. Wayland: wl_callback.done.
         // State-only — clears m_pending. The backend fires frameReady explicitly
         // at the right point in its handler (preserving the present-before-frame
         // ordering on DRM).
-        void onFrameComplete() {
-            m_pending = false;
-        }
+        void onFrameComplete();
 
         // the in-flight frame (if any) is void and no completion event will arrive;
         // reset the frame bookkeeping.
-        void invalidate() {
-            m_pending        = false;
-            m_frameRunning   = false;
-            m_frameScheduled = false;
-        }
+        void invalidate();
 
         // is a frame in flight awaiting completion?
-        bool frameInFlight() const {
-            return m_pending;
-        }
+        bool frameInFlight() const;
 
         // may a new frame be scheduled? (does not consider output enabled state)
-        bool canSchedule() const {
-            return !m_pending && !m_frameRunning && !m_frameScheduled;
-        }
+        bool canSchedule() const;
 
         // State accessors. setFrameScheduled / frameScheduled() drive the idle-frame
         // loop; setFrameRunning / frameRunning() guard event emission on completion.
-        bool frameScheduled() const {
-            return m_frameScheduled;
-        }
-        void setFrameScheduled(bool v) {
-            m_frameScheduled = v;
-        }
-        bool frameRunning() const {
-            return m_frameRunning;
-        }
-        void setFrameRunning(bool v) {
-            m_frameRunning = v;
-        }
+        bool frameScheduled() const;
+        void setFrameScheduled(bool v);
+        bool frameRunning() const;
+        void setFrameRunning(bool v);
 
         // Fires from onFrameComplete. The output wires this to events.frame.emit.
         Hyprutils::Signal::CSignalT<> frameReady;
@@ -72,12 +52,8 @@ namespace Aquamarine {
     // reentrant emit handler cannot strand it.
     class CFrameRunningGuard {
       public:
-        explicit CFrameRunningGuard(CFrameScheduler& s) : m_s(s) {
-            m_s.setFrameRunning(true);
-        }
-        ~CFrameRunningGuard() {
-            m_s.setFrameRunning(false);
-        }
+        explicit CFrameRunningGuard(CFrameScheduler& s);
+        ~CFrameRunningGuard();
         CFrameRunningGuard(const CFrameRunningGuard&)            = delete;
         CFrameRunningGuard& operator=(const CFrameRunningGuard&) = delete;
 

--- a/include/aquamarine/backend/FrameScheduler.hpp
+++ b/include/aquamarine/backend/FrameScheduler.hpp
@@ -1,33 +1,41 @@
 #pragma once
 
+#include <hyprutils/signal/Signal.hpp>
+
 namespace Aquamarine {
-    // Per-connector page-flip / frame scheduling state for the DRM backend.
+    // Per-output frame scheduling state, shared by the DRM and Wayland backends.
     //
-    // Wraps the flip-flags that previously lived directly on SDRMConnector
-    // (isPageFlipPending, frameEventScheduled, isFrameRunning) behind named methods,
-    // so a single owner holds the page-flip/frame lifecycle.
+    // Both backends produce an end-of-frame event — DRM from the kernel page-flip
+    // completion, Wayland from wl_callback.done on a wl_surface.frame. This class
+    // models that lifecycle uniformly and fires frameReady on completion.
     class CFrameScheduler {
       public:
-        // a page-flip was submitted to the kernel with a completion event requested.
-        void onFlipSubmitted() {
+        // a frame was submitted to the host with a completion event requested.
+        // DRM: page-flip submitted with PAGE_FLIP_EVENT. Wayland: sendCommit followed
+        // by a wl_surface.frame whose done is wired to onFrameComplete.
+        void onFrameSubmitted() {
             m_pending = true;
         }
 
-        // the kernel delivered the page-flip completion event.
-        void onFlipComplete() {
+        // the host delivered the frame completion event.
+        // DRM: kernel page-flip handler. Wayland: wl_callback.done.
+        // State-only — clears m_pending. The backend fires frameReady explicitly
+        // at the right point in its handler (preserving the present-before-frame
+        // ordering on DRM).
+        void onFrameComplete() {
             m_pending = false;
         }
 
-        // the in-flight flip (if any) is void and no completion event will arrive;
-        // reset the flip/frame bookkeeping.
+        // the in-flight frame (if any) is void and no completion event will arrive;
+        // reset the frame bookkeeping.
         void invalidate() {
             m_pending        = false;
             m_frameRunning   = false;
             m_frameScheduled = false;
         }
 
-        // is a page-flip in flight on this connector's CRTC?
-        bool flipInFlight() const {
+        // is a frame in flight awaiting completion?
+        bool frameInFlight() const {
             return m_pending;
         }
 
@@ -37,7 +45,7 @@ namespace Aquamarine {
         }
 
         // State accessors. setFrameScheduled / frameScheduled() drive the idle-frame
-        // loop; setFrameRunning / frameRunning() guard event emission in handlePF.
+        // loop; setFrameRunning / frameRunning() guard event emission on completion.
         bool frameScheduled() const {
             return m_frameScheduled;
         }
@@ -50,6 +58,9 @@ namespace Aquamarine {
         void setFrameRunning(bool v) {
             m_frameRunning = v;
         }
+
+        // Fires from onFrameComplete. The output wires this to events.frame.emit.
+        Hyprutils::Signal::CSignalT<> frameReady;
 
       private:
         bool m_pending        = false;

--- a/include/aquamarine/backend/Wayland.hpp
+++ b/include/aquamarine/backend/Wayland.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "./Backend.hpp"
+#include "./FrameScheduler.hpp"
 #include "../allocator/Swapchain.hpp"
 #include "../output/Output.hpp"
 #include "../input/Input.hpp"
@@ -62,14 +63,13 @@ namespace Aquamarine {
 
         Hyprutils::Memory::CSharedPointer<CWaylandBuffer> wlBufferFromBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buffer);
 
-        void                                              sendFrameAndSetCallback();
         void                                              onFrameDone();
         void                                              onEnter(Hyprutils::Memory::CSharedPointer<CCWlPointer> pointer, uint32_t serial);
 
-        // frame loop
-        bool frameScheduledWhileWaiting = false;
-        bool readyForFrameCallback      = false; // true after attaching a buffer
-        bool frameScheduled             = false;
+        // frame loop — unified scheduler shared with DRM. See CFrameScheduler.
+        CFrameScheduler                                   sched;
+        Hyprutils::Signal::CHyprSignalListener            frameReadyListener;
+        Hyprutils::Memory::CSharedPointer<std::function<void(void)>> frameIdle;
 
         struct {
             std::vector<std::pair<Hyprutils::Memory::CWeakPointer<IBuffer>, Hyprutils::Memory::CSharedPointer<CWaylandBuffer>>> buffers;

--- a/include/aquamarine/backend/drm/FrameScheduler.hpp
+++ b/include/aquamarine/backend/drm/FrameScheduler.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstdint>
+#include <ctime>
+
+namespace Aquamarine {
+    // Per-connector page-flip / frame scheduling state for the DRM backend.
+    //
+    // Wraps the flip-flags that previously lived directly on SDRMConnector
+    // (isPageFlipPending, pageFlipPendingAtMs, frameEventScheduled, isFrameRunning)
+    // behind named methods, so a single owner holds the page-flip/frame lifecycle.
+    class CFrameScheduler {
+      public:
+        // a page-flip was submitted to the kernel with a completion event requested.
+        void onFlipSubmitted() {
+            m_pending     = true;
+            m_pendingAtMs = bootMs();
+        }
+
+        // the kernel delivered the page-flip completion event.
+        void onFlipComplete() {
+            m_pending = false;
+        }
+
+        // the in-flight flip (if any) is void and no completion event will arrive;
+        // reset the flip/frame bookkeeping.
+        void invalidate() {
+            m_pending        = false;
+            m_frameRunning   = false;
+            m_frameScheduled = false;
+        }
+
+        // is a page-flip in flight on this connector's CRTC?
+        bool flipInFlight() const {
+            return m_pending;
+        }
+
+        // may a new frame be scheduled? (does not consider output enabled state)
+        bool canSchedule() const {
+            return !m_pending && !m_frameRunning && !m_frameScheduled;
+        }
+
+        // State accessors. setFrameScheduled / frameScheduled() drive the idle-frame
+        // loop; setFrameRunning / frameRunning() guard event emission in handlePF.
+        bool frameScheduled() const {
+            return m_frameScheduled;
+        }
+        void setFrameScheduled(bool v) {
+            m_frameScheduled = v;
+        }
+        bool frameRunning() const {
+            return m_frameRunning;
+        }
+        void setFrameRunning(bool v) {
+            m_frameRunning = v;
+        }
+        uint64_t pendingAtMs() const {
+            return m_pendingAtMs;
+        }
+
+      private:
+        static uint64_t bootMs() {
+            struct timespec ts;
+            clock_gettime(CLOCK_BOOTTIME, &ts);
+            return (ts.tv_sec * 1000ULL) + (ts.tv_nsec / 1000000ULL);
+        }
+
+        bool     m_pending        = false;
+        uint64_t m_pendingAtMs    = 0; // CLOCK_BOOTTIME ms when the flip was submitted
+        bool     m_frameScheduled = false;
+        bool     m_frameRunning   = false;
+    };
+}

--- a/include/aquamarine/backend/drm/FrameScheduler.hpp
+++ b/include/aquamarine/backend/drm/FrameScheduler.hpp
@@ -1,20 +1,16 @@
 #pragma once
 
-#include <cstdint>
-#include <ctime>
-
 namespace Aquamarine {
     // Per-connector page-flip / frame scheduling state for the DRM backend.
     //
     // Wraps the flip-flags that previously lived directly on SDRMConnector
-    // (isPageFlipPending, pageFlipPendingAtMs, frameEventScheduled, isFrameRunning)
-    // behind named methods, so a single owner holds the page-flip/frame lifecycle.
+    // (isPageFlipPending, frameEventScheduled, isFrameRunning) behind named methods,
+    // so a single owner holds the page-flip/frame lifecycle.
     class CFrameScheduler {
       public:
         // a page-flip was submitted to the kernel with a completion event requested.
         void onFlipSubmitted() {
-            m_pending     = true;
-            m_pendingAtMs = bootMs();
+            m_pending = true;
         }
 
         // the kernel delivered the page-flip completion event.
@@ -54,20 +50,10 @@ namespace Aquamarine {
         void setFrameRunning(bool v) {
             m_frameRunning = v;
         }
-        uint64_t pendingAtMs() const {
-            return m_pendingAtMs;
-        }
 
       private:
-        static uint64_t bootMs() {
-            struct timespec ts;
-            clock_gettime(CLOCK_BOOTTIME, &ts);
-            return (ts.tv_sec * 1000ULL) + (ts.tv_nsec / 1000000ULL);
-        }
-
-        bool     m_pending        = false;
-        uint64_t m_pendingAtMs    = 0; // CLOCK_BOOTTIME ms when the flip was submitted
-        bool     m_frameScheduled = false;
-        bool     m_frameRunning   = false;
+        bool m_pending        = false;
+        bool m_frameScheduled = false;
+        bool m_frameRunning   = false;
     };
 }

--- a/include/aquamarine/backend/drm/FrameScheduler.hpp
+++ b/include/aquamarine/backend/drm/FrameScheduler.hpp
@@ -56,4 +56,21 @@ namespace Aquamarine {
         bool m_frameScheduled = false;
         bool m_frameRunning   = false;
     };
+
+    // RAII pair for isFrameRunning: set on ctor, cleared on every exit path so a
+    // reentrant emit handler cannot strand it.
+    class CFrameRunningGuard {
+      public:
+        explicit CFrameRunningGuard(CFrameScheduler& s) : m_s(s) {
+            m_s.setFrameRunning(true);
+        }
+        ~CFrameRunningGuard() {
+            m_s.setFrameRunning(false);
+        }
+        CFrameRunningGuard(const CFrameRunningGuard&)            = delete;
+        CFrameRunningGuard& operator=(const CFrameRunningGuard&) = delete;
+
+      private:
+        CFrameScheduler& m_s;
+    };
 }

--- a/src/backend/FrameScheduler.cpp
+++ b/src/backend/FrameScheduler.cpp
@@ -1,0 +1,49 @@
+#include <aquamarine/backend/FrameScheduler.hpp>
+
+using namespace Aquamarine;
+
+void CFrameScheduler::onFrameSubmitted() {
+    m_pending = true;
+}
+
+void CFrameScheduler::onFrameComplete() {
+    m_pending = false;
+}
+
+void CFrameScheduler::invalidate() {
+    m_pending        = false;
+    m_frameRunning   = false;
+    m_frameScheduled = false;
+}
+
+bool CFrameScheduler::frameInFlight() const {
+    return m_pending;
+}
+
+bool CFrameScheduler::canSchedule() const {
+    return !m_pending && !m_frameRunning && !m_frameScheduled;
+}
+
+bool CFrameScheduler::frameScheduled() const {
+    return m_frameScheduled;
+}
+
+void CFrameScheduler::setFrameScheduled(bool v) {
+    m_frameScheduled = v;
+}
+
+bool CFrameScheduler::frameRunning() const {
+    return m_frameRunning;
+}
+
+void CFrameScheduler::setFrameRunning(bool v) {
+    m_frameRunning = v;
+}
+
+CFrameRunningGuard::CFrameRunningGuard(CFrameScheduler& s) : m_s(s) {
+    m_s.setFrameRunning(true);
+}
+
+CFrameRunningGuard::~CFrameRunningGuard() {
+    m_s.setFrameRunning(false);
+}

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -492,6 +492,21 @@ Hyprutils::Memory::CWeakPointer<IBackendImplementation> Aquamarine::CWaylandBack
 Aquamarine::CWaylandOutput::CWaylandOutput(const std::string& name_, Hyprutils::Memory::CWeakPointer<CWaylandBackend> backend_) : backend(backend_) {
     name = name_;
 
+    // The scheduler's frameReady signal drives the public events.frame on this output.
+    frameReadyListener = sched.frameReady.listen([this]() { events.frame.emit(); });
+
+    // Idle that emits the scheduled frame, fired via the core backend's idle queue
+    // (addIdleEvent), which the consumer's event loop pumps every iteration. Deliberately
+    // not the backend-local idleCallbacks vector: that only drains inside dispatchEvents,
+    // i.e. when the wayland fd is readable, so a frame scheduled with no host traffic
+    // pending (e.g. right after a focus change) would never fire.
+    frameIdle = makeShared<std::function<void(void)>>([this]() {
+        sched.setFrameScheduled(false);
+        if (sched.frameInFlight() || sched.frameRunning())
+            return;
+        sched.frameReady.emit();
+    });
+
     waylandState.surface = makeShared<CCWlSurface>(backend->waylandState.compositor->sendCreateSurface());
 
     if (!waylandState.surface->resource()) {
@@ -529,7 +544,11 @@ Aquamarine::CWaylandOutput::CWaylandOutput(const std::string& name_, Hyprutils::
             h = 720;
         }
         events.state.emit(SStateEvent{.size = {w, h}});
-        sendFrameAndSetCallback();
+        // Kick off the first frame synchronously: the consumer expects events.frame in
+        // the same dispatch cycle as the toplevel configure. Deferring via scheduleFrame's
+        // idle races the first commit and can leave the output blank until the next event.
+        needsFrame = true;
+        sched.frameReady.emit();
     });
 
     waylandState.xdgToplevel->setClose([this](CCXdgToplevel* r) { destroy(); });
@@ -551,6 +570,8 @@ Aquamarine::CWaylandOutput::CWaylandOutput(const std::string& name_, Hyprutils::
 
 Aquamarine::CWaylandOutput::~CWaylandOutput() {
     events.destroy.emit();
+    // frameIdle captures a raw this and may still be queued; pull it before we die.
+    backend->backend->removeIdleEvent(frameIdle);
     if (waylandState.xdgToplevel)
         waylandState.xdgToplevel->sendDestroy();
     if (waylandState.xdgSurface)
@@ -567,11 +588,11 @@ std::vector<SDRMFormat> Aquamarine::CWaylandOutput::getRenderFormats() {
 }
 
 bool Aquamarine::CWaylandOutput::pendingPageFlip() {
-    return false;
+    return sched.frameInFlight();
 }
 
 bool Aquamarine::CWaylandOutput::pendingIdleFrame() {
-    return frameScheduled;
+    return sched.frameScheduled();
 }
 
 bool Aquamarine::CWaylandOutput::destroy() {
@@ -579,6 +600,7 @@ bool Aquamarine::CWaylandOutput::destroy() {
     waylandState.surface->sendAttach(nullptr, 0, 0);
     waylandState.surface->sendCommit();
     waylandState.frameCallback.reset();
+    sched.invalidate();
     std::erase(backend->outputs, self.lock());
     return true;
 }
@@ -642,9 +664,29 @@ bool Aquamarine::CWaylandOutput::commit() {
 
     waylandState.surface->sendAttach(wlBuffer->waylandState.buffer.get(), 0, 0);
     waylandState.surface->sendDamageBuffer(0, 0, INT32_MAX, INT32_MAX);
+
+    // Register the next wl_surface.frame callback as part of this commit's pending state,
+    // but only if one isn't already pending. A consumer that commits twice in quick
+    // succession (e.g. cursor + buffer) shares the in-flight callback — when it fires,
+    // onFrameDone runs and the next render cycle registers a fresh one. Mirrors DRM's
+    // "one flip in flight per CRTC" invariant, expressed via the scheduler.
+    //
+    // PROTOCOL: wl_surface.frame becomes part of pending state and takes effect on the
+    // NEXT wl_surface.commit. So the frame request must precede sendCommit() — sending
+    // it after commit would queue the callback for a future commit that never happens.
+    if (!sched.frameInFlight()) {
+        waylandState.frameCallback = makeShared<CCWlCallback>(waylandState.surface->sendFrame());
+        waylandState.frameCallback->setDone([this](CCWlCallback* r, uint32_t ms) { onFrameDone(); });
+        sched.onFrameSubmitted();
+    }
+
     waylandState.surface->sendCommit();
 
-    readyForFrameCallback = true;
+    // Flush immediately: commit() runs from the consumer's render path, outside
+    // dispatchEvents() (which flushes only at its top). Without this the buffer commit and
+    // frame request sit unflushed, the host never sends wl_callback.done, the fd never
+    // becomes readable, and the frame loop deadlocks.
+    wl_display_flush(backend->waylandState.display);
 
     events.commit.emit();
     state->onCommit();
@@ -678,33 +720,19 @@ SP<CWaylandBuffer> Aquamarine::CWaylandOutput::wlBufferFromBuffer(SP<IBuffer> bu
     return wlBuffer;
 }
 
-void Aquamarine::CWaylandOutput::sendFrameAndSetCallback() {
-    events.frame.emit();
-    frameScheduled = false;
-    if (waylandState.frameCallback || !readyForFrameCallback)
-        return;
-
-    waylandState.frameCallback = makeShared<CCWlCallback>(waylandState.surface->sendFrame());
-    waylandState.frameCallback->setDone([this](CCWlCallback* r, uint32_t ms) { onFrameDone(); });
-
-    waylandState.surface->sendCommit();
-}
-
 void Aquamarine::CWaylandOutput::onFrameDone() {
+    // Mirrors DRM's handlePF: settle scheduler state, emit present, then emit frame
+    // via the scheduler signal. The loop self-limits — if the consumer doesn't
+    // commit (its needsFrame bit clears in renderMonitor), no new wl_surface.frame
+    // is registered (registration lives in commit()), so no further done arrives.
     waylandState.frameCallback.reset();
-    readyForFrameCallback = false;
+    sched.onFrameComplete();
+
+    CFrameRunningGuard frameRunning(sched);
+
     events.present.emit(IOutput::SPresentEvent{.presented = true});
 
-    // FIXME: this is wrong, but otherwise we get bugs.
-    // thanks @phonetic112
-    scheduleFrame(AQ_SCHEDULE_NEEDS_FRAME);
-
-    if (frameScheduledWhileWaiting)
-        sendFrameAndSetCallback();
-    else
-        events.frame.emit();
-
-    frameScheduledWhileWaiting = false;
+    sched.frameReady.emit();
 }
 
 bool Aquamarine::CWaylandOutput::setCursor(Hyprutils::Memory::CSharedPointer<IBuffer> buffer, const Hyprutils::Math::Vector2D& hotspot) {
@@ -809,22 +837,14 @@ Hyprutils::Math::Vector2D Aquamarine::CWaylandOutput::cursorPlaneSize() {
 
 void Aquamarine::CWaylandOutput::scheduleFrame(const scheduleFrameReason reason) {
     TRACE(backend->backend->log(AQ_LOG_TRACE,
-                                std::format("CWaylandOutput::scheduleFrame: reason {}, needsFrame {}, frameScheduled {}", (uint32_t)reason, needsFrame, frameScheduled)));
+                                std::format("CWaylandOutput::scheduleFrame: reason {}, needsFrame {}, canSchedule {}", (uint32_t)reason, needsFrame, sched.canSchedule())));
     needsFrame = true;
 
-    if (frameScheduled)
+    if (!sched.canSchedule())
         return;
 
-    frameScheduled = true;
-
-    if (waylandState.frameCallback)
-        frameScheduledWhileWaiting = true;
-    else {
-        backend->idleCallbacks.emplace_back([w = self]() {
-            if (auto o = w.lock())
-                o->sendFrameAndSetCallback();
-        });
-    }
+    sched.setFrameScheduled(true);
+    backend->backend->addIdleEvent(frameIdle);
 }
 
 Aquamarine::CWaylandBuffer::CWaylandBuffer(SP<IBuffer> buffer_, Hyprutils::Memory::CWeakPointer<CWaylandBackend> backend_) : buffer(buffer_), backend(backend_) {

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -408,11 +408,9 @@ void Aquamarine::CDRMBackend::restoreAfterVT() {
     // restore, but isPageFlipPending is already false so the = false
     // assignment is a harmless no-op.
     for (auto const& c : connectors) {
-        if (c->isPageFlipPending || c->isFrameRunning) {
+        if (c->sched.flipInFlight() || c->sched.frameRunning()) {
             backend->log(AQ_LOG_DEBUG, std::format("drm: Clearing stale page-flip state for {}", c->szName));
-            c->isPageFlipPending   = false;
-            c->isFrameRunning      = false;
-            c->frameEventScheduled = false;
+            c->sched.invalidate();
         }
     }
 
@@ -1142,7 +1140,7 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
     if (!pageFlip || !pageFlip->connector)
         return;
 
-    pageFlip->connector->isPageFlipPending = false;
+    pageFlip->connector->sched.onFlipComplete();
 
     const auto& BACKEND = pageFlip->connector->backend;
 
@@ -1154,7 +1152,7 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
     }
 
     if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState)
-        pageFlip->connector->isFrameRunning = true;
+        pageFlip->connector->sched.setFrameRunning(true);
 
     pageFlip->connector->onPresent();
 
@@ -1171,13 +1169,13 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
     });
 
     if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState) {
-        if (pageFlip->connector->frameEventScheduled) {
-            pageFlip->connector->isFrameRunning = false;
+        if (pageFlip->connector->sched.frameScheduled()) {
+            pageFlip->connector->sched.setFrameRunning(false);
             return; // we got a idleFrame waiting before this pf was committed.
         }
 
         pageFlip->connector->output->events.frame.emit();
-        pageFlip->connector->isFrameRunning = false;
+        pageFlip->connector->sched.setFrameRunning(false);
     }
 }
 
@@ -1899,8 +1897,8 @@ void Aquamarine::SDRMConnector::onPresent() {
 Aquamarine::CDRMOutput::~CDRMOutput() {
     if (backend && backend->backend)
         backend->backend->removeIdleEvent(frameIdle);
-    connector->isPageFlipPending   = false;
-    connector->frameEventScheduled = false;
+    connector->sched.onFlipComplete();
+    connector->sched.setFrameScheduled(false);
 }
 
 void Aquamarine::CDRMOutput::releaseMgpuResources() {
@@ -2014,7 +2012,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
                 backend->backend->log(AQ_LOG_DEBUG, std::format("drm: Disabling output {}", name));
         }
 
-        if (STATE.enabled && (NEEDS_RECONFIG || (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER)) && connector->isPageFlipPending) {
+        if (STATE.enabled && (NEEDS_RECONFIG || (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER)) && connector->sched.flipInFlight()) {
             // Check if the pending page-flip is stale (>500ms — well beyond
             // any vblank interval, even at low refresh rates). Stale flips
             // occur after S3/S4 suspend when page-flip completion events are
@@ -2022,7 +2020,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
             struct timespec ts;
             clock_gettime(CLOCK_BOOTTIME, &ts);
             uint64_t nowMs     = ts.tv_sec * 1000ULL + ts.tv_nsec / 1000000ULL;
-            bool     staleFlip = (nowMs - connector->pageFlipPendingAtMs) > 500;
+            bool     staleFlip = (nowMs - connector->sched.pendingAtMs()) > 500;
 
             if (NEEDS_RECONFIG && staleFlip) {
                 // A blocking modeset uses DRM_MODE_ATOMIC_ALLOW_MODESET which
@@ -2030,10 +2028,9 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
                 // page-flip at the kernel level. Clear the stale userspace
                 // bookkeeping to match.
                 backend->backend->log(AQ_LOG_DEBUG,
-                                      std::format("drm: Clearing stale page-flip state for {} during modeset (pending for {}ms)", name, nowMs - connector->pageFlipPendingAtMs));
-                connector->isPageFlipPending   = false;
-                connector->isFrameRunning      = false;
-                connector->frameEventScheduled = false;
+                                      std::format("drm: Clearing stale page-flip state for {} during modeset (pending for {}ms)", name,
+                                                  nowMs - connector->sched.pendingAtMs()));
+                connector->sched.invalidate();
             } else {
                 backend->backend->log(AQ_LOG_ERROR, "drm: Cannot commit when a page-flip is awaiting");
                 return false;
@@ -2325,13 +2322,13 @@ void Aquamarine::CDRMOutput::moveCursor(const Vector2D& coord, bool skipSchedule
 void Aquamarine::CDRMOutput::scheduleFrame(const scheduleFrameReason reason) {
     TRACE(backend->backend->log(AQ_LOG_TRACE,
                                 std::format("CDRMOutput::scheduleFrame: reason {}, needsFrame {}, isPageFlipPending {}, frameEventScheduled {}", (uint32_t)reason, needsFrame,
-                                            connector->isPageFlipPending, connector->frameEventScheduled)));
+                                            connector->sched.flipInFlight(), connector->sched.frameScheduled())));
     needsFrame = true;
 
-    if (connector->isPageFlipPending || connector->isFrameRunning || connector->frameEventScheduled || !enabledState)
+    if (!connector->sched.canSchedule() || !enabledState)
         return;
 
-    connector->frameEventScheduled = true;
+    connector->sched.setFrameScheduled(true);
 
     backend->backend->addIdleEvent(frameIdle);
 }
@@ -2389,11 +2386,11 @@ std::vector<SDRMFormat> Aquamarine::CDRMOutput::getRenderFormats() {
 }
 
 bool Aquamarine::CDRMOutput::pendingPageFlip() {
-    return connector->isPageFlipPending;
+    return connector->sched.flipInFlight();
 }
 
 bool Aquamarine::CDRMOutput::pendingIdleFrame() {
-    return connector->frameEventScheduled;
+    return connector->sched.frameScheduled();
 }
 
 int Aquamarine::CDRMOutput::getConnectorID() {
@@ -2405,17 +2402,16 @@ Aquamarine::CDRMOutput::CDRMOutput(const std::string& name_, Hyprutils::Memory::
     name = name_;
 
     frameIdle = makeShared<std::function<void(void)>>([this, backend = backend_]() {
-        connector->frameEventScheduled = false;
-
-        if (connector->isPageFlipPending || connector->isFrameRunning)
+        connector->sched.setFrameScheduled(false);
+        if (connector->sched.flipInFlight() || connector->sched.frameRunning())
             return;
 
         events.frame.emit();
 
         // above frame scheduled, and then committed, remove the idle frame. the pageflip will emit the frame.
-        if (backend && backend->backend && connector->frameEventScheduled && connector->isPageFlipPending) {
+        if (backend && backend->backend && connector->sched.frameScheduled() && connector->sched.flipInFlight()) {
             backend->backend->removeIdleEvent(frameIdle);
-            connector->frameEventScheduled = false;
+            connector->sched.setFrameScheduled(false);
         }
     });
 }

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1151,8 +1151,9 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
         return;
     }
 
-    if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState)
-        pageFlip->connector->sched.setFrameRunning(true);
+    // hold isFrameRunning around the emit (RAII pair, so reentrant enable/disable
+    // can't strand it).
+    CFrameRunningGuard frameRunning(pageFlip->connector->sched);
 
     pageFlip->connector->onPresent();
 
@@ -1185,13 +1186,14 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
     }
 
     if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState) {
-        if (pageFlip->connector->sched.frameScheduled()) {
-            pageFlip->connector->sched.setFrameRunning(false);
-            return; // we got a idleFrame waiting before this pf was committed.
-        }
+        // An idle frame is already queued and will emit events.frame; emitting
+        // here too would double-fire — the wl event loop gives no ordering
+        // guarantee between the idle callback and this pf handler (#325). Let the
+        // idle frame win; the RAII guard clears frameRunning on this return.
+        if (pageFlip->connector->sched.frameScheduled())
+            return;
 
         pageFlip->connector->output->events.frame.emit();
-        pageFlip->connector->sched.setFrameRunning(false);
     }
 }
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1169,21 +1169,10 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
         .flags     = flags,
     });
 
-    // Drain BEFORE frame.emit: frame.emit triggers the compositor's next commit,
-    // which would race the drain and hit -EBUSY.
-    if (pageFlip->connector->nextCommit) {
-        if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState
-            && !pageFlip->connector->sched.frameInFlight()) {
-            SDRMConnectorCommitData draining = std::move(*pageFlip->connector->nextCommit);
-            pageFlip->connector->nextCommit.reset();
-            if (!pageFlip->connector->commitState(draining))
-                BACKEND->log(AQ_LOG_ERROR, std::format("drm: drain of coalesced commit failed for {}", pageFlip->connector->szName));
-        } else {
-            // Session inactive, output disabled, or a reentrant present.emit
-            // handler already submitted a newer flip — stash is obsolete, drop it.
-            pageFlip->connector->releaseStashedCommit();
-        }
-    }
+    // Drain any buffer-only commit stashed while this flip was in flight, BEFORE
+    // frame.emit — frame.emit triggers the compositor's next commit, which would
+    // otherwise race the drain and hit -EBUSY.
+    pageFlip->connector->drainStashedCommit();
 
     if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState) {
         // An idle frame is already queued and will emit events.frame; emitting
@@ -1844,17 +1833,43 @@ bool Aquamarine::SDRMConnector::commitState(SDRMConnectorCommitData& data) {
     return ok;
 }
 
+void Aquamarine::SDRMConnector::drainStashedCommit() {
+    if (!nextCommit)
+        return;
+
+    // Can the stashed buffer be submitted now? Only with a live session, an
+    // enabled output, and no newer flip already in flight. The last case arises
+    // when a reentrant present.emit (in handlePF, just before this call) drove a
+    // fresh commit that submitted directly and re-armed the flip — our stash is
+    // now stale and would clobber that newer frame (-EBUSY), so drop it instead.
+    const bool canDrain = backend->sessionActive() && output->enabledState && !sched.frameInFlight();
+    if (!canDrain) {
+        releaseCommitBuffers(*nextCommit); // stash guaranteed present here; no re-guard
+        nextCommit.reset();
+        return;
+    }
+
+    SDRMConnectorCommitData draining = std::move(*nextCommit);
+    nextCommit.reset();
+    if (!commitState(draining))
+        backend->log(AQ_LOG_ERROR, std::format("drm: drain of coalesced commit failed for {}", szName));
+}
+
+void Aquamarine::SDRMConnector::releaseCommitBuffers(SDRMConnectorCommitData& commit) {
+    if (commit.mainFB) {
+        commit.mainFB->buffer->lockedByBackend = false;
+        commit.mainFB->buffer->events.backendRelease.emit();
+    }
+    if (crtc && crtc->cursor && commit.cursorFB) {
+        commit.cursorFB->buffer->lockedByBackend = false;
+        commit.cursorFB->buffer->events.backendRelease.emit();
+    }
+}
+
 void Aquamarine::SDRMConnector::releaseStashedCommit() {
     if (!nextCommit)
         return;
-    if (nextCommit->mainFB) {
-        nextCommit->mainFB->buffer->lockedByBackend = false;
-        nextCommit->mainFB->buffer->events.backendRelease.emit();
-    }
-    if (crtc && crtc->cursor && nextCommit->cursorFB) {
-        nextCommit->cursorFB->buffer->lockedByBackend = false;
-        nextCommit->cursorFB->buffer->events.backendRelease.emit();
-    }
+    releaseCommitBuffers(*nextCommit);
     nextCommit.reset();
 }
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1169,21 +1169,12 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
         .flags     = flags,
     });
 
-    // Drain any buffer-only commit stashed while this flip was in flight, BEFORE
-    // frame.emit — frame.emit triggers the compositor's next commit, which would
-    // otherwise race the drain and hit -EBUSY.
-    pageFlip->connector->drainStashedCommit();
-
-    if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState) {
-        // An idle frame is already queued and will emit events.frame; emitting
-        // here too would double-fire — the wl event loop gives no ordering
-        // guarantee between the idle callback and this pf handler (#325). Let the
-        // idle frame win; the RAII guard clears frameRunning on this return.
-        if (pageFlip->connector->sched.frameScheduled())
-            return;
-
+    // Skip if an idle frame is already queued: it emits events.frame itself, and #325 forbids double-firing.
+    if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState && !pageFlip->connector->sched.frameScheduled())
         pageFlip->connector->sched.frameReady.emit();
-    }
+
+    // Drain after the emit: a fresh commit re-arms the flip, so the stash is dropped as stale; otherwise it's submitted.
+    pageFlip->connector->drainStashedCommit();
 }
 
 bool Aquamarine::CDRMBackend::dispatchEvents() {
@@ -1837,14 +1828,10 @@ void Aquamarine::SDRMConnector::drainStashedCommit() {
     if (!nextCommit)
         return;
 
-    // Can the stashed buffer be submitted now? Only with a live session, an
-    // enabled output, and no newer flip already in flight. The last case arises
-    // when a reentrant present.emit (in handlePF, just before this call) drove a
-    // fresh commit that submitted directly and re-armed the flip — our stash is
-    // now stale and would clobber that newer frame (-EBUSY), so drop it instead.
+    // A newer flip in flight means an emit in handlePF already submitted fresher content; the stash is stale, drop it.
     const bool canDrain = backend->sessionActive() && output->enabledState && !sched.frameInFlight();
     if (!canDrain) {
-        releaseCommitBuffers(*nextCommit); // stash guaranteed present here; no re-guard
+        releaseCommitBuffers(*nextCommit);
         nextCommit.reset();
         return;
     }

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1168,6 +1168,22 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
         .flags     = flags,
     });
 
+    // Drain BEFORE frame.emit: frame.emit triggers the compositor's next commit,
+    // which would race the drain and hit -EBUSY.
+    if (pageFlip->connector->nextCommit) {
+        if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState
+            && !pageFlip->connector->sched.flipInFlight()) {
+            SDRMConnectorCommitData draining = std::move(*pageFlip->connector->nextCommit);
+            pageFlip->connector->nextCommit.reset();
+            if (!pageFlip->connector->commitState(draining))
+                BACKEND->log(AQ_LOG_ERROR, std::format("drm: drain of coalesced commit failed for {}", pageFlip->connector->szName));
+        } else {
+            // Session inactive, output disabled, or a reentrant present.emit
+            // handler already submitted a newer flip — stash is obsolete, drop it.
+            pageFlip->connector->releaseStashedCommit();
+        }
+    }
+
     if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState) {
         if (pageFlip->connector->sched.frameScheduled()) {
             pageFlip->connector->sched.setFrameRunning(false);
@@ -1826,6 +1842,20 @@ bool Aquamarine::SDRMConnector::commitState(SDRMConnectorCommitData& data) {
     return ok;
 }
 
+void Aquamarine::SDRMConnector::releaseStashedCommit() {
+    if (!nextCommit)
+        return;
+    if (nextCommit->mainFB) {
+        nextCommit->mainFB->buffer->lockedByBackend = false;
+        nextCommit->mainFB->buffer->events.backendRelease.emit();
+    }
+    if (crtc && crtc->cursor && nextCommit->cursorFB) {
+        nextCommit->cursorFB->buffer->lockedByBackend = false;
+        nextCommit->cursorFB->buffer->events.backendRelease.emit();
+    }
+    nextCommit.reset();
+}
+
 void Aquamarine::SDRMConnector::applyCommit(const SDRMConnectorCommitData& data) {
     crtc->primary->back = data.mainFB;
     if (crtc->cursor && data.cursorFB)
@@ -1847,6 +1877,7 @@ void Aquamarine::SDRMConnector::applyCommit(const SDRMConnectorCommitData& data)
     if (!output->enabledState) {
         releaseFBReferences();
         sched.invalidate();
+        releaseStashedCommit();
     }
 
     if (!backend->updateSecondaryRendererState())
@@ -2014,16 +2045,12 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
                 backend->backend->log(AQ_LOG_DEBUG, std::format("drm: Disabling output {}", name));
         }
 
-        if (STATE.enabled && (NEEDS_RECONFIG || (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER)) && connector->sched.flipInFlight()) {
-            if (NEEDS_RECONFIG) {
-                // ALLOW_MODESET resets the CRTC and cancels the in-flight flip; no
-                // completion event will arrive, so clear the userspace state.
-                backend->backend->log(AQ_LOG_DEBUG, std::format("drm: page-flip on {} cancelled by modeset, clearing flip state", name));
-                connector->sched.invalidate();
-            } else {
-                backend->backend->log(AQ_LOG_ERROR, "drm: Cannot commit when a page-flip is awaiting");
-                return false;
-            }
+        if (STATE.enabled && NEEDS_RECONFIG && connector->sched.flipInFlight()) {
+            // ALLOW_MODESET resets the CRTC and cancels the in-flight flip; no
+            // completion event will arrive, so clear the userspace state.
+            backend->backend->log(AQ_LOG_DEBUG, std::format("drm: page-flip on {} cancelled by modeset, clearing flip state", name));
+            connector->sched.invalidate();
+            connector->releaseStashedCommit();
         }
 
         if (STATE.enabled && (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER))
@@ -2156,6 +2183,22 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
     // Once a real CTM commit succeeds, ordinary identity modesets can skip the blob.
     if (shouldSubmitCTM(connector, STATE, data.modeset))
         data.ctm = STATE.ctm;
+
+    // A second flip while one is pending returns -EBUSY; stash the commit
+    // in a latest-wins slot, drained by handlePF on flip completion.
+    if (!onlyTest && !data.modeset && connector->sched.flipInFlight()) {
+        if (data.mainFB)
+            data.mainFB->buffer->lockedByBackend = true;
+        if (connector->crtc->cursor && data.cursorFB)
+            data.cursorFB->buffer->lockedByBackend = true;
+        connector->releaseStashedCommit();
+        connector->nextCommit = std::move(data);
+        events.commit.emit();
+        state->onCommit();
+        lastCommitNoBuffer = false;
+        needsFrame         = false;
+        return true;
+    }
 
     bool ok = connector->commitState(data);
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1844,8 +1844,10 @@ void Aquamarine::SDRMConnector::applyCommit(const SDRMConnectorCommitData& data)
     const bool wasEnabled = output->enabledState;
     output->enabledState  = output->state->state().enabled;
 
-    if (!output->enabledState)
+    if (!output->enabledState) {
         releaseFBReferences();
+        sched.invalidate();
+    }
 
     if (!backend->updateSecondaryRendererState())
         backend->backend->log(AQ_LOG_ERROR, std::format("drm: Failed to update renderer state for {} on applyCommit", szName));
@@ -2013,23 +2015,10 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
         }
 
         if (STATE.enabled && (NEEDS_RECONFIG || (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER)) && connector->sched.flipInFlight()) {
-            // Check if the pending page-flip is stale (>500ms — well beyond
-            // any vblank interval, even at low refresh rates). Stale flips
-            // occur after S3/S4 suspend when page-flip completion events are
-            // lost because the display hardware was powered off.
-            struct timespec ts;
-            clock_gettime(CLOCK_BOOTTIME, &ts);
-            uint64_t nowMs     = ts.tv_sec * 1000ULL + ts.tv_nsec / 1000000ULL;
-            bool     staleFlip = (nowMs - connector->sched.pendingAtMs()) > 500;
-
-            if (NEEDS_RECONFIG && staleFlip) {
-                // A blocking modeset uses DRM_MODE_ATOMIC_ALLOW_MODESET which
-                // fully resets the CRTC, implicitly cancelling any stale
-                // page-flip at the kernel level. Clear the stale userspace
-                // bookkeeping to match.
-                backend->backend->log(AQ_LOG_DEBUG,
-                                      std::format("drm: Clearing stale page-flip state for {} during modeset (pending for {}ms)", name,
-                                                  nowMs - connector->sched.pendingAtMs()));
+            if (NEEDS_RECONFIG) {
+                // ALLOW_MODESET resets the CRTC and cancels the in-flight flip; no
+                // completion event will arrive, so clear the userspace state.
+                backend->backend->log(AQ_LOG_DEBUG, std::format("drm: page-flip on {} cancelled by modeset, clearing flip state", name));
                 connector->sched.invalidate();
             } else {
                 backend->backend->log(AQ_LOG_ERROR, "drm: Cannot commit when a page-flip is awaiting");

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -408,7 +408,7 @@ void Aquamarine::CDRMBackend::restoreAfterVT() {
     // restore, but isPageFlipPending is already false so the = false
     // assignment is a harmless no-op.
     for (auto const& c : connectors) {
-        if (c->sched.flipInFlight() || c->sched.frameRunning()) {
+        if (c->sched.frameInFlight() || c->sched.frameRunning()) {
             backend->log(AQ_LOG_DEBUG, std::format("drm: Clearing stale page-flip state for {}", c->szName));
             c->sched.invalidate();
         }
@@ -1140,7 +1140,7 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
     if (!pageFlip || !pageFlip->connector)
         return;
 
-    pageFlip->connector->sched.onFlipComplete();
+    pageFlip->connector->sched.onFrameComplete();
 
     const auto& BACKEND = pageFlip->connector->backend;
 
@@ -1173,7 +1173,7 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
     // which would race the drain and hit -EBUSY.
     if (pageFlip->connector->nextCommit) {
         if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState
-            && !pageFlip->connector->sched.flipInFlight()) {
+            && !pageFlip->connector->sched.frameInFlight()) {
             SDRMConnectorCommitData draining = std::move(*pageFlip->connector->nextCommit);
             pageFlip->connector->nextCommit.reset();
             if (!pageFlip->connector->commitState(draining))
@@ -1193,7 +1193,7 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
         if (pageFlip->connector->sched.frameScheduled())
             return;
 
-        pageFlip->connector->output->events.frame.emit();
+        pageFlip->connector->sched.frameReady.emit();
     }
 }
 
@@ -1932,7 +1932,7 @@ void Aquamarine::SDRMConnector::onPresent() {
 Aquamarine::CDRMOutput::~CDRMOutput() {
     if (backend && backend->backend)
         backend->backend->removeIdleEvent(frameIdle);
-    connector->sched.onFlipComplete();
+    connector->sched.onFrameComplete();
     connector->sched.setFrameScheduled(false);
 }
 
@@ -2047,7 +2047,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
                 backend->backend->log(AQ_LOG_DEBUG, std::format("drm: Disabling output {}", name));
         }
 
-        if (STATE.enabled && NEEDS_RECONFIG && connector->sched.flipInFlight()) {
+        if (STATE.enabled && NEEDS_RECONFIG && connector->sched.frameInFlight()) {
             // ALLOW_MODESET resets the CRTC and cancels the in-flight flip; no
             // completion event will arrive, so clear the userspace state.
             backend->backend->log(AQ_LOG_DEBUG, std::format("drm: page-flip on {} cancelled by modeset, clearing flip state", name));
@@ -2188,7 +2188,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
 
     // A second flip while one is pending returns -EBUSY; stash the commit
     // in a latest-wins slot, drained by handlePF on flip completion.
-    if (!onlyTest && !data.modeset && connector->sched.flipInFlight()) {
+    if (!onlyTest && !data.modeset && connector->sched.frameInFlight()) {
         if (data.mainFB)
             data.mainFB->buffer->lockedByBackend = true;
         if (connector->crtc->cursor && data.cursorFB)
@@ -2356,7 +2356,7 @@ void Aquamarine::CDRMOutput::moveCursor(const Vector2D& coord, bool skipSchedule
 void Aquamarine::CDRMOutput::scheduleFrame(const scheduleFrameReason reason) {
     TRACE(backend->backend->log(AQ_LOG_TRACE,
                                 std::format("CDRMOutput::scheduleFrame: reason {}, needsFrame {}, isPageFlipPending {}, frameEventScheduled {}", (uint32_t)reason, needsFrame,
-                                            connector->sched.flipInFlight(), connector->sched.frameScheduled())));
+                                            connector->sched.frameInFlight(), connector->sched.frameScheduled())));
     needsFrame = true;
 
     if (!connector->sched.canSchedule() || !enabledState)
@@ -2420,7 +2420,7 @@ std::vector<SDRMFormat> Aquamarine::CDRMOutput::getRenderFormats() {
 }
 
 bool Aquamarine::CDRMOutput::pendingPageFlip() {
-    return connector->sched.flipInFlight();
+    return connector->sched.frameInFlight();
 }
 
 bool Aquamarine::CDRMOutput::pendingIdleFrame() {
@@ -2437,17 +2437,20 @@ Aquamarine::CDRMOutput::CDRMOutput(const std::string& name_, Hyprutils::Memory::
 
     frameIdle = makeShared<std::function<void(void)>>([this, backend = backend_]() {
         connector->sched.setFrameScheduled(false);
-        if (connector->sched.flipInFlight() || connector->sched.frameRunning())
+        if (connector->sched.frameInFlight() || connector->sched.frameRunning())
             return;
 
-        events.frame.emit();
+        connector->sched.frameReady.emit();
 
         // above frame scheduled, and then committed, remove the idle frame. the pageflip will emit the frame.
-        if (backend && backend->backend && connector->sched.frameScheduled() && connector->sched.flipInFlight()) {
+        if (backend && backend->backend && connector->sched.frameScheduled() && connector->sched.frameInFlight()) {
             backend->backend->removeIdleEvent(frameIdle);
             connector->sched.setFrameScheduled(false);
         }
     });
+
+    // The scheduler's frameReady signal drives the public events.frame on this output.
+    frameReadyListener = connector->sched.frameReady.listen([this]() { events.frame.emit(); });
 }
 
 SP<CDRMFB> Aquamarine::CDRMFB::create(SP<IBuffer> buffer_, Hyprutils::Memory::CWeakPointer<CDRMBackend> backend_, bool* isNew) {

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -504,12 +504,8 @@ bool Aquamarine::CDRMAtomicImpl::commit(Hyprutils::Memory::CSharedPointer<SDRMCo
             if (data.atomic.ctmd)
                 connector->crtc->atomic.ctmStateKnown = true;
 
-            if (data.mainFB && connector->output->state->state().enabled && (flags & DRM_MODE_PAGE_FLIP_EVENT)) {
-                connector->isPageFlipPending = true;
-                struct timespec ts;
-                clock_gettime(CLOCK_BOOTTIME, &ts);
-                connector->pageFlipPendingAtMs = ts.tv_sec * 1000ULL + ts.tv_nsec / 1000000ULL;
-            }
+            if (data.mainFB && connector->output->state->state().enabled && (flags & DRM_MODE_PAGE_FLIP_EVENT))
+                connector->sched.onFlipSubmitted();
         }
     } else
         request.rollback(data);

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -505,7 +505,7 @@ bool Aquamarine::CDRMAtomicImpl::commit(Hyprutils::Memory::CSharedPointer<SDRMCo
                 connector->crtc->atomic.ctmStateKnown = true;
 
             if (data.mainFB && connector->output->state->state().enabled && (flags & DRM_MODE_PAGE_FLIP_EVENT))
-                connector->sched.onFlipSubmitted();
+                connector->sched.onFrameSubmitted();
         }
     } else
         request.rollback(data);

--- a/src/backend/drm/impl/Legacy.cpp
+++ b/src/backend/drm/impl/Legacy.cpp
@@ -137,7 +137,7 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
         return false;
     }
 
-    connector->sched.onFlipSubmitted();
+    connector->sched.onFrameSubmitted();
 
     return true;
 }

--- a/src/backend/drm/impl/Legacy.cpp
+++ b/src/backend/drm/impl/Legacy.cpp
@@ -137,10 +137,7 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
         return false;
     }
 
-    connector->isPageFlipPending = true;
-    struct timespec ts;
-    clock_gettime(CLOCK_BOOTTIME, &ts);
-    connector->pageFlipPendingAtMs = ts.tv_sec * 1000ULL + ts.tv_nsec / 1000000ULL;
+    connector->sched.onFlipSubmitted();
 
     return true;
 }


### PR DESCRIPTION
## Summary

Replace aquamarine's frame-scheduling state — four loose booleans + a 500 ms staleness timer, mutated from 11 sites — with a per-connector `CFrameScheduler`, deterministic kernel-event-driven invalidation, and a single latest-wins coalescing slot for racing commits. Removes the lossy `"Cannot commit when a page-flip is awaiting"` rejection.

Four independently-readable commits:

1. **`drm: extract CFrameScheduler to own per-connector flip/frame state`** — pure mechanical refactor, zero behaviour change. Wraps `isPageFlipPending`, `pageFlipPendingAtMs`, `frameEventScheduled`, `isFrameRunning` behind named methods on a new connector-owned `CFrameScheduler`. All 11 mutation sites migrated. `needsFrame` stays on `IOutput` (shared by all backends).

2. **`drm: clear in-flight page-flip deterministically on disable and modeset, drop 500ms timer`** — replaces #254's 500 ms `staleFlip` heuristic with two deterministic clears: (a) on **disable**, `applyCommit` clears the flip bookkeeping when the output transitions to disabled (the path #304 needed); (b) on a **blocking modeset**, the kernel guarantees the CRTC reset cancels any in-flight flip (#254's own comment documents this for `ALLOW_MODESET`), so the clear is unconditional — no elapsed-time guess. Deletes `pageFlipPendingAtMs`. Closes the sub-500 ms fast-cycle gap and the non-modeset re-enable gap that the heuristic missed.

3. **`drm: coalesce buffer commits that race an in-flight page-flip`** — when a buffer-only commit arrives while a flip is in flight, stash it in a single latest-wins slot per connector instead of rejecting (lossy — drops the compositor's update, see #306). `handlePF` drains the slot once the pending flip completes, submitting **before** `frame.emit` so the compositor's next render coalesces instead of racing. Buffer lock/release mirrors the existing `last/front/back` discipline; the stash is released on disable / modeset / dead-session.

4. **`drm: pair isFrameRunning set/clear with RAII; settle phase before emit`** — `handlePF`'s manual `setFrameRunning(true/false)` pair was both gated on `session && enabledState` evaluated at different times around event emission; a reentrant state change between them could strand the flag. Replace with a `CFrameRunningGuard` RAII object whose destructor runs on every exit path.

## Issues addressed

- **#304** (idle-DPMS panel wedge) — resolved by commits 1 + 2 (both case-3 disable and case-2 modeset clears are deterministic; no timer).
- **#306** (Source 1 cursor freeze) — the lossy reject is gone; the racing cursor commit is coalesced rather than dropped. The freeze becomes impossible as a *consequence* of no longer dropping the commit. (Cursor-plane reroute — also #306-adjacent — is deliberately out of scope here; happy to follow up.)
- **#254** (the merged 500 ms heuristic) — superseded by commit 2's deterministic clears.

## Not addressed

- **#308** (i915 lid-resume). Its root cause is unconfirmed and the wedge appears to be a *fresh* post-recovery flip whose event is silently dropped — none of the deterministic transition-driven clears here catch that case. I don't have i915 hardware to verify a fix; happy to coordinate with the reporter on a discriminating `AQ_TRACE` if useful.

- **Adjacent observation noticed during testing (not fixed here):** the hardware cursor stays hidden for several frames after a DPMS off→on cycle until either its shape changes or it crosses to another output (which triggers a cursor-plane commit). This looks like cursor-plane state being lost across modeset and not automatically re-armed — orthogonal to the lossy reject this PR fixes. Happy to follow up with a separate PR that primes the cursor plane after modeset, if this lands.

## Testing

Verified locally on amdgpu (Ryzen 9 9950X desktop, multi-monitor) across 30+ cursor-warp + manual-dpms cycles and 25+ wayland-idle DPMS cycles (hypridle 5 s timeout). Zero wedges, zero `Cannot commit when a page-flip is awaiting`, zero `drain of coalesced commit failed`, zero scheduler errors. Each cycle's screen recovery observed visually.

One real S3 suspend/resume cycle was also verified: `restoreAfterVT` fires as expected, no flags are stranded at restore time, no wedge, screen comes back cleanly. Worth disclosing that **one transient `atomic drm request: failed: Device or resource busy` `ERR` line may appear on resume** — the very next buffer commit reaches the kernel during the brief CRTC-settling window after the resume modeset. The existing `CDRMOutput::commitState` retry-as-modeset fallback (`if (!ok && !data.modeset && ...) { data.modeset=true; data.blocking=true; ... }`) re-issues it as a blocking modeset, waits for the kernel to settle, and succeeds — the compositor never sees the failure. The 500 ms `staleFlip` heuristic previously masked this by rejecting commits at the userspace guard before they reached the kernel; with the heuristic gone, the kernel-level transient is what surfaces in the log instead. Happy to silence the upstream ERR log in a follow-up if desired.
