### PR TITLE
drm: fix crash on null crtc in getGammaSize/getDeGammaSize

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -2315,6 +2315,11 @@ size_t Aquamarine::CDRMOutput::getGammaSize() {
         return 0;
     }
 
+    if (!connector->crtc) {
+        backend->log(AQ_LOG_ERROR, "Can't get gamma size: no crtc");
+        return 0;
+    }
+
     uint64_t size = 0;
     if (!getDRMProp(backend->gpu->fd, connector->crtc->id, connector->crtc->props.values.gamma_lut_size, &size)) {
         backend->log(AQ_LOG_ERROR, "Couldn't get the gamma_size prop");
@@ -2327,6 +2332,11 @@ size_t Aquamarine::CDRMOutput::getGammaSize() {
 size_t Aquamarine::CDRMOutput::getDeGammaSize() {
     if (!backend->atomic) {
         backend->log(AQ_LOG_ERROR, "No support for gamma on the legacy iface");
+        return 0;
+    }
+
+    if (!connector->crtc) {
+        backend->log(AQ_LOG_ERROR, "Can't get degamma size: no crtc");
         return 0;
     }
 


### PR DESCRIPTION
`getGammaSize()` and `getDeGammaSize()` dereference `connector->crtc` without checking it, so requesting gamma on an output that has no crtc causes segfaults. added guard against it.

crash report below
```
--------------------------------------------
   Hyprland Crash Report
--------------------------------------------
Sorry, didn't mean to...

Hyprland received signal 11(SEGV)
Version: cbcddf2848fcdd9d2490df786c92003bcd763fac
Tag: v0.55.0
Date: 2026-05-29
Flags:

System info:
	System name: Linux
	Node name: z13
	Release: 7.0.10
	Version: #1-NixOS SMP PREEMPT_DYNAMIC Sat May 23 11:09:44 UTC 2026

GPU:
	c3:00.0 VGA compatible controller [0300]: Advanced Micro Devices, Inc. [AMD/ATI] Phoenix1 [1002:15bf] (rev dd) (prog-if 00 [VGA controller])


os-release:
	ANSI_COLOR="0;38;2;126;186;228"
	BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
	BUILD_ID="26.11.20260527.4100e83"
	CPE_NAME="cpe:/o:nixos:nixos:26.11"
	DEFAULT_HOSTNAME=nixos
	DOCUMENTATION_URL="https://nixos.org/learn.html"
	HOME_URL="https://nixos.org/"
	ID=nixos
	ID_LIKE=""
	IMAGE_ID=""
	IMAGE_VERSION=""
	LOGO="nix-snowflake"
	NAME=NixOS
	PRETTY_NAME="NixOS 26.11 (Zokor)"
	SUPPORT_URL="https://nixos.org/community.html"
	VARIANT=""
	VARIANT_ID=""
	VENDOR_NAME=NixOS
	VENDOR_URL="https://nixos.org/"
	VERSION="26.11 (Zokor)"
	VERSION_CODENAME=zokor
	VERSION_ID="26.11"

Libraries:
Hyprgraphics: built against 0.5.1, system has unknown
Hyprutils: built against 0.13.1, system has unknown
Hyprcursor: built against 0.1.13, system has unknown
Hyprlang: built against 0.6.8, system has unknown
Aquamarine: built against 0.11.0, system has unknown

Backtrace:
	# | /nix/store/wf4ygwxwi0sq5iz0z08yi0bx0105cw85-hyprland-0.55.0+date=2026-05-29_cbcddf2/bin/Hyprland(_Z12getBacktracev+0x5c) [0x5636f25e135c]
		getBacktrace()
		??:?
	#1 | /nix/store/wf4ygwxwi0sq5iz0z08yi0bx0105cw85-hyprland-0.55.0+date=2026-05-29_cbcddf2/bin/Hyprland(_ZN13CrashReporter18createAndSaveCrashEi+0xb34) [0x5636f24df524]
		CrashReporter::createAndSaveCrash(int)
		??:?
	#2 | /nix/store/wf4ygwxwi0sq5iz0z08yi0bx0105cw85-hyprland-0.55.0+date=2026-05-29_cbcddf2/bin/Hyprland(+0x3edc05) [0x5636f22dec05]
		handleUnrecoverableSignal(int)
		??:?
	#3 | /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6(+0x42790) [0x72d34d842790]
		??
		??:0
	#4 | /nix/store/qravyz8mf7hlw15rlv0afawjrdmpjqbd-aquamarine-0.11.0+date=2026-05-15_ab2b0af/lib/libaquamarine.so.10(_ZN10Aquamarine10CDRMOutput12getGammaSizeEv+0x210) [0x72d3504940c0]
		??
		??:0
	#5 | /nix/store/wf4ygwxwi0sq5iz0z08yi0bx0105cw85-hyprland-0.55.0+date=2026-05-29_cbcddf2/bin/Hyprland(_ZN13CGammaControlC1EN9Hyprutils6Memory14CSharedPointerI19CZwlrGammaControlV1EEP11wl_resource+0x695) [0x5636f2914645]
		CGammaControl::CGammaControl(Hyprutils::Memory::CSharedPointer<CZwlrGammaControlV1>, wl_resource*)
		??:?
	#6 | /nix/store/wf4ygwxwi0sq5iz0z08yi0bx0105cw85-hyprland-0.55.0+date=2026-05-29_cbcddf2/bin/Hyprland(_ZN21CGammaControlProtocol17onGetGammaControlEP26CZwlrGammaControlManagerV1jP11wl_resource+0xd5) [0x5636f2914d25]
		CGammaControlProtocol::onGetGammaControl(CZwlrGammaControlManagerV1*, unsigned int, wl_resource*)
		??:?
	#7 | /nix/store/wf4ygwxwi0sq5iz0z08yi0bx0105cw85-hyprland-0.55.0+date=2026-05-29_cbcddf2/bin/Hyprland(+0xcc519e) [0x5636f2bb619e]
		_CZwlrGammaControlManagerV1GetGammaControl(wl_client*, wl_resource*, unsigned int, wl_resource*)
		??:?
	#8 | /nix/store/2zs4bbi72plfm8j6zxf1js4f3yc4yzwy-libffi-3.5.2/lib/libffi.so.8(+0xa052) [0x72d34de8c052]
		??
		??:0
	#9 | /nix/store/2zs4bbi72plfm8j6zxf1js4f3yc4yzwy-libffi-3.5.2/lib/libffi.so.8(+0x875c) [0x72d34de8a75c]
		??
		??:0
	#1 | /nix/store/2zs4bbi72plfm8j6zxf1js4f3yc4yzwy-libffi-3.5.2/lib/libffi.so.8(ffi_call+0x13e) [0x72d34de8b2ae]
		??
		??:0
	#11 | /nix/store/b89rbd2k8k3a8va6xkmh4nizgrpwv0y4-wayland-1.25.0/lib/libwayland-server.so.0(+0xfbcc) [0x72d3501f7bcc]
		??
		??:0
	#12 | /nix/store/b89rbd2k8k3a8va6xkmh4nizgrpwv0y4-wayland-1.25.0/lib/libwayland-server.so.0(+0x9de7) [0x72d3501f1de7]
		??
		??:0
	#13 | /nix/store/b89rbd2k8k3a8va6xkmh4nizgrpwv0y4-wayland-1.25.0/lib/libwayland-server.so.0(wl_event_loop_dispatch+0x1c2) [0x72d3501f5312]
		??
		??:0
	#14 | /nix/store/b89rbd2k8k3a8va6xkmh4nizgrpwv0y4-wayland-1.25.0/lib/libwayland-server.so.0(wl_display_run+0x25) [0x72d3501f2795]
		??
		??:0
	#15 | /nix/store/wf4ygwxwi0sq5iz0z08yi0bx0105cw85-hyprland-0.55.0+date=2026-05-29_cbcddf2/bin/Hyprland(_ZN17CEventLoopManager9enterLoopEv+0x2ba) [0x5636f27bf25a]
		CEventLoopManager::enterLoop()
		??:?
	#16 | /nix/store/wf4ygwxwi0sq5iz0z08yi0bx0105cw85-hyprland-0.55.0+date=2026-05-29_cbcddf2/bin/Hyprland(main+0x1324) [0x5636f22ce284]
		main
		??:?
	#17 | /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6(+0x2b285) [0x72d34d82b285]
		??
		??:0
	#18 | /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6(__libc_start_main+0x88) [0x72d34d82b338]
		??
		??:0
	#19 | /nix/store/wf4ygwxwi0sq5iz0z08yi0bx0105cw85-hyprland-0.55.0+date=2026-05-29_cbcddf2/bin/Hyprland(_start+0x25) [0x5636f22c6b65]
		_start
		??:?


Log tail:
ERR from aquamarine ]: Can't get formats: no crtc
ERR from aquamarine ]: GBM: Failed to allocate a GBM buffer: format XR24 isn't supported by primary backend
ERR from aquamarine ]: Couldn't allocate a gbm buffer with size [Vector2D: x: 1280, y: 800] and format XR24
ERR from aquamarine ]: Swapchain: Failed acquiring a buffer
ERR from aquamarine ]: Can't get formats: no crtc
ERR from aquamarine ]: GBM: Failed to allocate a GBM buffer: format XR24 isn't supported by primary backend
ERR from aquamarine ]: Couldn't allocate a gbm buffer with size [Vector2D: x: 1280, y: 720] and format XR24
ERR from aquamarine ]: Swapchain: Failed acquiring a buffer
ERR from aquamarine ]: Can't get formats: no crtc
ERR from aquamarine ]: GBM: Failed to allocate a GBM buffer: format XR24 isn't supported by primary backend
ERR from aquamarine ]: Couldn't allocate a gbm buffer with size [Vector2D: x: 1280, y: 720] and format XR24
ERR from aquamarine ]: Swapchain: Failed acquiring a buffer
ERR from aquamarine ]: Can't get formats: no crtc
ERR from aquamarine ]: GBM: Failed to allocate a GBM buffer: format XR24 isn't supported by primary backend
ERR from aquamarine ]: Couldn't allocate a gbm buffer with size [Vector2D: x: 1024, y: 768] and format XR24
ERR from aquamarine ]: Swapchain: Failed acquiring a buffer
ERR from aquamarine ]: Can't get formats: no crtc
ERR from aquamarine ]: GBM: Failed to allocate a GBM buffer: format XR24 isn't supported by primary backend
ERR from aquamarine ]: Couldn't allocate a gbm buffer with size [Vector2D: x: 1024, y: 768] and format XR24
ERR from aquamarine ]: Swapchain: Failed acquiring a buffer
ERR from aquamarine ]: Can't get formats: no crtc
ERR from aquamarine ]: GBM: Failed to allocate a GBM buffer: format XR24 isn't supported by primary backend
ERR from aquamarine ]: Couldn't allocate a gbm buffer with size [Vector2D: x: 800, y: 600] and format XR24
ERR from aquamarine ]: Swapchain: Failed acquiring a buffer
ERR from aquamarine ]: Can't get formats: no crtc
ERR from aquamarine ]: GBM: Failed to allocate a GBM buffer: format XR24 isn't supported by primary backend
ERR from aquamarine ]: Couldn't allocate a gbm buffer with size [Vector2D: x: 800, y: 600] and format XR24
ERR from aquamarine ]: Swapchain: Failed acquiring a buffer
ERR from aquamarine ]: Can't get formats: no crtc
ERR from aquamarine ]: GBM: Failed to allocate a GBM buffer: format XR24 isn't supported by primary backend
ERR from aquamarine ]: Couldn't allocate a gbm buffer with size [Vector2D: x: 640, y: 480] and format XR24
ERR from aquamarine ]: Swapchain: Failed acquiring a buffer
ERR from aquamarine ]: Can't get formats: no crtc
ERR from aquamarine ]: GBM: Failed to allocate a GBM buffer: format XR24 isn't supported by primary backend
ERR from aquamarine ]: Couldn't allocate a gbm buffer with size [Vector2D: x: 640, y: 480] and format XR24
ERR from aquamarine ]: Swapchain: Failed acquiring a buffer
ERR from aquamarine ]: Can't get formats: no crtc
ERR from aquamarine ]: GBM: Failed to allocate a GBM buffer: format XR24 isn't supported by primary backend
ERR from aquamarine ]: Couldn't allocate a gbm buffer with size [Vector2D: x: 640, y: 480] and format XR24
ERR from aquamarine ]: Swapchain: Failed acquiring a buffer
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 463
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 463
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 463
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 458
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 458
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 458
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 458
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 458
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 458
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 458
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 458
```