### PR TITLE
atomic: fix undefined behavior in cursor plane position cast

### DIFF
--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -88,8 +88,8 @@ void Aquamarine::CDRMAtomicRequest::planeProps(Hyprutils::Memory::CSharedPointer
         TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic planeProps: disabling plane {}", plane->id)));
         add(plane->id, plane->props.values.fb_id, 0);
         add(plane->id, plane->props.values.crtc_id, 0);
-        add(plane->id, plane->props.values.crtc_x, (uint64_t)pos.x);
-        add(plane->id, plane->props.values.crtc_y, (uint64_t)pos.y);
+        add(plane->id, plane->props.values.crtc_x, (uint64_t)(int64_t)pos.x);
+        add(plane->id, plane->props.values.crtc_y, (uint64_t)(int64_t)pos.y);
         return;
     }
 
@@ -117,8 +117,8 @@ void Aquamarine::CDRMAtomicRequest::planePropsPos(Hyprutils::Memory::CSharedPoin
 
     TRACE(backend->log(AQ_LOG_TRACE, std::format("atomic planeProps: pos blobs: crtc_x {}, crtc_y {}", plane->props.values.crtc_x, plane->props.values.crtc_y)));
 
-    add(plane->id, plane->props.values.crtc_x, (uint64_t)pos.x);
-    add(plane->id, plane->props.values.crtc_y, (uint64_t)pos.y);
+    add(plane->id, plane->props.values.crtc_x, (uint64_t)(int64_t)pos.x);
+    add(plane->id, plane->props.values.crtc_y, (uint64_t)(int64_t)pos.y);
 }
 
 void Aquamarine::CDRMAtomicRequest::setConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector) {


### PR DESCRIPTION
Fixes undefined behavior where negative cursor plane coordinates are cast directly from double to uint64_t.
On generic x86-64 targets, the compiler emits a signed conversion that incidentally produces the correct bit representation of a negative input.
On AVX-512 targets, the compiler emits a true unsigned conversion that saturates negative inputs to all-ones and gets read as -1. This locks CRTC_X or CRTC_Y to -1 when either axis of the cursor plane position is negative. 
The fix is to first cast to int64_t and then to uint64_t, which is defined behavior.

The cursor plane geometry issue addressed in hyprwm/Hyprland#14988 makes this issue much more apparent on rotated displays because the cursor buffer reaches the edge of the monitor before the cursor image does. The combined effect can be seen in hyprwm/Hyprland#10969 and described in #225.

With this change, and building with -march=znver4, I am able to use HW cursors without the cursor plane getting stuck.