### PR TITLE
renderer: use version-compatible EGL debug context attributes

### DIFF
--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -475,8 +475,15 @@ void CDRMRenderer::initContext() {
         attrs.push_back(EGL_CONTEXT_RELEASE_BEHAVIOR_NONE_KHR); // or _FLUSH_KHR
     }
 
-    attrs.push_back(EGL_CONTEXT_OPENGL_DEBUG);
-    attrs.push_back(Aquamarine::isTrace() ? EGL_TRUE : EGL_FALSE);
+    if (Aquamarine::isTrace()) {
+        if (major > 1 || (major == 1 && minor >= 5)) {
+            attrs.push_back(EGL_CONTEXT_OPENGL_DEBUG);
+            attrs.push_back(EGL_TRUE);
+        } else if (EGLEXTENSIONS.contains("EGL_KHR_create_context")) {
+            attrs.push_back(EGL_CONTEXT_FLAGS_KHR);
+            attrs.push_back(EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR);
+        }
+    }
 
     auto attrsNoVer = attrs;
 


### PR DESCRIPTION
EGL introduced EGL_CONTEXT_OPENGL_DEBUG starting with 1.5, older EGL implementations don't recognize this attribute and will return EGL_BAD_ATTRIBUTE error back.
For older implementations exposing EGL_KHR_create_context, request the equivalent debug context through EGL_CONTEXT_FLAGS_KHR and EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR.

Issue: #292 