### PR TITLE
swapchain: preserve multigpu flag in resize()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,14 @@ add_test(
   COMMAND attachments "attachments")
 add_dependencies(tests attachments)
 
+add_executable(swapchain "tests/Swapchain.cpp")
+target_link_libraries(swapchain PRIVATE PkgConfig::deps aquamarine)
+add_test(
+  NAME "swapchain"
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
+  COMMAND swapchain "swapchain")
+add_dependencies(tests swapchain)
+
 # Installation
 install(TARGETS aquamarine)
 install(DIRECTORY "include/aquamarine" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/allocator/Swapchain.cpp
+++ b/src/allocator/Swapchain.cpp
@@ -104,8 +104,9 @@ bool Aquamarine::CSwapchain::resize(size_t newSize) {
         }
     } else {
         while (buffers.size() < newSize) {
-            auto buf =
-                allocator->acquire(SAllocatorBufferParams{.size = options.size, .format = options.format, .scanout = options.scanout, .cursor = options.cursor}, self.lock());
+            auto buf = allocator->acquire(
+                SAllocatorBufferParams{.size = options.size, .format = options.format, .scanout = options.scanout, .cursor = options.cursor, .multigpu = options.multigpu},
+                self.lock());
             if (!buf) {
                 allocator->getBackend()->log(AQ_LOG_ERROR, "Swapchain: Failed acquiring a buffer");
                 return false;

--- a/tests/Swapchain.cpp
+++ b/tests/Swapchain.cpp
@@ -1,0 +1,117 @@
+#include <aquamarine/allocator/Swapchain.hpp>
+#include <aquamarine/backend/Backend.hpp>
+#include <aquamarine/buffer/Buffer.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <drm_fourcc.h>
+#include "shared.hpp"
+
+using namespace Aquamarine;
+using namespace Hyprutils::Memory;
+using namespace Hyprutils::Math;
+#define SP CSharedPointer
+
+// Regression test: CSwapchain must hand identical SAllocatorBufferParams to the allocator no
+// matter which internal path (fullReconfigure vs resize) performs the allocation. resize() used
+// to omit .multigpu, so any reallocation that only changed the length silently dropped the flag.
+// On a multi-GPU secondary output this happened on every DPMS off -> on cycle (off clears the
+// swapchain to length 0, on re-adds buffers via resize()) and produced non-multigpu buffers the
+// consumer could not use, permanently blanking the output.
+
+class CMockBuffer : public IBuffer {
+  public:
+    virtual eBufferCapability caps() {
+        return (eBufferCapability)0;
+    }
+    virtual eBufferType type() {
+        return BUFFER_TYPE_MISC;
+    }
+    virtual void update(const CRegion& damage) {
+        ;
+    }
+    virtual bool isSynchronous() {
+        return false;
+    }
+    virtual bool good() {
+        return true;
+    }
+};
+
+class CMockAllocator : public IAllocator {
+  public:
+    CMockAllocator(SP<CBackend> backend_) : backend(backend_) {
+        ;
+    }
+
+    virtual SP<IBuffer> acquire(const SAllocatorBufferParams& params, SP<CSwapchain> swapchain) {
+        lastParams = params;
+        return makeShared<CMockBuffer>();
+    }
+    virtual SP<CBackend> getBackend() {
+        return backend;
+    }
+    virtual int drmFD() {
+        return -1;
+    }
+    virtual eAllocatorType type() {
+        return AQ_ALLOCATOR_TYPE_GBM;
+    }
+
+    SAllocatorBufferParams lastParams;
+    SP<CBackend>           backend;
+};
+
+int main() {
+    int ret = 0;
+
+    // a headless backend is enough for the swapchain's logging
+    auto implOptions               = SBackendImplementationOptions{};
+    implOptions.backendType        = AQ_BACKEND_HEADLESS;
+    implOptions.backendRequestMode = AQ_BACKEND_REQUEST_IF_AVAILABLE;
+
+    auto backendOptions = SBackendOptions{};
+
+    auto backend = CBackend::create({implOptions}, backendOptions);
+    EXPECT(!!backend, true);
+    if (!backend)
+        return 1;
+
+    auto allocator = makeShared<CMockAllocator>(backend);
+    auto swapchain = CSwapchain::create(allocator, nullptr);
+    EXPECT(!!swapchain, true);
+    if (!swapchain)
+        return 1;
+
+    SSwapchainOptions options;
+    options.length   = 3;
+    options.size     = {1920, 1080};
+    options.format   = DRM_FORMAT_XRGB8888;
+    options.scanout  = true;
+    options.multigpu = true;
+
+    // initial configuration: fullReconfigure path
+    EXPECT(swapchain->reconfigure(options), true);
+    EXPECT(allocator->lastParams.multigpu, true);
+    EXPECT(allocator->lastParams.scanout, true);
+
+    // a dpms-off style teardown: clear to length 0, options retained
+    auto cleared   = options;
+    cleared.length = 0;
+    EXPECT(swapchain->reconfigure(cleared), true);
+
+    // a dpms-on style reconfigure: same format/size, only the length differs -> resize() path.
+    // the allocation must still carry multigpu.
+    allocator->lastParams = {};
+    EXPECT(swapchain->reconfigure(options), true);
+    EXPECT(allocator->lastParams.multigpu, true);
+    EXPECT(allocator->lastParams.scanout, true);
+
+    // shrink then grow (pure resize both ways) must preserve it too
+    auto shorter   = options;
+    shorter.length = 2;
+    EXPECT(swapchain->reconfigure(shorter), true);
+    allocator->lastParams = {};
+    EXPECT(swapchain->reconfigure(options), true);
+    EXPECT(allocator->lastParams.multigpu, true);
+
+    return ret;
+}


### PR DESCRIPTION

Fixes multi-GPU **secondary outputs staying permanently black after a DPMS off → on cycle**
(idle blank, lock-screen blank, or the lock screen shown after wake-from-suspend). The output
still reports as enabled (`hyprctl monitors` shows `disabled: false`, `dpmsStatus: 1`) but never
produces another frame; a screencopy of it (`grim -o <output>`) blocks forever. Only a full
session restart recovers it.

### Root cause

`CSwapchain::fullReconfigure()` passes `.multigpu = options_.multigpu` to the allocator, but
`CSwapchain::resize()` builds its `SAllocatorBufferParams` **without** `.multigpu`, so it
defaults to `false`. Any reallocation that only changes the swapchain length silently drops the
flag.

A DPMS cycle on a multi-GPU secondary output does exactly that:

1. **dpms off** → no enabled outputs left on the secondary GPU → `updateSecondaryRendererState()`
   deinitializes the secondary renderer → `releaseMgpuResources()` clears the output swapchain
   to length 0 (options, including `multigpu = true`, preserved).
2. **dpms on** → the consumer reconfigures the swapchain back to length 3 with the same
   format/size → `reconfigure()` takes the same-format-same-size branch → `resize()` → buffers
   allocated **without** `multigpu`.
3. The GBM allocator therefore skips the multi-GPU linear logic; on an nvidia primary it falls
   through to `GBM: Using modifier-less allocation` and returns implicit-modifier
   (`DRM_FORMAT_MOD_INVALID`) buffers instead of the explicit-modifier buffers the first
   configuration produced.
4. The consumer cannot render into those buffers. Hyprland logs
   `rbo: glCheckFramebufferStatus failed` → `failed to start a render pass for output ..., no
   RBO could be obtained` → `renderer: couldn't beginRender()!` on each frame event, commits
   nothing, and the output starves permanently.

The bug is timing-dependent from the user's point of view (it needs the reconfigure to hit the
`resize()` branch rather than `fullReconfigure()`), which is why the output sometimes survives a
cycle or two before dying.

### System where this was found and verified

- Hyprland 0.56.0 (Arch, `hyprland 0.56.0-2`), aquamarine 0.13.0 (`aquamarine 0.13.0-2`);
  the faulty `resize()` is unchanged on current `main`
- GPU 1 (primary): NVIDIA RTX 3070 Ti, `nvidia-open-dkms` / `nvidia-utils` 610.43.03
- GPU 2 (secondary): Intel UHD 750 (RocketLake, i915), Mesa 26.1.5
- Monitor on the secondary: 1080p@75 over HDMI on the Intel head; primary monitor on the NVIDIA
  head is unaffected throughout
- Kernel 7.1.4-arch1-1

### How it was diagnosed (in case the details are useful)

The failure was walked down layer by layer with added tracing on both sides:

- aquamarine's frame scheduler state was healthy after re-enable; `frameReady` was emitted to
  the consumer, and **zero** page-flips were submitted for the dead output afterwards (while the
  healthy primary submitted >1000 in the same window), ruling out lost kernel flip events.
- Hyprland received the frame events and called `renderMonitor()`, which failed in
  `beginRender()` with the RBO errors above — the buffers themselves were the problem.
- Comparing allocations: first configuration logs the multigpu path and explicit modifiers;
  post-DPMS reallocation logs `GBM: Using modifier-less allocation` → `modifier
  0xffffffffffffff : INVALID`. That pointed directly at the params difference between
  `fullReconfigure()` and `resize()`.

### Reproduction (before the fix)

On any nvidia-primary + iGPU-secondary multi-monitor setup:

```
hyprctl dispatch dpms off; sleep 4; hyprctl dispatch dpms on
# then check the secondary output; a screencopy of it never completes:
timeout 15 grim -o <secondary-output> /tmp/f.png; echo $?   # 124 = stalled
```

Dies within 1–2 cycles. With the fix applied: **13/13 consecutive cycles pass** on the machine
above (frame captured from the secondary output after every cycle).

### Test

Adds `tests/Swapchain.cpp` in the style of the existing tests (`shared.hpp` `EXPECT`, mock
classes, plain `main()`): a mock `IAllocator` records the `SAllocatorBufferParams` it receives,
and the swapchain is driven through the sequence above — full reconfigure → clear to length 0 →
same-format/size reconfigure → shrink → grow — asserting `multigpu` survives every allocation
path. On current `main` it fails on the two `resize()`-path assertions
(`allocator->lastParams.multigpu, expected 1 but got 0`); with the fix it passes. Runs fully
headless (headless backend for logging only, no GPU or session needed) and is wired into ctest
as `swapchain`.
