### PR TITLE
drm: drop unaccounted pageflip, dont present tearing twice

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -319,10 +319,10 @@ namespace Aquamarine {
         IOutput::SParsedEDID                           parseEDID(std::vector<uint8_t> data);
         bool                                           commitState(SDRMConnectorCommitData& data);
         void                                           applyCommit(const SDRMConnectorCommitData& data);
-        void                                           rollbackCommit(const SDRMConnectorCommitData& data);
         void                                           onPresent();
         void                                           recheckCRTCProps();
         void                                           parseTileInfo();
+        void                                           releaseFBBuffer(const Hyprutils::Memory::CSharedPointer<CDRMFB> fb);
         void                                           releaseFBReferences();
         void                                           invalidateFrame();
         void                                           setCRTC(Hyprutils::Memory::CSharedPointer<SDRMCRTC> newCRTC);
@@ -346,7 +346,6 @@ namespace Aquamarine {
 
         bool                                           cursorEnabled = false;
         Hyprutils::Math::Vector2D                      cursorPos, cursorSize, cursorHotspot;
-        Hyprutils::Memory::CSharedPointer<CDRMFB>      pendingCursorFB;
 
         CFrameScheduler                                sched;
 

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -163,7 +163,7 @@ namespace Aquamarine {
         int32_t                refresh = 0; // unused
 
         struct {
-            uintptr_t                                      id = 0; // 0 when nothing is in flight
+            std::optional<uintptr_t>                       id; // nullopt when nothing is in flight
             Hyprutils::Memory::CWeakPointer<SDRMConnector> connector;
             bool                                           async = false; // PAGE_FLIP_ASYNC
         } pendingFlip;

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -163,6 +163,15 @@ namespace Aquamarine {
         int32_t                refresh = 0; // unused
 
         struct {
+            uintptr_t                                      id = 0; // 0 when nothing is in flight
+            Hyprutils::Memory::CWeakPointer<SDRMConnector> connector;
+            bool                                           async = false; // PAGE_FLIP_ASYNC
+        } pendingFlip;
+
+        uintptr_t armPageFlip(Hyprutils::Memory::CWeakPointer<SDRMConnector> connector, bool async);
+        void      disarmPageFlip();
+
+        struct {
             int gammaSize = 0;
         } legacy;
 
@@ -251,10 +260,6 @@ namespace Aquamarine {
         friend class CDRMLease;
     };
 
-    struct SDRMPageFlip {
-        Hyprutils::Memory::CWeakPointer<SDRMConnector> connector;
-    };
-
     struct SDRMConnectorCommitData {
         Hyprutils::Memory::CSharedPointer<CDRMFB> mainFB, cursorFB;
         bool                                      modeset   = false;
@@ -319,6 +324,8 @@ namespace Aquamarine {
         void                                           recheckCRTCProps();
         void                                           parseTileInfo();
         void                                           releaseFBReferences();
+        void                                           invalidateFrame();
+        void                                           setCRTC(Hyprutils::Memory::CSharedPointer<SDRMCRTC> newCRTC);
 
         Hyprutils::Memory::CSharedPointer<CDRMOutput>  output;
         Hyprutils::Memory::CWeakPointer<CDRMBackend>   backend;
@@ -341,7 +348,6 @@ namespace Aquamarine {
         Hyprutils::Math::Vector2D                      cursorPos, cursorSize, cursorHotspot;
         Hyprutils::Memory::CSharedPointer<CDRMFB>      pendingCursorFB;
 
-        SDRMPageFlip                                   pendingPageFlip;
         CFrameScheduler                                sched;
 
         // the current state is invalid and won't commit, don't try to modeset.
@@ -435,6 +441,7 @@ namespace Aquamarine {
         std::string                                                        gpuName;
         virtual int                                                        drmRenderNodeFD();
         virtual eBackendGPUDriver                                          gpuDriver();
+        Hyprutils::Memory::CSharedPointer<SDRMCRTC>                        crtcByID(uint32_t id);
 
       private:
         CDRMBackend(Hyprutils::Memory::CSharedPointer<CBackend> backend);
@@ -477,6 +484,8 @@ namespace Aquamarine {
         std::vector<Hyprutils::Memory::CSharedPointer<SDRMConnector>> connectors;
         std::vector<SDRMFormat>                                       formats;
         std::vector<SDRMFormat>                                       glFormats;
+        uintptr_t                                                     m_lastPageFlipID = 0;
+        uintptr_t                                                     nextPageFlipID();
 
         Hyprutils::Memory::CSharedPointer<CDRMDumbAllocator>          dumbAllocator;
 
@@ -502,7 +511,6 @@ namespace Aquamarine {
         friend struct SDRMCRTC;
         friend struct SDRMPlane;
         friend class CDRMOutput;
-        friend struct SDRMPageFlip;
         friend class CDRMLegacyImpl;
         friend class CDRMAtomicImpl;
         friend class CDRMAtomicRequest;

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -90,6 +90,7 @@ namespace Aquamarine {
 
         const SInternalState& state();
 
+        bool                  needsReconfig() const;
         void                  addDamage(const Hyprutils::Math::CRegion& region);
         void                  clearDamage();
         void                  setEnabled(bool enabled);

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -16,7 +16,6 @@
 #include <cstring>
 #include <filesystem>
 #include <system_error>
-#include <unordered_set>
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -479,6 +478,8 @@ void Aquamarine::CDRMBackend::restoreAfterVT() {
 
         if (c->crtc->pendingCursor)
             data.cursorFB = c->crtc->pendingCursor;
+        else if (c->crtc->cursor)
+            data.cursorFB = c->crtc->cursor->front; // a consumed pending cursor lives on the plane
 
         if (data.cursorFB && (data.cursorFB->dead || data.cursorFB->buffer->dmabuf().modifier == DRM_FORMAT_MOD_INVALID))
             data.cursorFB = nullptr;
@@ -1570,20 +1571,19 @@ void Aquamarine::SDRMConnector::parseTileInfo() {
     free(blobData);
 }
 
+void Aquamarine::SDRMConnector::releaseFBBuffer(const SP<CDRMFB> fb) {
+    if (!fb)
+        return;
+
+    if (auto buf = fb->buffer.lock(); buf && buf->lockedByBackend) {
+        buf->lockedByBackend = false;
+        buf->events.backendRelease.emit();
+    }
+}
+
 void Aquamarine::SDRMConnector::releaseFBReferences() {
-    std::unordered_set<IBuffer*> releasedBuffers;
-
-    const auto                   releaseFB = [&releasedBuffers](SP<CDRMFB>& fb) {
-        if (!fb) {
-            fb.reset();
-            return;
-        }
-
-        if (auto buf = fb->buffer.lock(); buf && buf->lockedByBackend && releasedBuffers.emplace(buf.get()).second) {
-            buf->lockedByBackend = false;
-            buf->events.backendRelease.emit();
-        }
-
+    const auto releaseFB = [this](SP<CDRMFB> fb) {
+        releaseFBBuffer(fb);
         fb.reset();
     };
 
@@ -1602,8 +1602,6 @@ void Aquamarine::SDRMConnector::releaseFBReferences() {
 
         releaseFB(crtc->pendingCursor);
     }
-
-    releaseFB(pendingCursorFB);
 }
 
 Aquamarine::SDRMConnector::~SDRMConnector() {
@@ -1905,23 +1903,33 @@ bool Aquamarine::SDRMConnector::commitState(SDRMConnectorCommitData& data) {
 
     if (ok && !data.test)
         applyCommit(data);
-    else
-        rollbackCommit(data);
 
     return ok;
 }
 
 void Aquamarine::SDRMConnector::applyCommit(const SDRMConnectorCommitData& data) {
-    crtc->primary->back = data.mainFB;
-    if (crtc->cursor && data.cursorFB)
-        crtc->cursor->back = data.cursorFB;
+    const bool enable = data.enabled && data.mainFB;
 
-    if (data.mainFB)
+    if (enable && data.mainFB != crtc->primary->front) {
+        if (crtc->primary->back != crtc->primary->front && crtc->primary->back != data.mainFB)
+            releaseFBBuffer(crtc->primary->back);
+
+        crtc->primary->back                  = data.mainFB;
         data.mainFB->buffer->lockedByBackend = true;
-    if (crtc->cursor && data.cursorFB)
-        data.cursorFB->buffer->lockedByBackend = true;
+    }
 
-    pendingCursorFB.reset();
+    if (enable && crtc->cursor && data.cursorFB) {
+        if (data.cursorFB != crtc->cursor->front) {
+            if (crtc->cursor->back != crtc->cursor->front && crtc->cursor->back != data.cursorFB)
+                releaseFBBuffer(crtc->cursor->back);
+
+            crtc->cursor->back                     = data.cursorFB;
+            data.cursorFB->buffer->lockedByBackend = true;
+        }
+
+        if (crtc->pendingCursor == data.cursorFB)
+            crtc->pendingCursor.reset();
+    }
 
     if (data.committed & COutputState::AQ_OUTPUT_STATE_MODE)
         refresh = calculateRefresh(data.modeInfo);
@@ -1951,18 +1959,6 @@ void Aquamarine::SDRMConnector::applyCommit(const SDRMConnectorCommitData& data)
     }
 }
 
-void Aquamarine::SDRMConnector::rollbackCommit(const SDRMConnectorCommitData& data) {
-    // cursors are applied regardless,
-    // unless this was a test
-    if (data.test)
-        return;
-
-    if (crtc->cursor && data.cursorFB)
-        crtc->cursor->back = data.cursorFB;
-
-    crtc->pendingCursor.reset();
-}
-
 void Aquamarine::SDRMConnector::invalidateFrame() {
     sched.invalidate();
 
@@ -1980,14 +1976,16 @@ void Aquamarine::SDRMConnector::setCRTC(SP<SDRMCRTC> newCRTC) {
 }
 
 void Aquamarine::SDRMConnector::onPresent() {
-    crtc->primary->last  = crtc->primary->front;
-    crtc->primary->front = crtc->primary->back;
-    if (crtc->primary->last && crtc->primary->last->buffer) {
-        crtc->primary->last->buffer->lockedByBackend = false;
-        crtc->primary->last->buffer->events.backendRelease.emit();
+    if (crtc->primary->back && crtc->primary->back != crtc->primary->front) {
+        crtc->primary->last  = crtc->primary->front;
+        crtc->primary->front = crtc->primary->back;
+        if (crtc->primary->last && crtc->primary->last->buffer) {
+            crtc->primary->last->buffer->lockedByBackend = false;
+            crtc->primary->last->buffer->events.backendRelease.emit();
+        }
     }
 
-    if (crtc->cursor) {
+    if (crtc->cursor && crtc->cursor->back && crtc->cursor->back != crtc->cursor->front) {
         crtc->cursor->last  = crtc->cursor->front;
         crtc->cursor->front = crtc->cursor->back;
         if (crtc->cursor->last && crtc->cursor->last->buffer) {
@@ -2092,10 +2090,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
 
     // If we are changing the rendering format, we may need to reconfigure the output (aka modeset)
     // which may result in some glitches
-    const bool NEEDS_RECONFIG = COMMITTED &
-        (COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_ENABLED | COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_FORMAT |
-         COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_MODE | COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_HDR |
-         COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_WCG);
+    const bool NEEDS_RECONFIG = state->needsReconfig();
 
     const bool BLOCKING = NEEDS_RECONFIG || !(COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER);
 
@@ -2140,12 +2135,22 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
 
     SDRMConnectorCommitData data;
 
+    // A commit that carries no new buffer has nothing to blit: STATE.buffer is the one we already copied
+    SP<CDRMFB> blittedFB;
+    if (backend->shouldBlit() && !(COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER)) {
+        const auto& LAST = connector->crtc->primary->back ? connector->crtc->primary->back : connector->crtc->primary->front;
+        if (LAST && !LAST->dead)
+            blittedFB = LAST;
+    }
+
     if (STATE.buffer && STATE.enabled) {
         TRACE(backend->backend->log(AQ_LOG_TRACE, "drm: Committed a buffer, updating state"));
 
         SP<CDRMFB> drmFB;
 
-        if (backend->shouldBlit()) {
+        if (blittedFB)
+            drmFB = blittedFB;
+        else if (backend->shouldBlit()) {
             if (!backend->rendererState.renderer) {
                 backend->backend->log(AQ_LOG_DEBUG, "drm: No renderer attached to backend when required for blitting, initializing");
                 if (!backend->initMgpu() || !backend->rendererState.renderer || !backend->rendererState.allocator) {
@@ -2342,6 +2347,10 @@ SP<IBackendImplementation> Aquamarine::CDRMOutput::getBackend() {
 bool Aquamarine::CDRMOutput::setCursor(SP<IBuffer> buffer, const Vector2D& hotspot) {
     if (!connector->crtc)
         return false;
+
+    // already hidden
+    if (!buffer && !cursorVisible)
+        return true;
 
     state->internalState.committed |= COutputState::AQ_OUTPUT_STATE_CURSOR_SHAPE;
     if (!buffer)

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -2174,12 +2174,19 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
             OPTIONS.multigpu = false; // this is not a shared swapchain, and additionally, don't make it linear, nvidia would be mad
             OPTIONS.cursor   = false;
             OPTIONS.scanout  = true;
+            if (OPTIONS.length == 0) // releaseMgpuResources() cleared the swapchain and we committed without updating it.
+                OPTIONS.length = 2;
             if (!mgpu.swapchain->reconfigure(OPTIONS)) {
                 backend->backend->log(AQ_LOG_ERROR, "drm: Backend requires blit, but the mgpu swapchain failed reconfiguring");
                 return false;
             }
 
-            auto                         NEWAQBUF = mgpu.swapchain->next(nullptr);
+            auto NEWAQBUF = mgpu.swapchain->next(nullptr);
+            if (!NEWAQBUF) {
+                backend->backend->log(AQ_LOG_ERROR, "drm: Backend requires blit, but the mgpu swapchain has no buffer");
+                return false;
+            }
+
             SP<Aquamarine::CDRMRenderer> primaryRenderer;
             if (backend->primary)
                 primaryRenderer = backend->primary->rendererState.renderer;
@@ -2404,7 +2411,12 @@ bool Aquamarine::CDRMOutput::setCursor(SP<IBuffer> buffer, const Vector2D& hotsp
                 return false;
             }
 
-            auto                         NEWAQBUF = mgpu.cursorSwapchain->next(nullptr);
+            auto NEWAQBUF = mgpu.cursorSwapchain->next(nullptr);
+            if (!NEWAQBUF) {
+                backend->backend->log(AQ_LOG_ERROR, "drm: Backend requires blit, but the mgpu cursorSwapchain has no buffer");
+                return false;
+            }
+
             SP<Aquamarine::CDRMRenderer> primaryRenderer;
             if (backend->primary)
                 primaryRenderer = backend->primary->rendererState.renderer;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1582,7 +1582,7 @@ void Aquamarine::SDRMConnector::releaseFBBuffer(const SP<CDRMFB> fb) {
 }
 
 void Aquamarine::SDRMConnector::releaseFBReferences() {
-    const auto releaseFB = [this](SP<CDRMFB> fb) {
+    const auto releaseFB = [this](SP<CDRMFB>& fb) {
         releaseFBBuffer(fb);
         fb.reset();
     };

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1178,11 +1178,11 @@ uintptr_t Aquamarine::SDRMCRTC::armPageFlip(CWeakPointer<SDRMConnector> connecto
     pendingFlip.connector = connector;
     pendingFlip.async     = async;
 
-    return pendingFlip.id;
+    return pendingFlip.id.value();
 }
 
 void Aquamarine::SDRMCRTC::disarmPageFlip() {
-    pendingFlip.id = 0;
+    pendingFlip.id.reset();
     pendingFlip.connector.reset();
     pendingFlip.async = false;
 }

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -410,7 +410,7 @@ void Aquamarine::CDRMBackend::restoreAfterVT() {
     for (auto const& c : connectors) {
         if (c->sched.frameInFlight() || c->sched.frameRunning()) {
             backend->log(AQ_LOG_DEBUG, std::format("drm: Clearing stale page-flip state for {}", c->szName));
-            c->sched.invalidate();
+            c->invalidateFrame();
         }
     }
 
@@ -760,7 +760,7 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
         // disabled outputs release their CRTCs so active outputs get priority
         if (c->crtc && c->status == DRM_MODE_CONNECTED && c->output && !c->output->enabledState) {
             backend->log(AQ_LOG_DEBUG, std::format("drm: {} is disabled, releasing crtc {}", c->szName, c->crtc->id));
-            c->crtc.reset();
+            c->setCRTC(nullptr);
         }
 
         if (c->crtc && c->status == DRM_MODE_CONNECTED) {
@@ -812,7 +812,7 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
 
             backend->log(AQ_LOG_DEBUG,
                          std::format("drm: connected slot {} crtc {} assigned to {}{}", i, crtc->id, c->szName, c->crtc ? std::format(" (old {})", c->crtc->id) : ""));
-            c->crtc  = crtc;
+            c->setCRTC(crtc);
             assigned = true;
             changed.emplace_back(c);
             std::erase(recheck, c);
@@ -842,7 +842,7 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
                 continue;
 
             backend->log(AQ_LOG_DEBUG, std::format("drm: backup slot {} crtc {} assigned to disabled {}", i, crtcs.at(i)->id, c->szName));
-            c->crtc = crtcs.at(i);
+            c->setCRTC(crtcs.at(i));
             std::erase(recheck, c);
             break;
         }
@@ -854,7 +854,7 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
 
         if (c->crtc)
             backend->log(AQ_LOG_DEBUG, std::format("drm: {} is not connected, clearing stale crtc {}", c->szName, c->crtc->id));
-        c->crtc.reset();
+        c->setCRTC(nullptr);
     }
 
     // tell the user to re-assign a valid mode etc, if needed
@@ -1156,50 +1156,104 @@ eBackendGPUDriver Aquamarine::CDRMBackend::gpuDriver() {
     return driver;
 }
 
-static void handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, unsigned crtc_id, void* data) {
-    auto pageFlip = (SDRMPageFlip*)data;
+uintptr_t Aquamarine::CDRMBackend::nextPageFlipID() {
+    return ++m_lastPageFlipID;
+}
 
-    if (!pageFlip || !pageFlip->connector)
+SP<SDRMCRTC> Aquamarine::CDRMBackend::crtcByID(uint32_t id) {
+    auto it = std::find_if(crtcs.begin(), crtcs.end(), [id](const auto& c) { return c->id == id; });
+    return it == crtcs.end() ? nullptr : *it;
+}
+
+uintptr_t Aquamarine::SDRMCRTC::armPageFlip(CWeakPointer<SDRMConnector> connector, bool async) {
+    if (pendingFlip.id && !(pendingFlip.connector == connector)) {
+        if (const auto PREV = pendingFlip.connector.lock()) {
+            backend->log(AQ_LOG_ERROR, std::format("drm: crtc {} page-flip slot taken from {}, dropping its frame", id, PREV->szName));
+            PREV->invalidateFrame();
+        }
+    }
+
+    pendingFlip.id        = backend->nextPageFlipID();
+    pendingFlip.connector = connector;
+    pendingFlip.async     = async;
+
+    return pendingFlip.id;
+}
+
+void Aquamarine::SDRMCRTC::disarmPageFlip() {
+    pendingFlip.id = 0;
+    pendingFlip.connector.reset();
+    pendingFlip.async = false;
+}
+
+static CWeakPointer<CDRMBackend> gDispatchingBackend;
+static void                      handlePF(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec, unsigned crtc_id, void* data) {
+    const auto BACKEND = gDispatchingBackend.lock();
+
+    if (!BACKEND || BACKEND->drmFD() != fd)
         return;
 
-    pageFlip->connector->sched.onFrameComplete();
+    const auto FLIPID = rc<uintptr_t>(data);
+    const auto CRTC   = BACKEND->crtcByID(crtc_id);
 
-    const auto& BACKEND = pageFlip->connector->backend;
+    if (!CRTC || !FLIPID || CRTC->pendingFlip.id != FLIPID) {
+        BACKEND->log(AQ_LOG_DEBUG, std::format("drm: Ignoring a stale pf event, flip {} on crtc {}", FLIPID, crtc_id));
+        return;
+    }
+
+    const auto CONNECTOR = CRTC->pendingFlip.connector.lock();
+    const auto ASYNC     = CRTC->pendingFlip.async;
+    CRTC->disarmPageFlip();
+
+    if (!CONNECTOR) {
+        BACKEND->log(AQ_LOG_DEBUG, "drm: Ignoring a pf event whose connector is gone");
+        return;
+    }
 
     TRACE(BACKEND->log(AQ_LOG_TRACE, std::format("drm: pf event seq {} sec {} usec {} crtc {}", seq, tv_sec, tv_usec, crtc_id)));
 
-    if (pageFlip->connector->status != DRM_MODE_CONNECTED || !pageFlip->connector->crtc || !pageFlip->connector->output) {
+    if (!CONNECTOR->sched.frameInFlight()) {
+        BACKEND->log(AQ_LOG_DEBUG, std::format("drm: Ignoring pf event on {}, no frame in flight?", CONNECTOR->szName));
+        return;
+    }
+
+    CONNECTOR->sched.onFrameComplete();
+
+    if (CONNECTOR->status != DRM_MODE_CONNECTED || !CONNECTOR->crtc || !CONNECTOR->output) {
         BACKEND->log(AQ_LOG_DEBUG, "drm: Ignoring a pf event from a disabled crtc / connector");
         return;
     }
 
     // hold isFrameRunning around the emit (RAII pair, so reentrant enable/disable
     // can't strand it).
-    CFrameRunningGuard frameRunning(pageFlip->connector->sched);
+    CFrameRunningGuard frameRunning(CONNECTOR->sched);
 
-    pageFlip->connector->onPresent();
+    // a tearing commit already emitted present and rotated the FBs synchronously
+    if (!ASYNC) {
+        CONNECTOR->onPresent();
 
-    uint32_t flags = IOutput::AQ_OUTPUT_PRESENT_VSYNC | IOutput::AQ_OUTPUT_PRESENT_HW_CLOCK | IOutput::AQ_OUTPUT_PRESENT_HW_COMPLETION | IOutput::AQ_OUTPUT_PRESENT_ZEROCOPY;
+        uint32_t flags = IOutput::AQ_OUTPUT_PRESENT_VSYNC | IOutput::AQ_OUTPUT_PRESENT_HW_CLOCK | IOutput::AQ_OUTPUT_PRESENT_HW_COMPLETION | IOutput::AQ_OUTPUT_PRESENT_ZEROCOPY;
 
-    timespec presented = {.tv_sec = (time_t)tv_sec, .tv_nsec = (long)(tv_usec * 1000)};
+        timespec presented = {.tv_sec = (time_t)tv_sec, .tv_nsec = (long)(tv_usec * 1000)};
 
-    // nvidia-drm registers no vblank counter, unless module options 'nvidia_drm vblank=1' is set.
-    // kernel checks for vblank support and fallbacks to setting seq 0 and the timestamp is a plain ktime_get()
-    // this is not a HW clock, its just a plain software clock fetched from whenever the event was called.
-    if (BACKEND->gpuDriver() == AQ_BACKEND_GPU_DRIVER_NVIDIA && seq == 0)
-        flags &= ~IOutput::AQ_OUTPUT_PRESENT_HW_CLOCK;
+        // nvidia-drm registers no vblank counter, unless module options 'nvidia_drm vblank=1' is set.
+        // kernel checks for vblank support and fallbacks to setting seq 0 and the timestamp is a plain ktime_get()
+        // this is not a HW clock, its just a plain software clock fetched from whenever the event was called.
+        if (BACKEND->gpuDriver() == AQ_BACKEND_GPU_DRIVER_NVIDIA && seq == 0)
+            flags &= ~IOutput::AQ_OUTPUT_PRESENT_HW_CLOCK;
 
-    pageFlip->connector->output->events.present.emit(IOutput::SPresentEvent{
-        .presented = BACKEND->sessionActive(),
-        .when      = &presented,
-        .seq       = seq,
-        .refresh   = (int)(pageFlip->connector->refresh ? (1000000000000LL / pageFlip->connector->refresh) : 0),
-        .flags     = flags,
-    });
+        CONNECTOR->output->events.present.emit(IOutput::SPresentEvent{
+            .presented = BACKEND->sessionActive(),
+            .when      = &presented,
+            .seq       = seq,
+            .refresh   = (int)(CONNECTOR->refresh ? (1000000000000LL / CONNECTOR->refresh) : 0),
+            .flags     = flags,
+        });
+    }
 
     // Skip if an idle frame is already queued: it emits events.frame itself, and #325 forbids double-firing.
-    if (BACKEND->sessionActive() && pageFlip->connector->output->enabledState && !pageFlip->connector->sched.frameScheduled())
-        pageFlip->connector->sched.frameReady.emit();
+    if (BACKEND->sessionActive() && CONNECTOR->output->enabledState && !CONNECTOR->sched.frameScheduled())
+        CONNECTOR->sched.frameReady.emit();
 }
 
 bool Aquamarine::CDRMBackend::dispatchEvents() {
@@ -1207,6 +1261,11 @@ bool Aquamarine::CDRMBackend::dispatchEvents() {
         .version            = 3,
         .page_flip_handler2 = ::handlePF,
     };
+
+    // drmHandleEvent -> handlePF can dispatch another gpus fd so gDispatchingBackend is the wrong backend.
+    const auto  PREVIOUS = gDispatchingBackend;
+    CScopeGuard dispatchGuard([&PREVIOUS] { gDispatchingBackend = PREVIOUS; });
+    gDispatchingBackend = self;
 
     if (drmHandleEvent(gpu->fd, &event) != 0)
         backend->log(AQ_LOG_ERROR, std::format("drm: Failed to handle event on fd {}", gpu->fd));
@@ -1457,8 +1516,6 @@ SP<SDRMCRTC> Aquamarine::SDRMConnector::getCurrentCRTC(const drmModeConnector* c
 }
 
 bool Aquamarine::SDRMConnector::init(drmModeConnector* connector) {
-    pendingPageFlip.connector = self.lock();
-
     if (!getDRMConnectorProps(backend->gpu->fd, id, &props))
         return false;
     if (props.values.Colorspace)
@@ -1475,7 +1532,7 @@ bool Aquamarine::SDRMConnector::init(drmModeConnector* connector) {
     if (!possibleCrtcs)
         backend->backend->log(AQ_LOG_ERROR, "drm: No CRTCs possible");
 
-    crtc = getCurrentCRTC(connector);
+    setCRTC(getCurrentCRTC(connector));
 
     return true;
 }
@@ -1834,6 +1891,8 @@ void Aquamarine::SDRMConnector::disconnect() {
         return;
     }
 
+    invalidateFrame();
+
     status = DRM_MODE_DISCONNECTED;
     releaseFBReferences();
 
@@ -1872,7 +1931,7 @@ void Aquamarine::SDRMConnector::applyCommit(const SDRMConnectorCommitData& data)
 
     if (!output->enabledState) {
         releaseFBReferences();
-        sched.invalidate();
+        invalidateFrame();
     }
 
     if (!backend->updateSecondaryRendererState())
@@ -1902,6 +1961,22 @@ void Aquamarine::SDRMConnector::rollbackCommit(const SDRMConnectorCommitData& da
         crtc->cursor->back = data.cursorFB;
 
     crtc->pendingCursor.reset();
+}
+
+void Aquamarine::SDRMConnector::invalidateFrame() {
+    sched.invalidate();
+
+    if (crtc && crtc->pendingFlip.connector == self)
+        crtc->disarmPageFlip();
+}
+
+void Aquamarine::SDRMConnector::setCRTC(SP<SDRMCRTC> newCRTC) {
+    if (crtc == newCRTC)
+        return;
+
+    invalidateFrame();
+
+    crtc = newCRTC;
 }
 
 void Aquamarine::SDRMConnector::onPresent() {
@@ -2041,10 +2116,11 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
         }
 
         if (STATE.enabled && NEEDS_RECONFIG && connector->sched.frameInFlight()) {
-            // ALLOW_MODESET resets the CRTC and cancels the in-flight flip; no
-            // completion event will arrive, so clear the userspace state.
+            // ALLOW_MODESET resets the CRTC, so the in-flight flip is either cancelled or
+            // superseded by this commit. drop it either way; whatever event still arrives no
+            // longer matches the crtcs id and is discarded.
             backend->backend->log(AQ_LOG_DEBUG, std::format("drm: page-flip on {} cancelled by modeset, clearing flip state", name));
-            connector->sched.invalidate();
+            connector->invalidateFrame();
         }
 
         if (STATE.enabled && (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER) && connector->sched.frameInFlight()) {

--- a/src/backend/drm/Renderer.cpp
+++ b/src/backend/drm/Renderer.cpp
@@ -934,6 +934,11 @@ void CDRMRenderer::clearBuffer(IBuffer* buf) {
 }
 
 CDRMRenderer::SBlitResult CDRMRenderer::blit(SP<IBuffer> from, SP<IBuffer> to, SP<CDRMRenderer> primaryRenderer, int waitFD) {
+    if (!from || !to) {
+        backend->log(AQ_LOG_ERROR, "EGL (blit): null source or destination buffer");
+        return {};
+    }
+
     CEglContextGuard eglContext(*this);
 
     if (from->dmabuf().size != to->dmabuf().size) {

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -301,11 +301,22 @@ bool Aquamarine::CDRMAtomicRequest::commit(uint32_t flagssss) {
         return false;
     }
 
-    if (auto ret = drmModeAtomicCommit(backend->gpu->fd, req, flagssss, conn ? &conn->pendingPageFlip : nullptr); ret) {
+    // a test never flips.
+    const bool WANTSFLIP = conn && conn->crtc && (flagssss & DRM_MODE_PAGE_FLIP_EVENT) && !(flagssss & DRM_MODE_ATOMIC_TEST_ONLY);
+    const auto FLIPID    = WANTSFLIP ? conn->crtc->armPageFlip(conn, flagssss & DRM_MODE_PAGE_FLIP_ASYNC) : uintptr_t{0};
+
+    if (auto ret = drmModeAtomicCommit(backend->gpu->fd, req, flagssss, rc<void*>(FLIPID)); ret) {
         backend->log((flagssss & DRM_MODE_ATOMIC_TEST_ONLY) ? AQ_LOG_DEBUG : AQ_LOG_ERROR,
                      std::format("atomic drm request: failed to commit: {}, flags: {}", strerror(ret == -1 ? errno : -ret), flagsToStr(flagssss)));
+
+        if (WANTSFLIP)
+            conn->crtc->disarmPageFlip();
+
         return false;
     }
+
+    if (WANTSFLIP)
+        conn->sched.onFrameSubmitted();
 
     return true;
 }
@@ -519,9 +530,6 @@ bool Aquamarine::CDRMAtomicImpl::commit(Hyprutils::Memory::CSharedPointer<SDRMCo
             connector->atomic.propsCached = true;
             if (data.atomic.ctmd)
                 connector->crtc->atomic.ctmStateKnown = true;
-
-            if (data.mainFB && data.enabled && (flags & DRM_MODE_PAGE_FLIP_EVENT))
-                connector->sched.onFrameSubmitted();
         }
     } else
         request.rollback(data);

--- a/src/backend/drm/impl/Legacy.cpp
+++ b/src/backend/drm/impl/Legacy.cpp
@@ -132,8 +132,11 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
     if (!(data.flags & DRM_MODE_PAGE_FLIP_EVENT))
         return true;
 
-    if (int ret = drmModePageFlip(connector->backend->gpu->fd, connector->crtc->id, mainFB ? mainFB->id : -1, data.flags, &connector->pendingPageFlip); ret) {
+    const auto FLIPID = connector->crtc->armPageFlip(connector, data.flags & DRM_MODE_PAGE_FLIP_ASYNC);
+
+    if (int ret = drmModePageFlip(connector->backend->gpu->fd, connector->crtc->id, mainFB ? mainFB->id : -1, data.flags, rc<void*>(FLIPID)); ret) {
         connector->backend->backend->log(AQ_LOG_ERROR, std::format("legacy drm: drmModePageFlip failed: {}", strerror(-ret)));
+        connector->crtc->disarmPageFlip();
         return false;
     }
 

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -51,6 +51,10 @@ const Aquamarine::COutputState::SInternalState& Aquamarine::COutputState::state(
     return internalState;
 }
 
+bool Aquamarine::COutputState::needsReconfig() const {
+    return internalState.committed & (AQ_OUTPUT_STATE_ENABLED | AQ_OUTPUT_STATE_FORMAT | AQ_OUTPUT_STATE_MODE | AQ_OUTPUT_STATE_HDR | AQ_OUTPUT_STATE_WCG);
+}
+
 void Aquamarine::COutputState::addDamage(const Hyprutils::Math::CRegion& region) {
     internalState.damage.add(region);
     internalState.committed |= AQ_OUTPUT_STATE_DAMAGE;


### PR DESCRIPTION
this reworks pageflips entirerly, moving them from per connector to per CRTC, the data we sent drmModeAtomicCommit would be destroyed if you hotplug a monitor with a pageflip in flight. and the kernel so gracefully does NOT stop that event from occuring. so handlePF casted a freed memory pointer and UAF, causing UB and driver faults.

moving them to CRTC also means they relate to the actual CRTC that is pending a flip, but as codex so kindly pointed out we cant identify them by CRTC_ID either because that one can be reused on attach. so use a backend lookup with crtcByID and match with the pendingPageflip id. `pendingFlip.id != FLIPID`

and the data we now commit is the FLIP id that is an ever increasing number. sequence like on nextPageFlipID() so we are setting our pageflips with a new type of id to diff them apart.

add an ASYNC guard so tearing commits doesnt present twice, because the tear commit still makes a page flip event, but we call onPresented ourself earlier.

now because we are intending to make bufferless commits, we have to rework the entire applyCommit idea. we now check the front, back against eachother and data.mainFB, and only change it when a new one has actually been committed, we also have to ensure we release the backendlock when switching buffers or we end up holding them for to long on direct scanout.

skip mgpu blit when no buffer was committed, reusing the FB that already was on the plane, and add needsReconfig() because modeset commits needs a matching buffer to go with the commit.


and remove rollback of commits, generally wrong.

https://docs.kernel.org/gpu/drm-kms.html#atomic-mode-setting
```
Firstly, no hardware changes are allowed when the commit would fail. This allows us to implement the DRM_MODE_ATOMIC_TEST_ONLY mode, which allows userspace to explore whether certain configurations would work or not.
```

we were rolling back failed commits that never applied. not TEST commits.


- [x] dual gpu blitting.