### PR TITLE
drm: dont reset needFrame on stashing

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -2216,7 +2216,6 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
         events.commit.emit();
         state->onCommit();
         lastCommitNoBuffer = false;
-        needsFrame         = false;
         return true;
     }
 


### PR DESCRIPTION
this commit hasnt been presented and handlePF emits frameReady before draining the stash, clearing here would drop scheduleFrame requests made while the flip was in flight.