### PR TITLE
drm: add support for COLOR_RANGE prop

### DIFF
--- a/include/aquamarine/backend/Backend.hpp
+++ b/include/aquamarine/backend/Backend.hpp
@@ -30,6 +30,15 @@ namespace Aquamarine {
         AQ_BACKEND_NULL,
     };
 
+    enum eBackendGPUDriver : uint32_t {
+        AQ_BACKEND_GPU_DRIVER_UNKNOWN = 0,
+        AQ_BACKEND_GPU_DRIVER_INTEL,   // i915, xe
+        AQ_BACKEND_GPU_DRIVER_AMD,     // amdgpu, radeon
+        AQ_BACKEND_GPU_DRIVER_NVIDIA,  // proprietary nvidia-drm
+        AQ_BACKEND_GPU_DRIVER_NOUVEAU, // open source nouveau
+        AQ_BACKEND_GPU_DRIVER_EVDI,    // displayLink virtual driver
+    };
+
     enum eBackendRequestMode : uint32_t {
         /*
             Require the provided backend, will error out if it's not available.
@@ -95,6 +104,7 @@ namespace Aquamarine {
         virtual std::vector<Hyprutils::Memory::CSharedPointer<IAllocator>> getAllocators()   = 0;
         virtual Hyprutils::Memory::CWeakPointer<IBackendImplementation>    getPrimary()      = 0;
         virtual int                                                        drmRenderNodeFD() = 0;
+        virtual eBackendGPUDriver                                          gpuDriver();
     };
 
     class CBackend {

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -140,10 +140,21 @@ namespace Aquamarine {
                 uint32_t hotspot_x;
                 uint32_t hotspot_y;
                 uint32_t in_fence_fd;
+                uint32_t color_range;
             } values;
-            uint32_t props[17] = {0};
+            uint32_t props[18] = {0};
         };
         UDRMPlaneProps props;
+
+        // only valid when color_range != 0
+        union UDRMPlaneColorRange {
+            struct {
+                uint32_t Full_YCbCr;
+                uint32_t Limited_YCbCr;
+            } values;
+            uint32_t props[2] = {0};
+        };
+        UDRMPlaneColorRange colorRange;
     };
 
     struct SDRMCRTC {
@@ -436,6 +447,7 @@ namespace Aquamarine {
         std::vector<FIdleCallback>                                         idleCallbacks;
         std::string                                                        gpuName;
         virtual int                                                        drmRenderNodeFD();
+        virtual eBackendGPUDriver                                          gpuDriver();
 
       private:
         CDRMBackend(Hyprutils::Memory::CSharedPointer<CBackend> backend);
@@ -469,6 +481,7 @@ namespace Aquamarine {
         } rendererState;
 
         bool                                                          rendererRequired = true;
+        eBackendGPUDriver                                             driver           = AQ_BACKEND_GPU_DRIVER_UNKNOWN;
 
         Hyprutils::Memory::CWeakPointer<CBackend>                     backend;
 

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -37,6 +37,12 @@ namespace Aquamarine {
         AQ_SUBPIXEL_VERTICAL_BGR,
     };
 
+    enum eOutputColorRange : uint32_t {
+        AQ_OUTPUT_COLOR_RANGE_AUTO = 0, // leave the driver default
+        AQ_OUTPUT_COLOR_RANGE_FULL,     // force full range
+        AQ_OUTPUT_COLOR_RANGE_LIMITED,  // force limited (16-235) range
+    };
+
     class IOutput;
 
     class COutputState {
@@ -79,6 +85,7 @@ namespace Aquamarine {
             bool                                           wideColorGamut = false;
             hdr_output_metadata                            hdrMetadata;
             uint16_t                                       contentType = DRM_MODE_CONTENT_TYPE_GRAPHICS;
+            eOutputColorRange                              colorRange  = AQ_OUTPUT_COLOR_RANGE_AUTO;
         };
 
         const SInternalState& state();
@@ -101,6 +108,7 @@ namespace Aquamarine {
         void                  setWideColorGamut(bool wcg);
         void                  setHDRMetadata(const hdr_output_metadata& metadata);
         void                  setContentType(const uint16_t drmContentType);
+        void                  setColorRange(eOutputColorRange range);
 
       private:
         SInternalState internalState;

--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -389,3 +389,7 @@ int Aquamarine::CBackend::reopenDRMNode(int drmFD, bool allowRenderNode) {
 std::vector<SDRMFormat> Aquamarine::IBackendImplementation::getRenderableFormats() {
     return {};
 }
+
+eBackendGPUDriver Aquamarine::IBackendImplementation::gpuDriver() {
+    return AQ_BACKEND_GPU_DRIVER_UNKNOWN;
+}

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -873,13 +873,29 @@ bool Aquamarine::CDRMBackend::registerGPU(SP<CSessionDevice> gpu_, SP<CDRMBacken
     gpu     = gpu_;
     primary = primary_;
 
+    auto driverFromName = [](const std::string_view name) {
+        if (name == "i915" || name == "xe")
+            return AQ_BACKEND_GPU_DRIVER_INTEL;
+        if (name == "amdgpu" || name == "radeon")
+            return AQ_BACKEND_GPU_DRIVER_AMD;
+        if (name == "nvidia-drm")
+            return AQ_BACKEND_GPU_DRIVER_NVIDIA;
+        if (name == "nouveau")
+            return AQ_BACKEND_GPU_DRIVER_NOUVEAU;
+        if (name == "evdi")
+            return AQ_BACKEND_GPU_DRIVER_EVDI;
+
+        return AQ_BACKEND_GPU_DRIVER_UNKNOWN;
+    };
+
     auto drmName = drmGetDeviceNameFromFd2(gpu->fd);
     auto drmVer  = drmGetVersion(gpu->fd);
 
     gpuName = drmName ? drmName : "unknown";
 
     auto drmVerName = drmVer && drmVer->name ? drmVer->name : "unknown";
-    if (std::string_view(drmVerName) == "evdi") {
+    driver          = driverFromName(drmVerName);
+    if (driver == AQ_BACKEND_GPU_DRIVER_EVDI) {
         // DisplayLink/evdi exposes KMS without a usable EGL renderer.
         primary          = {};
         rendererRequired = false;
@@ -1136,6 +1152,10 @@ int Aquamarine::CDRMBackend::drmRenderNodeFD() {
     return gpu->renderNodeFd;
 }
 
+eBackendGPUDriver Aquamarine::CDRMBackend::gpuDriver() {
+    return driver;
+}
+
 static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, unsigned crtc_id, void* data) {
     auto pageFlip = (SDRMPageFlip*)data;
 
@@ -1322,6 +1342,9 @@ bool Aquamarine::SDRMPlane::init(drmModePlane* plane) {
 
     if (!getDRMPlaneProps(backend->gpu->fd, id, &props))
         return false;
+
+    if (props.values.color_range)
+        getDRMPlaneColorRange(backend->gpu->fd, props.values.color_range, &colorRange);
 
     if (!getDRMProp(backend->gpu->fd, id, props.values.type, &type))
         return false;

--- a/src/backend/drm/Props.cpp
+++ b/src/backend/drm/Props.cpp
@@ -57,6 +57,7 @@ static const struct prop_info crtc_info[] = {
 
 static const struct prop_info plane_info[] = {
 #define INDEX(name) (offsetof(SDRMPlane::UDRMPlaneProps, values.name) / sizeof(uint32_t))
+    {.name = "COLOR_RANGE", .index = INDEX(color_range)},
     {.name = "CRTC_H", .index = INDEX(crtc_h)},
     {.name = "CRTC_ID", .index = INDEX(crtc_id)},
     {.name = "CRTC_W", .index = INDEX(crtc_w)},
@@ -74,6 +75,13 @@ static const struct prop_info plane_info[] = {
     {.name = "SRC_Y", .index = INDEX(src_y)},
     {.name = "rotation", .index = INDEX(rotation)},
     {.name = "type", .index = INDEX(type)},
+#undef INDEX
+};
+
+static const struct prop_info colorrange_info[] = {
+#define INDEX(name) (offsetof(SDRMPlane::UDRMPlaneColorRange, values.name) / sizeof(uint32_t))
+    {.name = "YCbCr full range", .index = INDEX(Full_YCbCr)},
+    {.name = "YCbCr limited range", .index = INDEX(Limited_YCbCr)},
 #undef INDEX
 };
 
@@ -137,6 +145,10 @@ namespace Aquamarine {
 
     bool getDRMPlaneProps(int fd, uint32_t id, SDRMPlane::UDRMPlaneProps* out) {
         return scanProperties(fd, id, DRM_MODE_OBJECT_PLANE, out->props, plane_info, sizeof(plane_info) / sizeof(plane_info[0]));
+    }
+
+    bool getDRMPlaneColorRange(int fd, uint32_t id, SDRMPlane::UDRMPlaneColorRange* out) {
+        return scanPropertyEnum(fd, id, out->props, colorrange_info, sizeof(colorrange_info) / sizeof(colorrange_info[0]));
     }
 
     bool getDRMProp(int fd, uint32_t obj, uint32_t prop, uint64_t* ret) {

--- a/src/backend/drm/Props.hpp
+++ b/src/backend/drm/Props.hpp
@@ -7,6 +7,7 @@ namespace Aquamarine {
     bool  getDRMConnectorColorspace(int fd, uint32_t id, SDRMConnector::UDRMConnectorColorspace* out);
     bool  getDRMCRTCProps(int fd, uint32_t id, SDRMCRTC::UDRMCRTCProps* out);
     bool  getDRMPlaneProps(int fd, uint32_t id, SDRMPlane::UDRMPlaneProps* out);
+    bool  getDRMPlaneColorRange(int fd, uint32_t id, SDRMPlane::UDRMPlaneColorRange* out);
     bool  getDRMProp(int fd, uint32_t obj, uint32_t prop, uint64_t* ret);
     void* getDRMPropBlob(int fd, uint32_t obj, uint32_t prop, size_t* ret_len);
     char* getDRMPropEnum(int fd, uint32_t obj, uint32_t prop_id);

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -6,6 +6,7 @@
 #include <xf86drmMode.h>
 #include <sys/mman.h>
 #include <sstream>
+#include <optional>
 #include "Shared.hpp"
 #include "aquamarine/output/Output.hpp"
 
@@ -107,6 +108,23 @@ void Aquamarine::CDRMAtomicRequest::planeProps(Hyprutils::Memory::CSharedPointer
     add(plane->id, plane->props.values.crtc_h, (uint32_t)fb->buffer->size.y);
     add(plane->id, plane->props.values.fb_id, fb->id);
     add(plane->id, plane->props.values.crtc_id, crtc);
+
+    if (plane->props.values.color_range) {
+        const auto              colorRange = conn && conn->output ? conn->output->state->state().colorRange : AQ_OUTPUT_COLOR_RANGE_AUTO;
+        std::optional<uint32_t> rangeVal;
+        switch (colorRange) {
+            case AQ_OUTPUT_COLOR_RANGE_FULL: rangeVal = plane->colorRange.values.Full_YCbCr; break;
+            case AQ_OUTPUT_COLOR_RANGE_LIMITED: rangeVal = plane->colorRange.values.Limited_YCbCr; break;
+            case AQ_OUTPUT_COLOR_RANGE_AUTO:
+                // https://github.com/NVIDIA/open-gpu-kernel-modules/discussions/1105
+                if (backend->gpuDriver() == AQ_BACKEND_GPU_DRIVER_NVIDIA)
+                    rangeVal = plane->colorRange.values.Full_YCbCr;
+                break;
+        }
+        if (rangeVal)
+            add(plane->id, plane->props.values.color_range, *rangeVal);
+    }
+
     planePropsPos(plane, pos);
 }
 

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -142,6 +142,10 @@ void Aquamarine::COutputState::setContentType(const uint16_t drmContentType) {
     internalState.contentType = drmContentType;
 }
 
+void Aquamarine::COutputState::setColorRange(eOutputColorRange range) {
+    internalState.colorRange = range;
+}
+
 void Aquamarine::COutputState::onCommit() {
     internalState.committed = 0;
     internalState.damage.clear();


### PR DESCRIPTION
https://drmdb.emersion.fr/properties/plane/COLOR_RANGE

add support for COLOR_RANGE drm prop, so we both can manually set it, and quirk around a nvidia bug
https://github.com/NVIDIA/open-gpu-kernel-modules/discussions/1105 , also add a enum for getting the backend gpu driver in use.