### PR TITLE
drm: don't delete HDR_OUTPUT_METADATA when EOTF is 0

### DIFF
--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -534,10 +534,7 @@ bool Aquamarine::CDRMAtomicImpl::prepareConnector(Hyprutils::Memory::CSharedPoin
         if (!connector->props.values.hdr_output_metadata)
             connector->backend->backend->log(AQ_LOG_ERROR, "atomic drm: failed to commit hdr metadata: no HDR_OUTPUT_METADATA prop support");
         else {
-            if (!data.hdrMetadata->hdmi_metadata_type1.eotf) {
-                data.atomic.hdrBlob = 0;
-                data.atomic.hdrd    = true;
-            } else if (drmModeCreatePropertyBlob(connector->backend->gpu->fd, &data.hdrMetadata.value(), sizeof(hdr_output_metadata), &data.atomic.hdrBlob)) {
+            if (drmModeCreatePropertyBlob(connector->backend->gpu->fd, &data.hdrMetadata.value(), sizeof(hdr_output_metadata), &data.atomic.hdrBlob)) {
                 connector->backend->backend->log(AQ_LOG_ERROR, "atomic drm: failed to create a hdr metadata blob");
                 data.atomic.hdrBlob = 0;
                 data.atomic.hdrd    = false;


### PR DESCRIPTION
LLMs were used to partly author this (inc. partly the description), cause HDR spec is pain. I have read, compiled, and run the test suite. also am running it live. If this is unaccpatable, let me know, and I will rewrite/close this off.

This is the pr mentioned in https://github.com/hyprwm/Hyprland/pull/15908.

prepareConnector() turns eotf = 0 (Traditional gamma, SDR) into deleting the HDR_OUTPUT_METADATA property. That stops the metadata SDP entirely rather than telling the sink "this is SDR now". eotf = 0 is a first-class CTA-861 code point, so send it instead.

This fixes two separate things.

The sink latches its last-seen PQ metadata when the SDP stops. SDR content then keeps being processed as PQ - blindingly bright, blues washing to white - until a full modeset reinitialises the panel (looked weirdly pretty tho). Isolated this with an A/B on an identical end state (GMP clear, blob absent, Colorspace 9), reached once by modeset (correct) and once by fastset (corrupted). Neither a forced link retrain nor a DPCD DP_SET_POWER D3 -> D0 bounce clears it; only a modeset does.

It also forces a full modeset. Dropping the blob flips the GMP bit in infoframes.enable, which i915/xe's fastset comparator rejects (`fastset requirement not met in infoframes.enable (expected 0x00000000, found 0x00000002)`). On eDP that power-cycles the panel via intel_ddi_post_disable_dp() → intel_pps_off(), and this panel's VBT sequencing then mandates ~951 ms.

On a stock kernel:

| transition                 | before                          | after                               |
|----------------------------|---------------------------------|-------------------------------------|
| enter HDR (first per boot) | 1045 ms + blank                 | 1094 ms + blank (one-time, GMP 0→1) |
| enter HDR (subsequent)     | 1045 ms + blank                 | 47 ms, no blank                     |
| leave HDR                  | 1080 ms + blank, then corrupted | 45 ms, no blank, correct            |

(Timings are from ~10 ms polling, so upper bounds; measured with /dev/kmsg markers the switch lands within one vblank.)

EOTF=0 is the right signal because i915 already distinguishes by value rather than presence - intel_dp_in_hdr_mode() returns eotf == HDMI_EOTF_SMPTE_ST2084 - so an EOTF=0 blob is correctly read as SDR and the backlight stays on its normal path.

A few things worth flagging:

- The remaining one-time modeset on first HDR entry is GMP going 0 -> 1. I verified on a clean boot in SDR that HDR_OUTPUT_METADATA is unset at that point - nothing calls setHDRMetadata() until HDR is first wanted, so data.hdrMetadata has no value and even the initial modeset skips the blob. Sending SDR metadata at monitor init would enable GMP from the start and make the first transition a fastset too; that's a separate hyprland change - I'll open a pr once this one is merged.
- The eotf == 0 special case dates to the original HDR support commit (aeab812e, #112). Neither the commit nor its review gives a reason, so it reads as how "HDR off" was expressed rather than a workaround for a specific sink - but if there is an undocumented reason, this should be conditional rather than removed.
- One panel, one driver, one kernel: Intel Arrow Lake, xe, eDP HDR10 OLED, kernel 7.1.8. Built and running against current main (f32cfd0).

(this has the largest description to loc ratio I have ever done in my life)