### PR TITLE
swapchain: preserve multigpu flag in resize()

### DIFF
--- a/src/allocator/Swapchain.cpp
+++ b/src/allocator/Swapchain.cpp
@@ -104,8 +104,9 @@ bool Aquamarine::CSwapchain::resize(size_t newSize) {
         }
     } else {
         while (buffers.size() < newSize) {
-            auto buf =
-                allocator->acquire(SAllocatorBufferParams{.size = options.size, .format = options.format, .scanout = options.scanout, .cursor = options.cursor}, self.lock());
+            auto buf = allocator->acquire(
+                SAllocatorBufferParams{.size = options.size, .format = options.format, .scanout = options.scanout, .cursor = options.cursor, .multigpu = options.multigpu},
+                self.lock());
             if (!buf) {
                 allocator->getBackend()->log(AQ_LOG_ERROR, "Swapchain: Failed acquiring a buffer");
                 return false;


### PR DESCRIPTION
fullReconfigure() passes .multigpu when acquiring buffers, resize() did not, so any reallocation that only changed the swapchain length silently dropped it.

Issue caught when using dual monitor setup with multi gpu: Intel integrated + Nvidia RTX.