### PR TITLE
frame: ensure only one frame when pageflip occurs

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -155,13 +155,13 @@ namespace Aquamarine {
         } legacy;
 
         struct {
-            bool     ownModeID     = false;
-            uint32_t modeID        = 0;
-            uint32_t gammaLut      = 0;
-            uint32_t ctm           = 0;
-            uint32_t hdr           = 0;
+            bool     ownModeID = false;
+            uint32_t modeID    = 0;
+            uint32_t gammaLut  = 0;
+            uint32_t ctm       = 0;
+            uint32_t hdr       = 0;
             // true once a real commit has made the kernel CTM match our state.
-            bool     ctmStateKnown = false;
+            bool ctmStateKnown = false;
         } atomic;
 
         Hyprutils::Memory::CSharedPointer<SDRMPlane> primary;
@@ -205,6 +205,7 @@ namespace Aquamarine {
         virtual size_t                                                    getDeGammaSize();
         virtual std::vector<SDRMFormat>                                   getRenderFormats();
         virtual bool                                                      pendingPageFlip();
+        virtual bool                                                      pendingIdleFrame();
         void                                                              releaseMgpuResources();
 
         int                                                               getConnectorID();

--- a/include/aquamarine/backend/Headless.hpp
+++ b/include/aquamarine/backend/Headless.hpp
@@ -21,6 +21,7 @@ namespace Aquamarine {
         virtual bool                                                      destroy();
         virtual std::vector<SDRMFormat>                                   getRenderFormats();
         virtual bool                                                      pendingPageFlip();
+        virtual bool                                                      pendingIdleFrame();
 
         Hyprutils::Memory::CWeakPointer<CHeadlessOutput>                  self;
 

--- a/include/aquamarine/backend/Wayland.hpp
+++ b/include/aquamarine/backend/Wayland.hpp
@@ -51,6 +51,7 @@ namespace Aquamarine {
         virtual bool                                                      destroy();
         virtual std::vector<SDRMFormat>                                   getRenderFormats();
         virtual bool                                                      pendingPageFlip();
+        virtual bool                                                      pendingIdleFrame();
 
         Hyprutils::Memory::CWeakPointer<CWaylandOutput>                   self;
 

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -75,7 +75,7 @@ namespace Aquamarine {
             uint32_t                                       drmFormat = DRM_FORMAT_INVALID;
             Hyprutils::Memory::CSharedPointer<IBuffer>     buffer;
             int32_t                                        explicitInFence = -1, explicitOutFence = -1;
-            Hyprutils::Math::Mat3x3                        ctm = Hyprutils::Math::Mat3x3::identity();
+            Hyprutils::Math::Mat3x3                        ctm            = Hyprutils::Math::Mat3x3::identity();
             bool                                           wideColorGamut = false;
             hdr_output_metadata                            hdrMetadata;
             uint16_t                                       contentType = DRM_MODE_CONTENT_TYPE_GRAPHICS;
@@ -171,7 +171,8 @@ namespace Aquamarine {
         virtual size_t                                                    getGammaSize();
         virtual size_t                                                    getDeGammaSize();
         virtual bool                                                      destroy(); // not all backends allow this!!!
-        virtual bool                                                      pendingPageFlip() = 0;
+        virtual bool                                                      pendingPageFlip()  = 0;
+        virtual bool                                                      pendingIdleFrame() = 0;
 
         std::string                                                       name, description, make, model, serial;
         SParsedEDID                                                       parsedEDID;

--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -110,6 +110,9 @@ Hyprutils::Memory::CSharedPointer<CBackend> Aquamarine::CBackend::create(const s
 }
 
 Aquamarine::CBackend::~CBackend() {
+    if (idle.fd >= 0)
+        close(idle.fd);
+
     // Tear down implementations before the logger is destroyed,
     // as backends may log during teardown (e.g. SDRMConnector::disconnect).
     implementations.clear();
@@ -130,7 +133,7 @@ bool Aquamarine::CBackend::start() {
 
     for (size_t i = 0; i < implementations.size(); ++i) {
         const auto& impl = implementations.at(i);
-        const bool ok = impl->start();
+        const bool  ok   = impl->start();
 
         if (!ok) {
             log(AQ_LOG_ERROR, std::format("Requested backend ({}) could not start, enabling fallbacks", backendTypeToName(impl->type())));

--- a/src/backend/Headless.cpp
+++ b/src/backend/Headless.cpp
@@ -44,6 +44,10 @@ bool Aquamarine::CHeadlessOutput::pendingPageFlip() {
     return false;
 }
 
+bool Aquamarine::CHeadlessOutput::pendingIdleFrame() {
+    return frameScheduled;
+}
+
 Hyprutils::Memory::CSharedPointer<IBackendImplementation> Aquamarine::CHeadlessOutput::getBackend() {
     return backend.lock();
 }

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -570,6 +570,10 @@ bool Aquamarine::CWaylandOutput::pendingPageFlip() {
     return false;
 }
 
+bool Aquamarine::CWaylandOutput::pendingIdleFrame() {
+    return frameScheduled;
+}
+
 bool Aquamarine::CWaylandOutput::destroy() {
     events.destroy.emit();
     waylandState.surface->sendAttach(nullptr, 0, 0);

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1171,6 +1171,11 @@ static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, un
     });
 
     if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState) {
+        if (pageFlip->connector->frameEventScheduled) {
+            pageFlip->connector->isFrameRunning = false;
+            return; // we got a idleFrame waiting before this pf was committed.
+        }
+
         pageFlip->connector->output->events.frame.emit();
         pageFlip->connector->isFrameRunning = false;
     }
@@ -2387,6 +2392,10 @@ bool Aquamarine::CDRMOutput::pendingPageFlip() {
     return connector->isPageFlipPending;
 }
 
+bool Aquamarine::CDRMOutput::pendingIdleFrame() {
+    return connector->frameEventScheduled;
+}
+
 int Aquamarine::CDRMOutput::getConnectorID() {
     return connector->id;
 }
@@ -2395,11 +2404,19 @@ Aquamarine::CDRMOutput::CDRMOutput(const std::string& name_, Hyprutils::Memory::
     backend(backend_), connector(connector_) {
     name = name_;
 
-    frameIdle = makeShared<std::function<void(void)>>([this]() {
+    frameIdle = makeShared<std::function<void(void)>>([this, backend = backend_]() {
         connector->frameEventScheduled = false;
+
         if (connector->isPageFlipPending || connector->isFrameRunning)
             return;
+
         events.frame.emit();
+
+        // above frame scheduled, and then committed, remove the idle frame. the pageflip will emit the frame.
+        if (backend && backend->backend && connector->frameEventScheduled && connector->isPageFlipPending) {
+            backend->backend->removeIdleEvent(frameIdle);
+            connector->frameEventScheduled = false;
+        }
     });
 }
 


### PR DESCRIPTION
ensure we only get one frame if a pageflip occurs or a idleFrame callback is about to run, otherwise we can end up emitting .frame() twice. the wayland event loop has no order guarantee that one or the other is called first even if added or signaled first.

also add a pendingIdleFrame() function that can be used from compositors to early out scheduling if there is already one scheduled.

and close the idle.fd in backend destructor.