### PR TITLE
drm: keep scanning extension blocks after the first CTA

### DIFF
--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -1642,6 +1642,10 @@ IOutput::SParsedEDID Aquamarine::SDRMConnector::parseEDID(std::vector<uint8_t> d
 
     auto exts = di_edid_get_extensions(edid);
 
+    // EDID can have more than one CTA extension. First hdr_static_metadata and colorimetry win
+    const di_cta_hdr_static_metadata_block* hdr_static_metadata = nullptr;
+    const di_cta_colorimetry_block*         colorimetry         = nullptr;
+
     for (; *exts != nullptr; exts++) {
         auto tag = di_edid_ext_get_tag(*exts);
         TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: checking ext {}", (uint32_t)tag)));
@@ -1649,29 +1653,27 @@ IOutput::SParsedEDID Aquamarine::SDRMConnector::parseEDID(std::vector<uint8_t> d
             backend->backend->log(AQ_LOG_WARNING, "FIXME: support displayid blocks");
 
         const auto cta = di_edid_ext_get_cta(*exts);
-        if (cta) {
-            TRACE(backend->backend->log(AQ_LOG_TRACE, "EDID: found CTA"));
-            const di_cta_hdr_static_metadata_block* hdr_static_metadata = nullptr;
-            const di_cta_colorimetry_block*         colorimetry         = nullptr;
-            auto                                    blocks              = di_edid_cta_get_data_blocks(cta);
-            for (; *blocks != nullptr; blocks++) {
-                if (!hdr_static_metadata && (hdr_static_metadata = di_cta_data_block_get_hdr_static_metadata(*blocks))) {
-                    TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found HDR {}", hdr_static_metadata->eotfs->pq)));
-                    parsed.hdrMetadata = IOutput::SHDRMetadata{
-                        .desiredContentMaxLuminance      = hdr_static_metadata->desired_content_max_luminance,
-                        .desiredMaxFrameAverageLuminance = hdr_static_metadata->desired_content_max_frame_avg_luminance,
-                        .desiredContentMinLuminance      = hdr_static_metadata->desired_content_min_luminance,
-                        .supportsPQ                      = hdr_static_metadata->eotfs->pq,
-                    };
-                    continue;
-                }
-                if (!colorimetry && (colorimetry = di_cta_data_block_get_colorimetry(*blocks))) {
-                    TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found colorimetry {}", colorimetry->bt2020_rgb)));
-                    parsed.supportsBT2020 = colorimetry->bt2020_rgb;
-                    continue;
-                }
+        if (!cta)
+            continue;
+
+        TRACE(backend->backend->log(AQ_LOG_TRACE, "EDID: found CTA"));
+        auto blocks = di_edid_cta_get_data_blocks(cta);
+        for (; *blocks != nullptr; blocks++) {
+            if (!hdr_static_metadata && (hdr_static_metadata = di_cta_data_block_get_hdr_static_metadata(*blocks))) {
+                TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found HDR {}", hdr_static_metadata->eotfs->pq)));
+                parsed.hdrMetadata = IOutput::SHDRMetadata{
+                    .desiredContentMaxLuminance      = hdr_static_metadata->desired_content_max_luminance,
+                    .desiredMaxFrameAverageLuminance = hdr_static_metadata->desired_content_max_frame_avg_luminance,
+                    .desiredContentMinLuminance      = hdr_static_metadata->desired_content_min_luminance,
+                    .supportsPQ                      = hdr_static_metadata->eotfs->pq,
+                };
+                continue;
             }
-            break;
+            if (!colorimetry && (colorimetry = di_cta_data_block_get_colorimetry(*blocks))) {
+                TRACE(backend->backend->log(AQ_LOG_TRACE, std::format("EDID: found colorimetry {}", colorimetry->bt2020_rgb)));
+                parsed.supportsBT2020 = colorimetry->bt2020_rgb;
+                continue;
+            }
         }
     }
 


### PR DESCRIPTION
Changes EDID scanning to visit all extension blocks, and picks HDR static metadata and colorimetry from the first CTA extension blocks that contain each one to be defensive against potentially bad EDIDs.

This is relatively uncommon as far as I know for monitors but can help with TVs that have multiple CTA extension blocks (they sometimes have lots of AV timing data and can't fit it in a single block) and HDR/colorimetry might not be in the first one. The spec only requires that HDR static metadata and colorimetry be singletons within the whole EDID payload, not that they be located on the same CTA extension block or that there only be one CTA extension block.

As a side effect, users whose monitors have a DisplayID extension block after a CTA extension block will start seeing the FIXME for DisplayID blocks.