### PR TITLE
Handle Atomic modeset DRM for AMD iGPU (Ryzen AI 9 370HX) panel max BPC reporting failure

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -291,6 +291,12 @@ namespace Aquamarine {
             uint64_t colorspace  = 0;
             uint16_t contentType = 0;
             uint32_t crtcID      = 0;
+
+            // true if the max_bpc property was actually added to the atomic request
+            // (i.e. not skipped as an unchanged cached value on a page-flip). only when
+            // this is set may a commit failure be attributed to max_bpc and trigger the
+            // max_bpc-less retry / maxBpcFailed workaround (see amdgpu eDP handling).
+            bool maxBpcEmitted = false;
         } atomic;
 
         void calculateMode(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector);
@@ -347,6 +353,10 @@ namespace Aquamarine {
 
         // the current state is invalid and won't commit, don't try to modeset.
         bool                                           commitTainted = false;
+
+        // set when an atomic commit with max_bpc fails; skips max_bpc on future
+        // commits for this connector (works around buggy drivers, e.g. amdgpu eDP).
+        bool                                           maxBpcFailed = false;
 
         Hyprutils::Memory::CSharedPointer<SOutputMode> fallbackMode;
 

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1714,6 +1714,9 @@ void Aquamarine::SDRMConnector::connect(drmModeConnector* connector) {
         return;
     }
 
+    // max_bpc-less retry is per-sink and must not persist across hotplugs.
+    maxBpcFailed = false;
+
     backend->backend->log(AQ_LOG_DEBUG, std::format("drm: Connecting connector {}, {}", szName, crtc ? std::format("CRTC ID {}", crtc->id) : "no CRTC"));
 
     output            = SP<CDRMOutput>(new CDRMOutput(szName, backend, self.lock()));

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -234,6 +234,7 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
     const uint32_t newCrtcID      = enable ? connector->crtc->id : 0;
     uint64_t       newMaxBpc = 0, newColorspace = 0;
     uint16_t       newContentType = 0;
+    bool           maxBpcEmitted  = false;
 
     if (enable) {
         drmModeModeInfo* currentMode = connector->getCurrentMode();
@@ -247,10 +248,12 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
             addConnectorModeset(connector, data);
 
         // Setup HDR
-        if (connector->props.values.max_bpc && connector->maxBpcBounds.at(0) && connector->maxBpcBounds.at(1)) {
+        if (connector->props.values.max_bpc && connector->maxBpcBounds.at(0) && connector->maxBpcBounds.at(1) && !connector->maxBpcFailed) {
             newMaxBpc = getMaxBPC(connector->maxBpcBounds.at(0), connector->maxBpcBounds.at(1), data.mainFB->buffer->dmabuf().format);
-            if (forceConnProps || connector->atomic.maxBpc != newMaxBpc)
+            if (forceConnProps || connector->atomic.maxBpc != newMaxBpc) {
                 add(connector->id, connector->props.values.max_bpc, newMaxBpc);
+                maxBpcEmitted = true;
+            }
         }
 
         if (connector->props.values.Colorspace && connector->colorspace.values.BT2020_RGB) {
@@ -275,10 +278,11 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
             add(connector->id, connector->props.values.content_type, newContentType);
     }
 
-    data.atomic.maxBpc      = newMaxBpc;
-    data.atomic.colorspace  = newColorspace;
-    data.atomic.contentType = newContentType;
-    data.atomic.crtcID      = newCrtcID;
+    data.atomic.maxBpc        = newMaxBpc;
+    data.atomic.maxBpcEmitted = maxBpcEmitted;
+    data.atomic.colorspace    = newColorspace;
+    data.atomic.contentType   = newContentType;
+    data.atomic.crtcID        = newCrtcID;
 
     add(connector->crtc->id, connector->crtc->props.values.active, enable);
 
@@ -575,6 +579,53 @@ bool Aquamarine::CDRMAtomicImpl::commit(Hyprutils::Memory::CSharedPointer<SDRMCo
         flags |= DRM_MODE_ATOMIC_NONBLOCK;
 
     bool ok = request.commit(flags);
+
+    // If the commit failed and max_bpc was actually emitted in this request, retry
+    // without it. Some drivers (notably amdgpu on eDP panels) reject atomic commits
+    // that touch max_bpc. Gate on maxBpcEmitted rather than the staged maxBpc value:
+    // on cached page-flips max_bpc is skipped when unchanged, so an unrelated atomic
+    // failure must not be misattributed to max_bpc and permanently latch maxBpcFailed.
+    if (!ok && data.atomic.maxBpcEmitted && !connector->maxBpcFailed) {
+        connector->backend->backend->log(AQ_LOG_WARNING, "drm: atomic commit failed with max_bpc set, retrying without max_bpc");
+
+        // Re-build the request without max_bpc (addConnector checks maxBpcFailed
+        // and will skip the max_bpc property). The property blobs created in
+        // prepareConnector() are reused as-is, so we must NOT roll back the
+        // original request here or request2 would submit already-destroyed blob
+        // IDs. Blob cleanup is handled by request2.apply()/rollback() below.
+        // maxBpcFailed is latched here so addConnector omits the property, then
+        // cleared on retry failure so a transient error does not permanently
+        // disable max_bpc for this connector.
+        connector->maxBpcFailed   = true;
+        data.atomic.maxBpc        = 0;
+        data.atomic.maxBpcEmitted = false;
+
+        CDRMAtomicRequest request2(backend);
+        request2.addConnector(connector, data);
+
+        ok = request2.commit(flags);
+
+        if (ok) {
+            request2.apply(data);
+            if (!data.test) {
+                connector->atomic.maxBpc      = data.atomic.maxBpc;
+                connector->atomic.colorspace  = data.atomic.colorspace;
+                connector->atomic.contentType = data.atomic.contentType;
+                connector->atomic.crtcID      = data.atomic.crtcID;
+                connector->atomic.propsCached = true;
+                if (data.atomic.ctmd)
+                    connector->crtc->atomic.ctmStateKnown = true;
+
+                if (data.mainFB && data.enabled && (flags & DRM_MODE_PAGE_FLIP_EVENT))
+                    connector->sched.onFrameSubmitted();
+            }
+        } else {
+            connector->maxBpcFailed = false;
+            request2.rollback(data);
+        }
+
+        return ok;
+    }
 
     // A modeset the driver rejects may still be reachable if every head is
     // modeset together, since display resources are allocated globally. Retry


### PR DESCRIPTION
This solves the black screen issue (in my testing) discussed at length here: https://github.com/hyprwm/Hyprland/discussions/10248

> [!NOTE]
> Claude generated this fix, so I have no idea how "good" it is but it appears to solve the black screen issue within aquamarine.

Former solutions involved commenting out the check on src/backend/drm/impl/Atomic.cpp:163 or using `AQ_NO_ATOMIC=1` but this would disable other features like gamma adjustment.

I'm happy to make any revisions or style changes, just wanted to hopefully add a fix for this CPU/machine upstream since I've been manually patching aquamarine with each new release.
 