### PR TITLE
drm: attach a right-sized swapchain buffer on modeset commits

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -2182,6 +2182,22 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
     else
         data.calculateMode(connector);
 
+    // A modeset commit must carry a buffer sized for the new mode: the atomic path
+    // derives the plane geometry from it (and legacy SetCrtc has the same requirement),
+    // so drivers without plane scaling (e.g. virtio-gpu) reject stale-size buffers,
+    // making larger modes unreachable.
+    // If the consumer already reconfigured the swapchain to the new size, attach a fresh buffer from it.
+    bool acquiredModesetBuffer = false;
+    if (data.modeset && data.mainFB && swapchain && data.mainFB->buffer->size != MODE->pixelSize && swapchain->currentOptions().size == MODE->pixelSize) {
+        if (auto newBuf = swapchain->next(nullptr); newBuf) {
+            if (auto newFB = CDRMFB::create(newBuf, backend, nullptr); newFB && !newFB->dead) {
+                data.mainFB           = newFB;
+                acquiredModesetBuffer = true;
+            } else
+                swapchain->rollback();
+        }
+    }
+
     // Re-send CTM when it changes, when preserving a non-identity CTM over a modeset,
     // or when we need one identity blob to clear unknown kernel state from before us.
     // Once a real CTM commit succeeds, ordinary identity modesets can skip the blob.
@@ -2205,6 +2221,11 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
     }
 
     bool ok = connector->commitState(data);
+
+    // a buffer acquired only to validate/attempt the modeset isn't consumed by the
+    // consumer: rewind the swapchain so the acquire cursor stays in sync with it.
+    if (acquiredModesetBuffer && (onlyTest || !ok))
+        swapchain->rollback();
 
     if (!ok && !data.modeset && !connector->commitTainted) {
         // attempt to re-modeset, however, flip a tainted flag if the modesetting fails


### PR DESCRIPTION
## Summary
- on modeset commits whose attached buffer size doesn't match the target mode, attach a fresh buffer from the output swapchain when it has already been reconfigured to the new size
- rewind the swapchain when the acquired buffer is only used for a test commit (or the commit fails), keeping the acquire cursor in sync with the consumer

## Why
The consumer (e.g. Hyprland) reconfigures the output swapchain before testing a new mode, but the state it commits still carries the previous front buffer. Both impls size the scanout from that buffer: the atomic path's `planeProps()` sets `src_w/h` and `crtc_w/h` from `fb->buffer->size`, and legacy `drmModeSetCrtc` has the same coverage requirement.

On drivers with primary-plane scaling (i915/amdgpu) this is mostly masked, but drivers without it — e.g. virtio-gpu in VMs — fail the atomic check for every mode **increase**:

```
[drm:drm_atomic_helper_check_plane_state] Plane must cover entire CRTC
[drm:drm_rect_debug_print] dst: 1920x1200+0+0      <- old buffer size
[drm:drm_rect_debug_print] clip: 2048x1280+0+0     <- requested mode
[drm:drm_atomic_check_only] atomic driver check for ... failed: -22
```

(captured with `drm.debug` in a Parallels aarch64 VM, kernel 6.18: the `dst` rect comes from the stale buffer, the `clip` from the new mode)

Mode **decreases** pass only because the kernel clips the oversized plane rect down to exactly the new mode. The net effect is a one-way ratchet: resolution can be lowered but never raised again until the compositor restarts (a fresh session works because no old buffer exists yet). This is the mechanism behind #268 (there on i915 HDMI, where no plane scaler was available).

## Notes
- The freshly acquired buffer is not rendered by the consumer before the real modeset scans it out, so its content is undefined for one frame. That seemed acceptable for a modeset (which blanks/flickers anyway); clearing it would require a renderer reference here — happy to add if preferred.
- The multi-GPU blit path allocates `data.mainFB` from `mgpu.swapchain`; a replacement pulled from the output swapchain there would fail KMS import and be dropped by the `newFB && !newFB->dead` guard, leaving current behavior. Not addressed here.

## Validation
- Parallels Desktop VM (aarch64, virtio-gpu, kernel 6.18), Hyprland 0.55.4 with this change backported onto aquamarine 0.11.0: resolution increases via wlr-output-management (`wlr-randr --mode` / `--custom-mode`) now apply, including sizes not in the connector mode list; previously every increase failed the `TEST_ONLY` commit and Hyprland fell back to the old (or a smaller) mode. Decreases behave as before.
- `nix build` on this branch succeeds.

Fixes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)
