### PR TITLE
drm: pick the standalone-capable tile when no connector spans the full tiled mode

### DIFF
--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -350,6 +350,7 @@ namespace Aquamarine {
         STileInfo                                      tileInfo;
         bool                                           tilingRedundant = false;
         Hyprutils::Math::Vector2D                      maxMode;
+        std::vector<Hyprutils::Math::Vector2D>         modeSizes;
 
         bool                                           cursorEnabled = false;
         Hyprutils::Math::Vector2D                      cursorPos, cursorSize, cursorHotspot;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -957,24 +957,56 @@ void Aquamarine::CDRMBackend::markRedundantTiles() {
 
         // check if any single connector already has the full tiled resolution,
         // meaning the driver handles tiling internally
-        SP<SDRMConnector> fullResConn;
+        SP<SDRMConnector> primary;
+        std::string       reason;
         for (const auto& conn : members) {
             if (conn->maxMode.x >= fullWidth && conn->maxMode.y >= fullHeight) {
-                fullResConn = conn;
+                primary = conn;
+                reason  = "driver-managed";
                 break;
             }
         }
 
-        if (!fullResConn)
+        if (!primary) {
+            // no connector drives the full tiled resolution on its own, so the tiles are
+            // genuinely separate streams — which we cannot stitch into one output. Driving
+            // more than one tile just creates a ghost output showing a slice of the panel.
+            // If exactly one tile can operate standalone — it advertises modes beyond the
+            // bare tile timing (e.g. the LG UltraFine 5K exposes scaled 4K modes on its
+            // primary tile, which the panel expands to the full display) — drive that tile
+            // alone and drop the rest.
+            bool ambiguous = false;
+            for (const auto& conn : members) {
+                const auto& cti            = conn->tileInfo;
+                bool        hasNonTileMode = std::ranges::any_of(conn->modeSizes, [&cti](const auto& m) { return m.x != cti.tileHSize || m.y != cti.tileVSize; });
+
+                if (!hasNonTileMode)
+                    continue;
+
+                if (primary) {
+                    ambiguous = true;
+                    break;
+                }
+
+                primary = conn;
+                reason  = "standalone-capable";
+            }
+
+            if (ambiguous) {
+                backend->log(AQ_LOG_DEBUG, std::format("drm: Tile group {} has multiple standalone-capable tiles, not marking any redundant", groupId));
+                continue;
+            }
+        }
+
+        if (!primary)
             continue;
 
         for (const auto& conn : members) {
-            if (conn == fullResConn)
+            if (conn == primary)
                 continue;
 
             conn->tilingRedundant = true;
-            backend->log(AQ_LOG_DEBUG,
-                         std::format("drm: Connector {} marked as tiling redundant (tile group {}, driver-managed by {})", conn->szName, groupId, fullResConn->szName));
+            backend->log(AQ_LOG_DEBUG, std::format("drm: Connector {} marked as tiling redundant (tile group {}, {} {})", conn->szName, groupId, reason, primary->szName));
         }
     }
 }
@@ -1069,9 +1101,11 @@ void Aquamarine::CDRMBackend::scanConnectors() {
         conn->status = drmConn->connection;
 
         conn->maxMode = {};
+        conn->modeSizes.clear();
         for (int i = 0; i < drmConn->count_modes; ++i) {
             conn->maxMode.x = std::max<double>(conn->maxMode.x, drmConn->modes[i].hdisplay);
             conn->maxMode.y = std::max<double>(conn->maxMode.y, drmConn->modes[i].vdisplay);
+            conn->modeSizes.emplace_back(drmConn->modes[i].hdisplay, drmConn->modes[i].vdisplay);
         }
 
         if (conn->crtc)


### PR DESCRIPTION
# drm: pick the standalone-capable tile when no connector spans the full tiled mode

## Problem

#238 suppresses ghost outputs from tiled displays where the driver handles tiling internally — detected by one connector in the tile group advertising the full combined resolution (e.g. Apple Studio Display exposing 5120x2880 on a single connector, with dead sibling connectors).

The **LG UltraFine 5K (27MD5K)** over Thunderbolt doesn't match that pattern. It exposes a genuine 2x1 tile group where *no* connector spans the full 5120x2880:

- `DP-5` (tile 0,0): 2560x2880 tile timing **plus** scaled modes — 4096x2304, 3840x2160, 3200x1800, 2560x1440, 640x480
- `DP-6` (tile 1,0): **only** the bare 2560x2880 tile timing

Since `fullResConn` is never found, `markRedundantTiles()` bails, and DP-6 appears as a live 2560x2880 ghost output. Workspaces get assigned to it and windows can land on a display slice that isn't usefully visible.

EDID (via `edid-decode`) confirms the topology — both connectors carry a Tiled Display Topology block, 2x1 tiles of 2560x2880, same tile group serial. Notably the primary tile declares:

```
Behavior if it is the only tile: Image is scaled to fit the entire tiled display
```

while the secondary tile's solo behavior is *Undefined*. In other words: driving DP-5 alone at any of its scaled modes covers the entire panel; DP-6 alone shows nothing useful.

## Fix

When no connector in a tile group offers the full tiled resolution, the tiles are genuinely separate streams — which we cannot stitch into one output, so driving more than one of them only produces a ghost. In that case, if **exactly one** tile advertises modes beyond the bare tile timing (i.e. it can operate standalone with panel-side scaling), drive that tile and mark its siblings redundant.

Safety: if several tiles look standalone-capable, we log and back off, leaving the group untouched — displays that genuinely require multiple driven tiles keep today's behavior.

`scanConnectors()` now records each connector's mode list (`modeSizes`) alongside the existing `maxMode` so the group pass can tell tile-timing-only connectors from standalone-capable ones.

## Testing

Running this build on Hyprland 0.56.2 with the LG UltraFine 5K over Thunderbolt (AMD GFX11, kernel DRM `TILE` properties present):

```
drm: Connector DP-5 tile info: group=1 tiles=2x1 pos=(0,0) size=2560x2880
drm: Connector DP-6 tile info: group=1 tiles=2x1 pos=(1,0) size=2560x2880
drm: Tile group 1 has 2 members, full tiled resolution 5120x2880
drm: Connector DP-6 marked as tiling redundant (tile group 1, standalone-capable DP-5)
```

No ghost output is created, workspaces no longer land on the dead tile, and DP-5 drives the panel at its scaled modes as before. Driver-managed tiled displays still take the `fullResConn` path first; the fallback only runs when that fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyTsTzWd8LSVDydJcJjJgo
