### PR TITLE
frame: reschedule one more idle frame if requested

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -239,6 +239,7 @@ namespace Aquamarine {
         Hyprutils::Memory::CSharedPointer<SDRMConnector>             connector;
         Hyprutils::Memory::CSharedPointer<std::function<void(void)>> frameIdle;
         Hyprutils::Signal::CHyprSignalListener                       frameReadyListener;
+        Hyprutils::Signal::CHyprSignalListener                       rescheduleListener;
 
         struct {
             Hyprutils::Memory::CSharedPointer<CSwapchain> swapchain;

--- a/include/aquamarine/backend/FrameScheduler.hpp
+++ b/include/aquamarine/backend/FrameScheduler.hpp
@@ -39,13 +39,22 @@ namespace Aquamarine {
         bool frameRunning() const;
         void setFrameRunning(bool v);
 
+        // a scheduleFrame arrived while a frame was running, so reschedule it when the frame is done.
+        void requestReschedule();
+
         // Fires from onFrameComplete. The output wires this to events.frame.emit.
         Hyprutils::Signal::CSignalT<> frameReady;
 
+        // emits from ~CFrameRunningGuard if m_rescheduleRequested is set.
+        Hyprutils::Signal::CSignalT<> rescheduleNeeded;
+
       private:
-        bool m_pending        = false;
-        bool m_frameScheduled = false;
-        bool m_frameRunning   = false;
+        bool m_pending             = false;
+        bool m_frameScheduled      = false;
+        bool m_frameRunning        = false;
+        bool m_rescheduleRequested = false;
+
+        friend class CFrameRunningGuard;
     };
 
     // RAII pair for isFrameRunning: set on ctor, cleared on every exit path so a

--- a/include/aquamarine/backend/Wayland.hpp
+++ b/include/aquamarine/backend/Wayland.hpp
@@ -67,8 +67,9 @@ namespace Aquamarine {
         void                                              onEnter(Hyprutils::Memory::CSharedPointer<CCWlPointer> pointer, uint32_t serial);
 
         // frame loop — unified scheduler shared with DRM. See CFrameScheduler.
-        CFrameScheduler                                   sched;
-        Hyprutils::Signal::CHyprSignalListener            frameReadyListener;
+        CFrameScheduler                                              sched;
+        Hyprutils::Signal::CHyprSignalListener                       frameReadyListener;
+        Hyprutils::Signal::CHyprSignalListener                       rescheduleListener;
         Hyprutils::Memory::CSharedPointer<std::function<void(void)>> frameIdle;
 
         struct {

--- a/src/backend/FrameScheduler.cpp
+++ b/src/backend/FrameScheduler.cpp
@@ -11,9 +11,10 @@ void CFrameScheduler::onFrameComplete() {
 }
 
 void CFrameScheduler::invalidate() {
-    m_pending        = false;
-    m_frameRunning   = false;
-    m_frameScheduled = false;
+    m_pending             = false;
+    m_frameRunning        = false;
+    m_frameScheduled      = false;
+    m_rescheduleRequested = false;
 }
 
 bool CFrameScheduler::frameInFlight() const {
@@ -40,10 +41,26 @@ void CFrameScheduler::setFrameRunning(bool v) {
     m_frameRunning = v;
 }
 
+void CFrameScheduler::requestReschedule() {
+    m_rescheduleRequested = true;
+}
+
 CFrameRunningGuard::CFrameRunningGuard(CFrameScheduler& s) : m_s(s) {
     m_s.setFrameRunning(true);
 }
 
 CFrameRunningGuard::~CFrameRunningGuard() {
     m_s.setFrameRunning(false);
+
+    if (!m_s.m_rescheduleRequested)
+        return;
+
+    m_s.m_rescheduleRequested = false;
+
+    // the running frame committed, or something already armed an idle frame that path
+    // delivers the next frame, re scheduling here would double fire.
+    if (!m_s.canSchedule())
+        return;
+
+    m_s.rescheduleNeeded.emit();
 }

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -495,6 +495,9 @@ Aquamarine::CWaylandOutput::CWaylandOutput(const std::string& name_, Hyprutils::
     // The scheduler's frameReady signal drives the public events.frame on this output.
     frameReadyListener = sched.frameReady.listen([this]() { events.frame.emit(); });
 
+    // a scheduleFrame mid frame, reschedule one more.
+    rescheduleListener = sched.rescheduleNeeded.listen([this]() { scheduleFrame(AQ_SCHEDULE_NEEDS_FRAME); });
+
     // Idle that emits the scheduled frame, fired via the core backend's idle queue
     // (addIdleEvent), which the consumer's event loop pumps every iteration. Deliberately
     // not the backend-local idleCallbacks vector: that only drains inside dispatchEvents,
@@ -839,6 +842,12 @@ void Aquamarine::CWaylandOutput::scheduleFrame(const scheduleFrameReason reason)
     TRACE(backend->backend->log(AQ_LOG_TRACE,
                                 std::format("CWaylandOutput::scheduleFrame: reason {}, needsFrame {}, canSchedule {}", (uint32_t)reason, needsFrame, sched.canSchedule())));
     needsFrame = true;
+
+    // scheduled from inside a running frame, schedule it once the running frame is done.
+    if (sched.frameRunning()) {
+        sched.requestReschedule();
+        return;
+    }
 
     if (!sched.canSchedule())
         return;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -2365,7 +2365,16 @@ void Aquamarine::CDRMOutput::scheduleFrame(const scheduleFrameReason reason) {
                                             connector->sched.frameInFlight(), connector->sched.frameScheduled())));
     needsFrame = true;
 
-    if (!connector->sched.canSchedule() || !enabledState)
+    if (!enabledState)
+        return;
+
+    // a scheduleFrame mid frame, reschedule one more.
+    if (connector->sched.frameRunning()) {
+        connector->sched.requestReschedule();
+        return;
+    }
+
+    if (!connector->sched.canSchedule())
         return;
 
     connector->sched.setFrameScheduled(true);
@@ -2463,6 +2472,9 @@ Aquamarine::CDRMOutput::CDRMOutput(const std::string& name_, Hyprutils::Memory::
 
     // The scheduler's frameReady signal drives the public events.frame on this output.
     frameReadyListener = connector->sched.frameReady.listen([this]() { events.frame.emit(); });
+
+    // scheduled from inside a running frame, schedule it once the running frame is done.
+    rescheduleListener = connector->sched.rescheduleNeeded.listen([this]() { scheduleFrame(AQ_SCHEDULE_NEEDS_FRAME); });
 }
 
 SP<CDRMFB> Aquamarine::CDRMFB::create(SP<IBuffer> buffer_, Hyprutils::Memory::CWeakPointer<CDRMBackend> backend_, bool* isNew) {


### PR DESCRIPTION
if something schedules a frame midframe, the CFrameGuard didnt let it because a frame is running. and we silently dropped it. let it reschedule once more with the idleFrame callback.

hyprland currently does a similiar thing but this belongs more in AQ now with the CFrameGuards and CFrameScheduler.