### PR TITLE
core/drm: introduce async commits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBDIR ${CMAKE_INSTALL_FULL_LIBDIR})
 
 find_package(PkgConfig REQUIRED)
 find_package(OpenGL REQUIRED COMPONENTS "GLES3")
+find_package(Threads REQUIRED)
 find_package(hyprwayland-scanner 0.4.0 REQUIRED)
 pkg_check_modules(
   deps
@@ -70,7 +71,7 @@ target_include_directories(
   PRIVATE "./src" "./src/include" "./protocols" "${CMAKE_BINARY_DIR}")
 set_target_properties(aquamarine PROPERTIES VERSION ${AQUAMARINE_VERSION}
                                             SOVERSION 13)
-target_link_libraries(aquamarine OpenGL::EGL OpenGL::OpenGL PkgConfig::deps)
+target_link_libraries(aquamarine OpenGL::EGL OpenGL::OpenGL PkgConfig::deps Threads::Threads)
 
 check_include_file("sys/timerfd.h" HAS_TIMERFD)
 pkg_check_modules(epoll IMPORTED_TARGET epoll-shim)
@@ -157,6 +158,15 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
   COMMAND output "output")
 add_dependencies(tests output)
+
+add_executable(commitThread "tests/CommitThread.cpp")
+target_include_directories(commitThread PRIVATE "./src/backend/drm")
+target_link_libraries(commitThread PRIVATE PkgConfig::deps aquamarine)
+add_test(
+  NAME "commitThread"
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
+  COMMAND commitThread "commitThread")
+add_dependencies(tests commitThread)
 
 # Installation
 install(TARGETS aquamarine)

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -18,6 +18,8 @@ namespace Aquamarine {
     class CDRMRenderer;
     class CDRMDumbAllocator;
 
+    using DRMFBList = std::vector<Hyprutils::Memory::CSharedPointer<CDRMFB>>;
+
     typedef std::function<void(void)> FIdleCallback;
 
     class CDRMBufferAttachment : public IAttachment {
@@ -116,6 +118,7 @@ namespace Aquamarine {
         Hyprutils::Memory::CSharedPointer<CDRMFB>    front /* currently displaying */, back /* submitted */, last /* keep just in case */;
         Hyprutils::Memory::CWeakPointer<CDRMBackend> backend;
         Hyprutils::Memory::CWeakPointer<SDRMPlane>   self;
+        bool                                         backSet = false;
         std::vector<SDRMFormat>                      formats;
 
         union UDRMPlaneProps {
@@ -265,12 +268,17 @@ namespace Aquamarine {
 
     struct SDRMConnectorCommitData {
         Hyprutils::Memory::CSharedPointer<CDRMFB> mainFB, cursorFB;
-        bool                                      modeset   = false;
-        bool                                      blocking  = false;
-        uint32_t                                  flags     = 0;
-        bool                                      test      = false;
-        bool                                      enabled   = false;
-        uint32_t                                  committed = 0;
+        COutputState::SInternalState              outputState;
+        Hyprutils::Math::Vector2D                 cursorPos, cursorHotspot;
+        bool                                      cursorVisible    = false;
+        bool                                      modeset          = false;
+        bool                                      blocking         = false;
+        uint32_t                                  flags            = 0;
+        bool                                      test             = false;
+        bool                                      enabled          = false;
+        uint32_t                                  committed        = 0;
+        bool                                      primaryFBChanged = false, cursorFBChanged = false;
+        DRMFBList                                 retiredFBs;
         Hyprutils::Math::CRegion                  damage;
         drmModeModeInfo                           modeInfo;
         std::optional<Hyprutils::Math::Mat3x3>    ctm;
@@ -327,12 +335,12 @@ namespace Aquamarine {
         drmModeModeInfo*                               getCurrentMode();
         IOutput::SParsedEDID                           parseEDID(std::vector<uint8_t> data);
         bool                                           commitState(SDRMConnectorCommitData& data);
-        void                                           applyCommit(const SDRMConnectorCommitData& data);
-        void                                           onPresent();
+        void                                           applyCommit(SDRMConnectorCommitData& data);
+        void                                           onPresent(bool primary = true, bool cursor = true, DRMFBList* retired = nullptr);
         void                                           recheckCRTCProps();
         void                                           parseTileInfo();
         void                                           releaseFBBuffer(const Hyprutils::Memory::CSharedPointer<CDRMFB> fb);
-        void                                           releaseFBReferences();
+        void                                           releaseFBReferences(DRMFBList* retired = nullptr);
         void                                           invalidateFrame();
         void                                           setCRTC(Hyprutils::Memory::CSharedPointer<SDRMCRTC> newCRTC);
 
@@ -372,11 +380,12 @@ namespace Aquamarine {
 
             // last connector_state values successfully committed to the kernel. used
             // to skip re-emitting unchanged values on page-flips (see #265).
-            uint64_t maxBpc      = 0;
-            uint64_t colorspace  = 0;
-            uint16_t contentType = 0;
-            uint32_t crtcID      = 0;
-            bool     propsCached = false;
+            uint64_t          maxBpc      = 0;
+            uint64_t          colorspace  = 0;
+            uint16_t          contentType = 0;
+            uint32_t          crtcID      = 0;
+            bool              propsCached = false;
+            eOutputColorRange colorRange  = AQ_OUTPUT_COLOR_RANGE_AUTO;
         } atomic;
 
         union UDRMConnectorProps {
@@ -466,7 +475,7 @@ namespace Aquamarine {
         bool checkFeatures();
         bool initResources();
         bool initMgpu();
-        bool updateSecondaryRendererState();
+        bool updateSecondaryRendererState(DRMFBList* retired = nullptr);
         bool grabFormats();
         bool shouldBlit();
         void scanConnectors();

--- a/include/aquamarine/backend/DRM.hpp
+++ b/include/aquamarine/backend/DRM.hpp
@@ -6,8 +6,10 @@
 #include "../input/Input.hpp"
 #include "FrameScheduler.hpp"
 #include <hyprutils/memory/WeakPtr.hpp>
+#include <hyprutils/memory/Atomic.hpp>
 #include <wayland-client.h>
 #include <xf86drmMode.h>
+#include <memory>
 #include <optional>
 
 namespace Aquamarine {
@@ -17,6 +19,10 @@ namespace Aquamarine {
     struct SDRMConnector;
     class CDRMRenderer;
     class CDRMDumbAllocator;
+    class CDRMCommitThread;
+    class CDRMCursorPositionMailbox;
+    class CDRMAsyncCommitData;
+    struct SDRMConnectorCommitData;
 
     using DRMFBList = std::vector<Hyprutils::Memory::CSharedPointer<CDRMFB>>;
 
@@ -168,10 +174,20 @@ namespace Aquamarine {
         struct {
             std::optional<uintptr_t>                       id; // nullopt when nothing is in flight
             Hyprutils::Memory::CWeakPointer<SDRMConnector> connector;
-            bool                                           async = false; // PAGE_FLIP_ASYNC
+            bool                                           async       = false; // PAGE_FLIP_ASYNC
+            uint64_t                                       commitID    = 0;
+            bool                                           resultReady = true;
+
+            struct {
+                bool         valid = false;
+                unsigned int seq   = 0;
+                unsigned int sec   = 0;
+                unsigned int usec  = 0;
+            } early;
         } pendingFlip;
 
-        uintptr_t armPageFlip(Hyprutils::Memory::CWeakPointer<SDRMConnector> connector, bool async);
+        uintptr_t armPageFlip(Hyprutils::Memory::CWeakPointer<SDRMConnector> connector, bool async, std::optional<uintptr_t> id = std::nullopt, uint64_t commitID = 0,
+                              bool resultReady = true);
         void      disarmPageFlip();
 
         struct {
@@ -232,6 +248,8 @@ namespace Aquamarine {
         virtual std::vector<SDRMFormat>                                   getRenderFormats();
         virtual bool                                                      pendingPageFlip();
         virtual bool                                                      pendingIdleFrame();
+        virtual uint32_t                                                  commitCapabilities() const;
+        virtual SCommitSubmission                                         commitAsync(const SCommitOptions& options);
         void                                                              releaseMgpuResources();
 
         int                                                               getConnectorID();
@@ -247,7 +265,9 @@ namespace Aquamarine {
       private:
         CDRMOutput(const std::string& name_, Hyprutils::Memory::CWeakPointer<CDRMBackend> backend_, Hyprutils::Memory::CSharedPointer<SDRMConnector> connector_);
 
-        bool                                                         commitState(bool onlyTest = false);
+        bool commitState(bool onlyTest = false);
+        bool prepareAsyncCommitData(const COutputState::CSnapshot& snapshot, SDRMConnectorCommitData& data, Hyprutils::OS::CFileDescriptor& mgpuFence, bool& mgpuAcquired,
+                                    bool& requiresSync);
 
         Hyprutils::Memory::CWeakPointer<CDRMBackend>                 backend;
         Hyprutils::Memory::CSharedPointer<SDRMConnector>             connector;
@@ -260,10 +280,14 @@ namespace Aquamarine {
             Hyprutils::Memory::CSharedPointer<CSwapchain> cursorSwapchain;
         } mgpu;
 
-        bool lastCommitNoBuffer = true;
+        bool                                                               lastCommitNoBuffer = true;
+        uint64_t                                                           asyncOwnerID = 0, pendingAsyncCommit = 0;
+        bool                                                               asyncCommitEventPending = false;
+        Hyprutils::Memory::CAtomicSharedPointer<CDRMCursorPositionMailbox> cursorMailbox;
 
         friend struct SDRMConnector;
         friend class CDRMLease;
+        friend class CDRMBackend;
     };
 
     struct SDRMConnectorCommitData {
@@ -367,7 +391,7 @@ namespace Aquamarine {
         CFrameScheduler                                sched;
 
         // the current state is invalid and won't commit, don't try to modeset.
-        bool                                           commitTainted = false;
+        bool commitTainted = false;
 
         // set when an atomic commit with max_bpc fails; skips max_bpc on future
         // commits for this connector (works around buggy drivers, e.g. amdgpu eDP).
@@ -464,6 +488,9 @@ namespace Aquamarine {
         virtual eBackendGPUDriver                                          gpuDriver();
         Hyprutils::Memory::CSharedPointer<SDRMCRTC>                        crtcByID(uint32_t id);
 
+        void                                                               dispatchCommitResults();
+        void                                                               handlePageFlip(uintptr_t flipID, unsigned int seq, unsigned int sec, unsigned int usec, uint32_t crtcID);
+
       private:
         CDRMBackend(Hyprutils::Memory::CSharedPointer<CBackend> backend);
 
@@ -471,20 +498,28 @@ namespace Aquamarine {
         static Hyprutils::Memory::CSharedPointer<CDRMBackend>              fromGpu(std::string path, Hyprutils::Memory::CSharedPointer<CBackend> backend,
                                                                                    Hyprutils::Memory::CSharedPointer<CDRMBackend> primary);
 
-        bool registerGPU(Hyprutils::Memory::CSharedPointer<CSessionDevice> gpu_, Hyprutils::Memory::CSharedPointer<CDRMBackend> primary_ = {});
-        bool checkFeatures();
-        bool initResources();
-        bool initMgpu();
-        bool updateSecondaryRendererState(DRMFBList* retired = nullptr);
-        bool grabFormats();
-        bool shouldBlit();
-        void scanConnectors();
-        void scanLeases();
-        void restoreAfterVT();
-        void recheckOutputs();
-        void recheckCRTCs();
-        void markRedundantTiles();
-        void buildGlFormats(const std::vector<SGLFormat>& fmts);
+        bool     registerGPU(Hyprutils::Memory::CSharedPointer<CSessionDevice> gpu_, Hyprutils::Memory::CSharedPointer<CDRMBackend> primary_ = {});
+        bool     checkFeatures();
+        bool     initResources();
+        bool     initMgpu();
+        bool     updateSecondaryRendererState(DRMFBList* retired = nullptr);
+        bool     grabFormats();
+        bool     shouldBlit();
+        void     scanConnectors();
+        void     scanLeases();
+        void     restoreAfterVT();
+        void     recheckOutputs();
+        void     recheckCRTCs();
+        void     markRedundantTiles();
+        void     buildGlFormats(const std::vector<SGLFormat>& fmts);
+        bool     initCommitThread();
+        void     stopCommitThread();
+        void     cancelAsyncOutput(CDRMOutput* output, bool renewOwner = false);
+        void     emitAsyncCommitEvent(Hyprutils::Memory::CSharedPointer<CDRMOutput> output);
+        void     flushAsyncCommitEvents();
+        bool     pauseCommitQueue(uint64_t queueKey);
+        void     resumeCommitQueue(uint64_t queueKey);
+        uint64_t nextAsyncOwnerID();
 
         Hyprutils::Memory::CSharedPointer<CSessionDevice>     gpu;
         Hyprutils::Memory::CSharedPointer<IDRMImplementation> impl;
@@ -505,8 +540,12 @@ namespace Aquamarine {
         std::vector<Hyprutils::Memory::CSharedPointer<SDRMConnector>> connectors;
         std::vector<SDRMFormat>                                       formats;
         std::vector<SDRMFormat>                                       glFormats;
-        uintptr_t                                                     m_lastPageFlipID = 0;
+        uintptr_t                                                     m_lastPageFlipID           = 0;
+        uint64_t                                                      m_lastAsyncOwnerID         = 0;
+        size_t                                                        m_pendingAsyncCommitEvents = 0;
         uintptr_t                                                     nextPageFlipID();
+        Hyprutils::Memory::CUniquePointer<CDRMCommitThread>           commitThread;
+        std::chrono::microseconds                                     commitLeadTime = std::chrono::microseconds{2000};
 
         Hyprutils::Memory::CSharedPointer<CDRMDumbAllocator>          dumbAllocator;
 
@@ -532,6 +571,8 @@ namespace Aquamarine {
         friend struct SDRMCRTC;
         friend struct SDRMPlane;
         friend class CDRMOutput;
+        friend class CDRMAsyncCommitData;
+        friend struct SDRMConnector;
         friend class CDRMLegacyImpl;
         friend class CDRMAtomicImpl;
         friend class CDRMAtomicRequest;

--- a/include/aquamarine/backend/drm/Atomic.hpp
+++ b/include/aquamarine/backend/drm/Atomic.hpp
@@ -30,7 +30,8 @@ namespace Aquamarine {
         void addConnectorCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
         bool commit(uint32_t flagssss);
         void add(uint32_t id, uint32_t prop, uint64_t val);
-        void planeProps(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane, Hyprutils::Memory::CSharedPointer<CDRMFB> fb, uint32_t crtc, Hyprutils::Math::Vector2D pos);
+        void planeProps(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane, Hyprutils::Memory::CSharedPointer<CDRMFB> fb, uint32_t crtc, Hyprutils::Math::Vector2D pos,
+                        eOutputColorRange colorRange = AQ_OUTPUT_COLOR_RANGE_AUTO);
         void planePropsPos(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane, Hyprutils::Math::Vector2D pos);
 
         void rollback(SDRMConnectorCommitData& data);

--- a/include/aquamarine/backend/drm/Atomic.hpp
+++ b/include/aquamarine/backend/drm/Atomic.hpp
@@ -3,12 +3,18 @@
 #include "../DRM.hpp"
 
 namespace Aquamarine {
+    class CDRMAtomicRequest;
+
     class CDRMAtomicImpl : public IDRMImplementation {
       public:
         CDRMAtomicImpl(Hyprutils::Memory::CSharedPointer<CDRMBackend> backend_);
-        virtual bool commit(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
-        virtual bool reset();
-        virtual bool moveCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, bool skipSchedule = false);
+        virtual bool                                         commit(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
+        virtual bool                                         reset();
+        virtual bool                                         moveCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, bool skipSchedule = false);
+
+        Hyprutils::Memory::CUniquePointer<CDRMAtomicRequest> prepareAsync(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data,
+                                                                          uint32_t& flags);
+        void finalizeAsync(CDRMAtomicRequest& request, Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data, bool success);
 
       private:
         bool                                         prepareConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
@@ -20,24 +26,31 @@ namespace Aquamarine {
 
     class CDRMAtomicRequest {
       public:
+        struct SAsyncResult {
+            bool submitted = false;
+            int  error     = 0;
+        };
+
         CDRMAtomicRequest(Hyprutils::Memory::CWeakPointer<CDRMBackend> backend);
         ~CDRMAtomicRequest();
 
-        void setConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector);
-        void addConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
-        bool restateConnectors(Hyprutils::Memory::CSharedPointer<SDRMConnector> self);
-        void addConnectorModeset(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
-        void addConnectorCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
-        bool commit(uint32_t flagssss);
-        void add(uint32_t id, uint32_t prop, uint64_t val);
-        void planeProps(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane, Hyprutils::Memory::CSharedPointer<CDRMFB> fb, uint32_t crtc, Hyprutils::Math::Vector2D pos,
-                        eOutputColorRange colorRange = AQ_OUTPUT_COLOR_RANGE_AUTO);
-        void planePropsPos(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane, Hyprutils::Math::Vector2D pos);
+        void         setConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector);
+        void         addConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
+        bool         restateConnectors(Hyprutils::Memory::CSharedPointer<SDRMConnector> self);
+        void         addConnectorModeset(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
+        void         addConnectorCursor(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data);
+        bool         commit(uint32_t flagssss);
+        void         add(uint32_t id, uint32_t prop, uint64_t val);
+        bool         addRaw(uint32_t id, uint32_t prop, uint64_t val) noexcept;
+        SAsyncResult submitAsync(int drmFD, uint32_t flags, uint64_t commitID) noexcept;
+        void         planeProps(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane, Hyprutils::Memory::CSharedPointer<CDRMFB> fb, uint32_t crtc, Hyprutils::Math::Vector2D pos,
+                                eOutputColorRange colorRange = AQ_OUTPUT_COLOR_RANGE_AUTO);
+        void         planePropsPos(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane, Hyprutils::Math::Vector2D pos);
 
-        void rollback(SDRMConnectorCommitData& data);
-        void apply(SDRMConnectorCommitData& data);
+        void         rollback(SDRMConnectorCommitData& data);
+        void         apply(SDRMConnectorCommitData& data);
 
-        bool failed = false;
+        bool         failed = false;
 
       private:
         void                                             destroyBlob(uint32_t id);

--- a/include/aquamarine/buffer/Buffer.hpp
+++ b/include/aquamarine/buffer/Buffer.hpp
@@ -58,6 +58,9 @@ namespace Aquamarine {
         virtual void                                   lock();
         virtual void                                   unlock();
         virtual bool                                   locked();
+        void                                           backendPin();
+        void                                           backendUnpin();
+        uint32_t                                       backendPinCount() const;
 
         Hyprutils::Math::Vector2D                      size;
         bool                                           opaque          = false;
@@ -71,7 +74,8 @@ namespace Aquamarine {
         } events;
 
       private:
-        int locks = 0;
+        int      locks       = 0;
+        uint32_t backendPins = 0;
     };
 
 };

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -127,6 +127,43 @@ namespace Aquamarine {
       public:
         virtual ~IOutput();
 
+        enum eOutputCommitCapabilities : uint32_t {
+            AQ_OUTPUT_COMMIT_CAPABILITY_QUEUED      = (1 << 0), // Supports commitAsync.
+            AQ_OUTPUT_COMMIT_CAPABILITY_TIMED       = (1 << 1), // Supports targetPresentation.
+            AQ_OUTPUT_COMMIT_CAPABILITY_VRR         = (1 << 2), // Supports queued commits while adaptive sync is active.
+            AQ_OUTPUT_COMMIT_CAPABILITY_TEARING     = (1 << 3), // Supports queued immediate-presentation commits.
+            AQ_OUTPUT_COMMIT_CAPABILITY_LATE_CURSOR = (1 << 4), // Supports lateCursor.
+        };
+
+        enum eOutputCommitStatus : uint32_t {
+            AQ_OUTPUT_COMMIT_SUBMITTED = 0,
+            AQ_OUTPUT_COMMIT_FAILED,
+            AQ_OUTPUT_COMMIT_CANCELLED,
+        };
+
+        // commitAsync snapshots pending state before returning. Requesting an option without its corresponding capability is rejected with ENOTSUP.
+        struct SCommitOptions {
+            // requires TIMED when set. The value is the desired presentation time; nullopt requests immediate submission.
+            std::optional<std::chrono::steady_clock::time_point> targetPresentation;
+            // requires LATE_CURSOR when set. The cursor position is the only state allowed to change after commitAsync returns.
+            bool lateCursor = false;
+        };
+
+        // rejection leaves pending output state untouched. Pending VRR or tearing state requires the corresponding capability.
+        struct SCommitSubmission {
+            uint64_t id    = 0; // 0 means rejected.
+            int      error = 0; // Positive errno, 0 on acceptance.
+        };
+
+        // every accepted id receives exactly one result after commitAsync returns, on the backend's dispatch thread. A submitted result precedes its presentation.
+        // cancellation results are emitted before destroy.
+        struct SCommitResult {
+            uint64_t            id           = 0;
+            eOutputCommitStatus status       = AQ_OUTPUT_COMMIT_FAILED;
+            int                 error        = 0;     // positive errno, 0 when submitted.
+            bool                missedTarget = false; // backend submission completed after targetPresentation. Valid only for timed, submitted commits.
+        };
+
         enum scheduleFrameReason : uint32_t {
             AQ_SCHEDULE_UNKNOWN = 0,
             AQ_SCHEDULE_NEW_CONNECTOR,
@@ -177,7 +214,7 @@ namespace Aquamarine {
         virtual void                                                      moveCursor(const Hyprutils::Math::Vector2D& coord, bool skipSchedule = false); // includes the hotspot
         virtual void                                                      setCursorVisible(bool visible); // moving the cursor will make it visible again without this util
         virtual bool                                                      hasCursorPlane() const;
-        virtual Hyprutils::Math::Vector2D                                 cursorPlaneSize();              // -1, -1 means no set size, 0, 0 means error
+        virtual Hyprutils::Math::Vector2D                                 cursorPlaneSize(); // -1, -1 means no set size, 0, 0 means error
         virtual std::optional<std::chrono::steady_clock::time_point>      nextVBlank() const;
         virtual void                                                      scheduleFrame(const scheduleFrameReason reason = AQ_SCHEDULE_UNKNOWN);
         virtual size_t                                                    getGammaSize();
@@ -185,6 +222,8 @@ namespace Aquamarine {
         virtual bool                                                      destroy(); // not all backends allow this!!!
         virtual bool                                                      pendingPageFlip()  = 0;
         virtual bool                                                      pendingIdleFrame() = 0;
+        virtual uint32_t                                                  commitCapabilities() const;
+        virtual SCommitSubmission                                         commitAsync(const SCommitOptions& options);
 
         std::string                                                       name, description, make, model, serial;
         SParsedEDID                                                       parsedEDID;
@@ -220,6 +259,7 @@ namespace Aquamarine {
             unsigned int seq       = 0;
             int          refresh   = 0;
             uint32_t     flags     = 0;
+            uint64_t     commitID  = 0; // 0 means the presentation is not associated with a queued commit.
         };
 
         struct {
@@ -229,6 +269,7 @@ namespace Aquamarine {
             Hyprutils::Signal::CSignalT<SPresentEvent> present;
             Hyprutils::Signal::CSignalT<>              commit;
             Hyprutils::Signal::CSignalT<SStateEvent>   state;
+            Hyprutils::Signal::CSignalT<SCommitResult> commitResult;
         } events;
     };
 }

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
 #include <chrono>
+#include <array>
 #include <vector>
 #include <optional>
 #include <hyprutils/signal/Signal.hpp>
 #include <hyprutils/memory/SharedPtr.hpp>
 #include <hyprutils/math/Region.hpp>
 #include <hyprutils/math/Mat3x3.hpp>
+#include <hyprutils/os/FileDescriptor.hpp>
 #include <drm_fourcc.h>
 #include <xf86drmMode.h>
 #include "../allocator/Swapchain.hpp"
@@ -84,12 +86,35 @@ namespace Aquamarine {
             int32_t                                        explicitInFence = -1, explicitOutFence = -1;
             Hyprutils::Math::Mat3x3                        ctm            = Hyprutils::Math::Mat3x3::identity();
             bool                                           wideColorGamut = false;
-            hdr_output_metadata                            hdrMetadata;
-            uint16_t                                       contentType = DRM_MODE_CONTENT_TYPE_GRAPHICS;
-            eOutputColorRange                              colorRange  = AQ_OUTPUT_COLOR_RANGE_AUTO;
+            hdr_output_metadata                            hdrMetadata    = {};
+            uint16_t                                       contentType    = DRM_MODE_CONTENT_TYPE_GRAPHICS;
+            eOutputColorRange                              colorRange     = AQ_OUTPUT_COLOR_RANGE_AUTO;
+        };
+
+        class CSnapshot {
+          public:
+            CSnapshot(CSnapshot&&) = default;
+
+            const SInternalState& state() const;
+            bool                  needsReconfig() const;
+            int                   error() const;
+
+          private:
+            CSnapshot(const COutputState* owner, const SInternalState& state, const std::array<uint64_t, 16>& generations);
+
+            const COutputState*            m_owner = nullptr;
+            SInternalState                 m_state;
+            std::array<uint64_t, 16>       m_generations = {};
+            Hyprutils::OS::CFileDescriptor m_explicitInFence;
+            int                            m_error = 0;
+
+            friend class COutputState;
         };
 
         const SInternalState& state();
+        const SInternalState& state() const;
+        CSnapshot             snapshot() const;
+        void                  consume(const CSnapshot& snapshot);
 
         bool                  needsReconfig() const;
         void                  addDamage(const Hyprutils::Math::CRegion& region);
@@ -113,14 +138,17 @@ namespace Aquamarine {
         void                  setColorRange(eOutputColorRange range);
 
       private:
-        SInternalState internalState;
+        SInternalState           internalState;
+        std::array<uint64_t, 16> propertyGenerations = {};
+        uint64_t                 nextGeneration      = 0;
 
-        void           onCommit(); // clears a few props like damage and committed.
+        void                     markCommitted(uint32_t properties);
 
         friend class IOutput;
         friend class CWaylandOutput;
         friend class CDRMOutput;
         friend class CHeadlessOutput;
+        friend struct SDRMConnector;
     };
 
     class IOutput {

--- a/include/aquamarine/output/Output.hpp
+++ b/include/aquamarine/output/Output.hpp
@@ -115,6 +115,7 @@ namespace Aquamarine {
         const SInternalState& state() const;
         CSnapshot             snapshot() const;
         void                  consume(const CSnapshot& snapshot);
+        void                  rearm(const CSnapshot& snapshot);
 
         bool                  needsReconfig() const;
         void                  addDamage(const Hyprutils::Math::CRegion& region);
@@ -147,6 +148,7 @@ namespace Aquamarine {
         friend class IOutput;
         friend class CWaylandOutput;
         friend class CDRMOutput;
+        friend class CDRMBackend;
         friend class CHeadlessOutput;
         friend struct SDRMConnector;
     };

--- a/src/backend/Headless.cpp
+++ b/src/backend/Headless.cpp
@@ -25,8 +25,9 @@ Aquamarine::CHeadlessOutput::~CHeadlessOutput() {
 }
 
 bool Aquamarine::CHeadlessOutput::commit() {
+    const auto snapshot = state->snapshot();
     events.commit.emit();
-    state->onCommit();
+    state->consume(snapshot);
     needsFrame = false;
     events.present.emit(IOutput::SPresentEvent{.presented = true});
     return true;

--- a/src/backend/Session.cpp
+++ b/src/backend/Session.cpp
@@ -234,8 +234,8 @@ void Aquamarine::CSessionDevice::resolveMatchingRenderNode(udev_device* cardDevi
     // for non-standard buses, reverted by 8ed71bb), commit 2455556b
     // (last known-good on M-series Asahi per the #260 thread).
     if (renderNodeFd < 0) {
-        int renderDCount = 0;
-        udev_list_entry* countEntry = nullptr;
+        int              renderDCount = 0;
+        udev_list_entry* countEntry   = nullptr;
         udev_list_entry_foreach(countEntry, devices) {
             const auto* path = udev_list_entry_get_name(countEntry);
             auto        dev  = udev_device_new_from_syspath(session->udevHandle, path);
@@ -263,9 +263,9 @@ void Aquamarine::CSessionDevice::resolveMatchingRenderNode(udev_device* cardDevi
                 }
                 renderNodeFd = open(fbDevnode, O_RDWR | O_CLOEXEC);
                 if (renderNodeFd >= 0) {
-                    session->backend->log(AQ_LOG_WARNING,
-                        std::format("drm: No matching render node for {}, falling back to sole renderD on the system: {}",
-                            parentSyspath ? parentSyspath : "(unknown)", fbDevnode));
+                    session->backend->log(
+                        AQ_LOG_WARNING,
+                        std::format("drm: No matching render node for {}, falling back to sole renderD on the system: {}", parentSyspath ? parentSyspath : "(unknown)", fbDevnode));
                     udev_device_unref(fbDev);
                     break;
                 }
@@ -273,8 +273,9 @@ void Aquamarine::CSessionDevice::resolveMatchingRenderNode(udev_device* cardDevi
             }
         } else if (renderDCount > 1) {
             session->backend->log(AQ_LOG_WARNING,
-                std::format("drm: No matching render node for {}, refusing to guess among {} renderD candidates; leaving renderer to fall through to KMS fd (may force software rendering; set AQ_DRM_DEVICES to disambiguate)",
-                    parentSyspath ? parentSyspath : "(unknown)", renderDCount));
+                                  std::format("drm: No matching render node for {}, refusing to guess among {} renderD candidates; leaving renderer to fall through to KMS fd (may "
+                                              "force software rendering; set AQ_DRM_DEVICES to disambiguate)",
+                                              parentSyspath ? parentSyspath : "(unknown)", renderDCount));
         }
     }
 

--- a/src/backend/Wayland.cpp
+++ b/src/backend/Wayland.cpp
@@ -615,18 +615,20 @@ bool Aquamarine::CWaylandOutput::test() {
 }
 
 bool Aquamarine::CWaylandOutput::commit() {
-    Vector2D pixelSize = {};
+    const auto  snapshot  = state->snapshot();
+    const auto& STATE     = snapshot.state();
+    Vector2D    pixelSize = {};
 
-    if (state->internalState.customMode)
-        pixelSize = state->internalState.customMode->pixelSize;
-    else if (state->internalState.mode)
-        pixelSize = state->internalState.mode->pixelSize;
+    if (STATE.customMode)
+        pixelSize = STATE.customMode->pixelSize;
+    else if (STATE.mode)
+        pixelSize = STATE.mode->pixelSize;
     else {
         backend->backend->log(AQ_LOG_ERROR, std::format("Output {}: pending state rejected: invalid mode", name));
         return false;
     }
 
-    uint32_t format = state->internalState.drmFormat;
+    uint32_t format = STATE.drmFormat;
 
     if (format == DRM_FORMAT_INVALID) {
         backend->backend->log(AQ_LOG_ERROR, std::format("Output {}: pending state rejected: invalid format", name));
@@ -643,19 +645,19 @@ bool Aquamarine::CWaylandOutput::commit() {
         return false;
     }
 
-    if (!state->internalState.buffer) {
+    if (!STATE.buffer) {
         // if the consumer explicitly committed a null buffer, that's a violation.
-        if (state->internalState.committed & COutputState::AQ_OUTPUT_STATE_BUFFER) {
+        if (STATE.committed & COutputState::AQ_OUTPUT_STATE_BUFFER) {
             backend->backend->log(AQ_LOG_ERROR, std::format("Output {}: pending state rejected: no buffer", name));
             return false;
         }
 
         events.commit.emit();
-        state->onCommit();
+        state->consume(snapshot);
         return true;
     }
 
-    auto wlBuffer = wlBufferFromBuffer(state->internalState.buffer);
+    auto wlBuffer = wlBufferFromBuffer(STATE.buffer);
 
     if (!wlBuffer) {
         backend->backend->log(AQ_LOG_ERROR, std::format("Output {}: pending state rejected: no wlBuffer??", name));
@@ -686,7 +688,7 @@ bool Aquamarine::CWaylandOutput::commit() {
     }
 
     waylandState.surface->sendCommit();
-    waylandState.surfaceSize = state->internalState.buffer->size;
+    waylandState.surfaceSize = STATE.buffer->size;
 
     // Flush immediately: commit() runs from the consumer's render path, outside
     // dispatchEvents() (which flushes only at its top). Without this the buffer commit and
@@ -695,7 +697,7 @@ bool Aquamarine::CWaylandOutput::commit() {
     wl_display_flush(backend->waylandState.display);
 
     events.commit.emit();
-    state->onCommit();
+    state->consume(snapshot);
     needsFrame = false;
 
     return true;

--- a/src/backend/drm/AsyncCommit.cpp
+++ b/src/backend/drm/AsyncCommit.cpp
@@ -1,0 +1,111 @@
+#include "AsyncCommit.hpp"
+
+#include <cerrno>
+#include <thread>
+
+using namespace Aquamarine;
+using namespace Hyprutils::Memory;
+
+void Aquamarine::CDRMCursorPositionMailbox::store(const Hyprutils::Math::Vector2D& position) {
+    m_sequence.fetch_add(1, std::memory_order_acq_rel);
+    m_x.store(sc<int64_t>(position.x), std::memory_order_relaxed);
+    m_y.store(sc<int64_t>(position.y), std::memory_order_relaxed);
+    m_sequence.fetch_add(1, std::memory_order_release);
+}
+
+Hyprutils::Math::Vector2D Aquamarine::CDRMCursorPositionMailbox::load() const {
+    while (true) {
+        const auto BEFORE = m_sequence.load(std::memory_order_acquire);
+        if (BEFORE & 1) {
+            std::this_thread::yield();
+            continue;
+        }
+
+        const auto X     = m_x.load(std::memory_order_relaxed);
+        const auto Y     = m_y.load(std::memory_order_relaxed);
+        const auto AFTER = m_sequence.load(std::memory_order_acquire);
+        if (BEFORE == AFTER)
+            return {sc<double>(X), sc<double>(Y)};
+    }
+}
+
+Aquamarine::CDRMAsyncCommitData::CDRMAsyncCommitData(COutputState::CSnapshot&& snapshot_) : snapshot(makeUnique<COutputState::CSnapshot>(std::move(snapshot_))) {
+    ;
+}
+
+Aquamarine::CDRMAsyncCommitData::~CDRMAsyncCommitData() {
+    rollbackMgpu();
+    releasePins();
+}
+
+void Aquamarine::CDRMAsyncCommitData::pinBuffers() {
+    if (mainBuffer && !mainPinned) {
+        mainBuffer->backendPin();
+        mainPinned = true;
+    }
+
+    if (cursorBuffer && cursorBuffer != mainBuffer && !cursorPinned) {
+        cursorBuffer->backendPin();
+        cursorPinned = true;
+    }
+}
+
+void Aquamarine::CDRMAsyncCommitData::releasePins() {
+    if (mainPinned && mainBuffer) {
+        mainBuffer->backendUnpin();
+        mainPinned = false;
+    }
+
+    if (cursorPinned && cursorBuffer) {
+        cursorBuffer->backendUnpin();
+        cursorPinned = false;
+    }
+}
+
+void Aquamarine::CDRMAsyncCommitData::rollbackMgpu() {
+    if (!mgpuAcquired || !mgpuSwapchain)
+        return;
+
+    mgpuSwapchain->rollback();
+    mgpuAcquired = false;
+}
+
+IDRMCommitSubmitter::SResult Aquamarine::CDRMAsyncCommitData::submit(int drmFD, uint64_t commitID) const noexcept {
+    if (!request || !commitID || !flipID)
+        return {.submitted = false, .error = EINVAL};
+
+    if (lateCursor && cursorMailbox && cursorPlaneID && cursorXProp && cursorYProp) {
+        const auto POSITION = cursorMailbox->load() - cursorHotspot;
+        if (!request->addRaw(cursorPlaneID, cursorXProp, sc<uint64_t>(sc<int64_t>(POSITION.x))) ||
+            !request->addRaw(cursorPlaneID, cursorYProp, sc<uint64_t>(sc<int64_t>(POSITION.y))))
+            return {.submitted = false, .error = EINVAL};
+    }
+
+    const auto RESULT = request->submitAsync(drmFD, flags, flipID);
+    return {.submitted = RESULT.submitted, .error = RESULT.error};
+}
+
+class CDRMCommitSubmitter final : public IDRMCommitSubmitter {
+  public:
+    explicit CDRMCommitSubmitter(int drmFD_) : drmFD(drmFD_) {
+        ;
+    }
+
+    virtual SResult submit(uint64_t commitID, const IDRMCommitThreadData& data) noexcept {
+        const auto* ASYNC_DATA = dynamic_cast<const CDRMAsyncCommitData*>(&data);
+        if (!ASYNC_DATA)
+            return {.submitted = false, .error = EINVAL};
+
+        return ASYNC_DATA->submit(drmFD, commitID);
+    }
+
+  private:
+    int drmFD = -1;
+};
+
+CUniquePointer<IDRMCommitSubmitter> Aquamarine::makeDRMCommitSubmitter(int drmFD) {
+    if (drmFD < 0)
+        return nullptr;
+
+    return makeUnique<CDRMCommitSubmitter>(drmFD);
+}

--- a/src/backend/drm/AsyncCommit.hpp
+++ b/src/backend/drm/AsyncCommit.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "CommitThread.hpp"
+#include <aquamarine/backend/DRM.hpp>
+#include <aquamarine/backend/drm/Atomic.hpp>
+
+#include <atomic>
+#include <memory>
+
+namespace Aquamarine {
+    class CDRMCursorPositionMailbox {
+      public:
+        void                      store(const Hyprutils::Math::Vector2D& position);
+        Hyprutils::Math::Vector2D load() const;
+
+      private:
+        std::atomic<uint64_t> m_sequence = 0;
+        std::atomic<int64_t>  m_x        = 0;
+        std::atomic<int64_t>  m_y        = 0;
+    };
+
+    class CDRMAsyncCommitData : public IDRMCommitThreadData {
+      public:
+        CDRMAsyncCommitData(COutputState::CSnapshot&& snapshot_);
+        virtual ~CDRMAsyncCommitData();
+
+        void                                                               pinBuffers();
+        void                                                               releasePins();
+        void                                                               rollbackMgpu();
+        IDRMCommitSubmitter::SResult                                       submit(int drmFD, uint64_t commitID) const noexcept;
+
+        Hyprutils::Memory::CUniquePointer<COutputState::CSnapshot>         snapshot;
+        SDRMConnectorCommitData                                            commitData;
+        Hyprutils::Memory::CUniquePointer<CDRMAtomicRequest>               request;
+        Hyprutils::Memory::CSharedPointer<CDRMOutput>                      output;
+        Hyprutils::Memory::CSharedPointer<SDRMConnector>                   connector;
+        Hyprutils::Memory::CSharedPointer<IBuffer>                         mainBuffer;
+        Hyprutils::Memory::CSharedPointer<IBuffer>                         cursorBuffer;
+        Hyprutils::Memory::CSharedPointer<CSwapchain>                      mgpuSwapchain;
+        Hyprutils::OS::CFileDescriptor                                     mgpuFence;
+        Hyprutils::Memory::CAtomicSharedPointer<CDRMCursorPositionMailbox> cursorMailbox;
+        uint32_t                                                           flags         = 0;
+        uintptr_t                                                          flipID        = 0;
+        uint32_t                                                           cursorPlaneID = 0;
+        uint32_t                                                           cursorXProp   = 0;
+        uint32_t                                                           cursorYProp   = 0;
+        Hyprutils::Math::Vector2D                                          cursorHotspot;
+        bool                                                               lateCursor   = false;
+        bool                                                               tearing      = false;
+        bool                                                               mainPinned   = false;
+        bool                                                               cursorPinned = false;
+        bool                                                               mgpuAcquired = false;
+    };
+
+    Hyprutils::Memory::CUniquePointer<IDRMCommitSubmitter> makeDRMCommitSubmitter(int drmFD);
+}

--- a/src/backend/drm/CommitThread.cpp
+++ b/src/backend/drm/CommitThread.cpp
@@ -50,7 +50,7 @@ Aquamarine::CDRMCommitThread::~CDRMCommitThread() {
     stop();
 }
 
-std::optional<uint64_t> Aquamarine::CDRMCommitThread::enqueue(CUniquePointer<SDRMCommitThreadRequest> request) {
+std::optional<uint64_t> Aquamarine::CDRMCommitThread::enqueue(CUniquePointer<SDRMCommitThreadRequest>&& request) {
     if (!request || !request->data || request->id != 0 || request->ownerID == 0 || request->queueKey == 0)
         return std::nullopt;
 
@@ -113,12 +113,39 @@ size_t Aquamarine::CDRMCommitThread::cancelOwner(uint64_t ownerID) {
         std::lock_guard<std::mutex> lock(m_queueMutex);
         std::erase_if(m_blockedQueues, [ownerID](const auto& entry) { return entry.second.ownerID == ownerID; });
         for (const auto QUEUE : cancelledQueues)
-            m_pausedQueues.erase(QUEUE);
+            m_cancellingQueues.erase(QUEUE);
     }
 
     m_queueCondition.notify_one();
 
     return requests.size();
+}
+
+bool Aquamarine::CDRMCommitThread::pauseQueue(uint64_t queueKey) {
+    if (queueKey == 0)
+        return false;
+
+    std::unique_lock<std::mutex> lock(m_queueMutex);
+    ++m_pausedQueues[queueKey];
+    m_queueCondition.wait(lock, [this, queueKey] { return !m_activeRequest || m_activeRequest->queueKey != queueKey; });
+    return true;
+}
+
+bool Aquamarine::CDRMCommitThread::resumeQueue(uint64_t queueKey) {
+    if (queueKey == 0)
+        return false;
+
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        const auto                  PAUSE = m_pausedQueues.find(queueKey);
+        if (PAUSE == m_pausedQueues.end())
+            return false;
+        if (--PAUSE->second == 0)
+            m_pausedQueues.erase(PAUSE);
+    }
+
+    m_queueCondition.notify_one();
+    return true;
 }
 
 bool Aquamarine::CDRMCommitThread::releaseQueue(uint64_t queueKey, uint64_t commitID) {
@@ -278,7 +305,8 @@ CUniquePointer<SDRMCommitThreadRequest> Aquamarine::CDRMCommitThread::takeNextRe
             const auto& QUEUED = m_queue.at(i);
             const auto  KEY    = QUEUED.request->queueKey;
 
-            if (!seenQueues.emplace(KEY).second || m_blockedQueues.contains(KEY) || m_pausedQueues.contains(KEY) || m_cancelledOwners.contains(QUEUED.request->ownerID))
+            if (!seenQueues.emplace(KEY).second || m_blockedQueues.contains(KEY) || m_pausedQueues.contains(KEY) || m_cancellingQueues.contains(KEY) ||
+                m_cancelledOwners.contains(QUEUED.request->ownerID))
                 continue;
 
             const auto SUBMIT_AT = QUEUED.request->submitAt.value_or(std::chrono::steady_clock::time_point::min());
@@ -345,7 +373,7 @@ std::vector<CUniquePointer<SDRMCommitThreadRequest>> Aquamarine::CDRMCommitThrea
                 continue;
             }
 
-            m_pausedQueues.emplace(it->request->queueKey);
+            m_cancellingQueues.emplace(it->request->queueKey);
             requests.emplace_back(std::move(it->request));
             it = m_queue.erase(it);
         }

--- a/src/backend/drm/CommitThread.cpp
+++ b/src/backend/drm/CommitThread.cpp
@@ -1,0 +1,355 @@
+#include "CommitThread.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <exception>
+#include <limits>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+using namespace Aquamarine;
+using namespace Hyprutils::Memory;
+using namespace Hyprutils::OS;
+
+Aquamarine::IDRMCommitThreadData::~IDRMCommitThreadData() {
+    ;
+}
+
+Aquamarine::SDRMCommitThreadRequest::SDRMCommitThreadRequest()                                                 = default;
+Aquamarine::SDRMCommitThreadRequest::SDRMCommitThreadRequest(SDRMCommitThreadRequest&&)                        = default;
+Aquamarine::SDRMCommitThreadRequest& Aquamarine::SDRMCommitThreadRequest::operator=(SDRMCommitThreadRequest&&) = default;
+Aquamarine::SDRMCommitThreadRequest::~SDRMCommitThreadRequest()                                                = default;
+
+Aquamarine::IDRMCommitSubmitter::~IDRMCommitSubmitter() {
+    ;
+}
+
+Aquamarine::CDRMCommitThread::SResult::SResult()                                                   = default;
+Aquamarine::CDRMCommitThread::SResult::SResult(SResult&&)                                          = default;
+Aquamarine::CDRMCommitThread::SResult& Aquamarine::CDRMCommitThread::SResult::operator=(SResult&&) = default;
+Aquamarine::CDRMCommitThread::SResult::~SResult()                                                  = default;
+
+CUniquePointer<CDRMCommitThread> Aquamarine::CDRMCommitThread::create(CUniquePointer<IDRMCommitSubmitter> submitter) {
+    if (!submitter)
+        return nullptr;
+
+    auto thread = CUniquePointer<CDRMCommitThread>{new CDRMCommitThread(std::move(submitter))};
+    if (!thread->m_completionFD.isValid())
+        return nullptr;
+
+    thread->m_thread = std::thread([threadPtr = thread.get()] { threadPtr->run(); });
+    return thread;
+}
+
+Aquamarine::CDRMCommitThread::CDRMCommitThread(CUniquePointer<IDRMCommitSubmitter> submitter) :
+    m_submitter(std::move(submitter)), m_completionFD(eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)) {
+    ;
+}
+
+Aquamarine::CDRMCommitThread::~CDRMCommitThread() {
+    stop();
+}
+
+std::optional<uint64_t> Aquamarine::CDRMCommitThread::enqueue(CUniquePointer<SDRMCommitThreadRequest> request) {
+    if (!request || !request->data || request->id != 0 || request->ownerID == 0 || request->queueKey == 0)
+        return std::nullopt;
+
+    uint64_t commitID = 0;
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        constexpr size_t            MAX_QUEUED_REQUESTS = 64;
+        if (m_stopping || m_cancelledOwners.contains(request->ownerID) || m_queue.size() >= MAX_QUEUED_REQUESTS)
+            return std::nullopt;
+
+        ++m_lastCommitID;
+        if (m_lastCommitID == 0)
+            ++m_lastCommitID;
+
+        commitID    = m_lastCommitID;
+        request->id = commitID;
+
+        m_queue.emplace_back(SQueuedRequest{
+            .sequence = ++m_lastSequence,
+            .request  = std::move(request),
+        });
+    }
+
+    m_queueCondition.notify_one();
+    return commitID;
+}
+
+size_t Aquamarine::CDRMCommitThread::cancelOwner(uint64_t ownerID) {
+    if (ownerID == 0)
+        return 0;
+
+    std::vector<CUniquePointer<SDRMCommitThreadRequest>> requests;
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        m_cancelledOwners.emplace(ownerID);
+    }
+
+    requests = takeOwnerRequests(ownerID);
+
+    std::unordered_set<uint64_t> cancelledQueues;
+    for (const auto& request : requests)
+        cancelledQueues.emplace(request->queueKey);
+
+    {
+        std::unique_lock<std::mutex> lock(m_queueMutex);
+        m_queueCondition.wait(
+            lock, [this, ownerID, &cancelledQueues] { return !m_activeRequest || (m_activeRequest->ownerID != ownerID && !cancelledQueues.contains(m_activeRequest->queueKey)); });
+    }
+
+    for (auto& request : requests) {
+        SResult result;
+        result.request     = std::move(request);
+        result.status      = AQ_DRM_COMMIT_THREAD_CANCELLED;
+        result.error       = ECANCELED;
+        result.completedAt = std::chrono::steady_clock::now();
+        appendResult(std::move(result));
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        std::erase_if(m_blockedQueues, [ownerID](const auto& entry) { return entry.second.ownerID == ownerID; });
+        for (const auto QUEUE : cancelledQueues)
+            m_pausedQueues.erase(QUEUE);
+    }
+
+    m_queueCondition.notify_one();
+
+    return requests.size();
+}
+
+bool Aquamarine::CDRMCommitThread::releaseQueue(uint64_t queueKey, uint64_t commitID) {
+    if (queueKey == 0 || commitID == 0)
+        return false;
+
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        const auto                  BLOCKER = m_blockedQueues.find(queueKey);
+        if (BLOCKER == m_blockedQueues.end() || BLOCKER->second.commitID != commitID)
+            return false;
+
+        m_blockedQueues.erase(BLOCKER);
+    }
+
+    m_queueCondition.notify_one();
+    return true;
+}
+
+void Aquamarine::CDRMCommitThread::stop() {
+    std::lock_guard<std::mutex>                          stopLock(m_stopMutex);
+
+    std::vector<CUniquePointer<SDRMCommitThreadRequest>> cancelled;
+
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        if (!m_stopping) {
+            m_stopping = true;
+            cancelled.reserve(m_queue.size());
+            for (auto& queued : m_queue)
+                cancelled.emplace_back(std::move(queued.request));
+            m_queue.clear();
+        }
+    }
+
+    m_queueCondition.notify_one();
+    if (m_thread.joinable() && m_thread.get_id() == std::this_thread::get_id())
+        std::terminate();
+
+    if (m_thread.joinable())
+        m_thread.join();
+
+    for (auto& request : cancelled) {
+        SResult result;
+        result.request     = std::move(request);
+        result.status      = AQ_DRM_COMMIT_THREAD_CANCELLED;
+        result.error       = ECANCELED;
+        result.completedAt = std::chrono::steady_clock::now();
+        appendResult(std::move(result));
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        m_activeRequest.reset();
+        m_blockedQueues.clear();
+    }
+}
+
+std::vector<CDRMCommitThread::SResult> Aquamarine::CDRMCommitThread::stopAndDrain() {
+    stop();
+    return drainResults();
+}
+
+int Aquamarine::CDRMCommitThread::completionFD() const {
+    return m_completionFD.get();
+}
+
+std::vector<CDRMCommitThread::SResult> Aquamarine::CDRMCommitThread::drainResults() {
+    std::vector<SResult> results;
+    {
+        std::lock_guard<std::mutex> lock(m_resultMutex);
+
+        uint64_t                    signals = 0;
+        while (true) {
+            const auto READ = read(m_completionFD.get(), &signals, sizeof(signals));
+            if (READ == sizeof(signals))
+                continue;
+            if (READ < 0 && errno == EINTR)
+                continue;
+            break;
+        }
+
+        results = std::move(m_results);
+        m_results.clear();
+    }
+
+    return results;
+}
+
+bool Aquamarine::CDRMCommitThread::accepting() const {
+    std::lock_guard<std::mutex> lock(m_queueMutex);
+    return !m_stopping;
+}
+
+size_t Aquamarine::CDRMCommitThread::queued() const {
+    std::lock_guard<std::mutex> lock(m_queueMutex);
+    return m_queue.size();
+}
+
+bool Aquamarine::CDRMCommitThread::submitting() const {
+    std::lock_guard<std::mutex> lock(m_queueMutex);
+    return m_activeRequest.has_value();
+}
+
+void Aquamarine::CDRMCommitThread::run() {
+    while (true) {
+        CUniquePointer<SDRMCommitThreadRequest> request;
+        {
+            std::unique_lock<std::mutex> lock(m_queueMutex);
+            request = takeNextRequest(lock);
+        }
+
+        if (!request)
+            return;
+
+        const auto SUBMIT_RESULT = m_submitter->submit(request->id, *request->data);
+        const auto COMPLETED_AT  = std::chrono::steady_clock::now();
+
+        SResult    result;
+        result.status       = SUBMIT_RESULT.submitted ? AQ_DRM_COMMIT_THREAD_SUBMITTED : AQ_DRM_COMMIT_THREAD_FAILED;
+        result.error        = SUBMIT_RESULT.submitted ? 0 : (SUBMIT_RESULT.error > 0 ? SUBMIT_RESULT.error : EIO);
+        result.missedTarget = SUBMIT_RESULT.submitted && request->targetPresentation.has_value() && COMPLETED_AT > *request->targetPresentation;
+        result.completedAt  = COMPLETED_AT;
+        result.request      = std::move(request);
+        appendResult(std::move(result));
+
+        {
+            std::lock_guard<std::mutex> lock(m_queueMutex);
+            const auto&                 REQUEST = *m_activeRequest;
+            if (!SUBMIT_RESULT.submitted) {
+                const auto BLOCKER = m_blockedQueues.find(REQUEST.queueKey);
+                if (BLOCKER != m_blockedQueues.end() && BLOCKER->second.commitID == REQUEST.commitID)
+                    m_blockedQueues.erase(BLOCKER);
+            }
+
+            m_activeRequest.reset();
+        }
+
+        m_queueCondition.notify_all();
+    }
+}
+
+CUniquePointer<SDRMCommitThreadRequest> Aquamarine::CDRMCommitThread::takeNextRequest(std::unique_lock<std::mutex>& lock) {
+    while (true) {
+        if (m_stopping)
+            return nullptr;
+
+        const auto                                           NOW = std::chrono::steady_clock::now();
+
+        std::unordered_set<uint64_t>                         seenQueues;
+        std::optional<size_t>                                candidate;
+        std::chrono::steady_clock::time_point                candidateDeadline = std::chrono::steady_clock::time_point::max();
+        uint64_t                                             candidateSequence = std::numeric_limits<uint64_t>::max();
+        std::optional<std::chrono::steady_clock::time_point> earliestWake;
+
+        for (size_t i = 0; i < m_queue.size(); ++i) {
+            const auto& QUEUED = m_queue.at(i);
+            const auto  KEY    = QUEUED.request->queueKey;
+
+            if (!seenQueues.emplace(KEY).second || m_blockedQueues.contains(KEY) || m_pausedQueues.contains(KEY) || m_cancelledOwners.contains(QUEUED.request->ownerID))
+                continue;
+
+            const auto SUBMIT_AT = QUEUED.request->submitAt.value_or(std::chrono::steady_clock::time_point::min());
+            if (SUBMIT_AT > NOW) {
+                if (!earliestWake || SUBMIT_AT < *earliestWake)
+                    earliestWake = SUBMIT_AT;
+                continue;
+            }
+
+            const auto DEADLINE = QUEUED.request->targetPresentation.value_or(std::chrono::steady_clock::time_point::max());
+            if (!candidate || DEADLINE < candidateDeadline || (DEADLINE == candidateDeadline && QUEUED.sequence < candidateSequence)) {
+                candidate         = i;
+                candidateDeadline = DEADLINE;
+                candidateSequence = QUEUED.sequence;
+            }
+        }
+
+        if (!candidate) {
+            if (earliestWake)
+                m_queueCondition.wait_until(lock, *earliestWake);
+            else
+                m_queueCondition.wait(lock);
+            continue;
+        }
+
+        auto request = std::move(m_queue.at(*candidate).request);
+        m_queue.erase(m_queue.begin() + *candidate);
+        m_activeRequest = SActiveRequest{
+            .commitID = request->id,
+            .ownerID  = request->ownerID,
+            .queueKey = request->queueKey,
+        };
+        if (request->blocksQueue) {
+            m_blockedQueues[request->queueKey] = SBlocker{
+                .commitID = request->id,
+                .ownerID  = request->ownerID,
+            };
+        }
+        return request;
+    }
+}
+
+void Aquamarine::CDRMCommitThread::appendResult(SResult&& result) {
+    std::lock_guard<std::mutex> lock(m_resultMutex);
+    m_results.emplace_back(std::move(result));
+    signalResults();
+}
+
+void Aquamarine::CDRMCommitThread::signalResults() {
+    const uint64_t SIGNAL = 1;
+    while (write(m_completionFD.get(), &SIGNAL, sizeof(SIGNAL)) < 0 && errno == EINTR) {
+        ;
+    }
+}
+
+std::vector<CUniquePointer<SDRMCommitThreadRequest>> Aquamarine::CDRMCommitThread::takeOwnerRequests(uint64_t ownerID) {
+    std::vector<CUniquePointer<SDRMCommitThreadRequest>> requests;
+
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        for (auto it = m_queue.begin(); it != m_queue.end();) {
+            if (it->request->ownerID != ownerID) {
+                ++it;
+                continue;
+            }
+
+            m_pausedQueues.emplace(it->request->queueKey);
+            requests.emplace_back(std::move(it->request));
+            it = m_queue.erase(it);
+        }
+    }
+
+    return requests;
+}

--- a/src/backend/drm/CommitThread.hpp
+++ b/src/backend/drm/CommitThread.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <hyprutils/memory/UniquePtr.hpp>
+#include <hyprutils/os/FileDescriptor.hpp>
+
+namespace Aquamarine {
+    class IDRMCommitThreadData {
+      public:
+        virtual ~IDRMCommitThreadData();
+    };
+
+    struct SDRMCommitThreadRequest {
+        SDRMCommitThreadRequest();
+        SDRMCommitThreadRequest(SDRMCommitThreadRequest&&);
+        SDRMCommitThreadRequest& operator=(SDRMCommitThreadRequest&&);
+        ~SDRMCommitThreadRequest();
+
+        uint64_t                                                id       = 0;
+        uint64_t                                                ownerID  = 0;
+        uint64_t                                                queueKey = 0;
+        std::optional<std::chrono::steady_clock::time_point>    submitAt;
+        std::optional<std::chrono::steady_clock::time_point>    targetPresentation;
+        bool                                                    blocksQueue = true;
+        Hyprutils::Memory::CUniquePointer<IDRMCommitThreadData> data;
+    };
+
+    class IDRMCommitSubmitter {
+      public:
+        struct SResult {
+            bool submitted = false;
+            int  error     = 0;
+        };
+
+        virtual ~IDRMCommitSubmitter();
+
+        // Data must own everything used by submit() and must not reference mutable backend state.
+        // submit() must not wait on user-space synchronization and must eventually return.
+        virtual SResult submit(uint64_t commitID, const IDRMCommitThreadData& data) noexcept = 0;
+    };
+
+    class CDRMCommitThread {
+      public:
+        enum eResultStatus : uint32_t {
+            AQ_DRM_COMMIT_THREAD_SUBMITTED = 0,
+            AQ_DRM_COMMIT_THREAD_FAILED,
+            AQ_DRM_COMMIT_THREAD_CANCELLED,
+        };
+
+        struct SResult {
+            SResult();
+            SResult(SResult&&);
+            SResult& operator=(SResult&&);
+            ~SResult();
+
+            Hyprutils::Memory::CUniquePointer<SDRMCommitThreadRequest> request;
+            eResultStatus                                              status       = AQ_DRM_COMMIT_THREAD_FAILED;
+            int                                                        error        = 0;
+            bool                                                       missedTarget = false;
+            std::chrono::steady_clock::time_point                      completedAt;
+        };
+
+        static Hyprutils::Memory::CUniquePointer<CDRMCommitThread> create(Hyprutils::Memory::CUniquePointer<IDRMCommitSubmitter> submitter);
+
+        ~CDRMCommitThread();
+
+        std::optional<uint64_t> enqueue(Hyprutils::Memory::CUniquePointer<SDRMCommitThreadRequest> request);
+        size_t                  cancelOwner(uint64_t ownerID);
+        bool                    releaseQueue(uint64_t queueKey, uint64_t commitID);
+        std::vector<SResult>    stopAndDrain();
+
+        int                     completionFD() const;
+        std::vector<SResult>    drainResults();
+        bool                    accepting() const;
+        size_t                  queued() const;
+        bool                    submitting() const;
+
+      private:
+        struct SQueuedRequest {
+            uint64_t                                                   sequence = 0;
+            Hyprutils::Memory::CUniquePointer<SDRMCommitThreadRequest> request;
+        };
+
+        struct SBlocker {
+            uint64_t commitID = 0;
+            uint64_t ownerID  = 0;
+        };
+
+        struct SActiveRequest {
+            uint64_t commitID = 0;
+            uint64_t ownerID  = 0;
+            uint64_t queueKey = 0;
+        };
+
+        CDRMCommitThread(Hyprutils::Memory::CUniquePointer<IDRMCommitSubmitter> submitter);
+
+        void                                                                    run();
+        void                                                                    stop();
+        Hyprutils::Memory::CUniquePointer<SDRMCommitThreadRequest>              takeNextRequest(std::unique_lock<std::mutex>& lock);
+        void                                                                    appendResult(SResult&& result);
+        void                                                                    signalResults();
+        std::vector<Hyprutils::Memory::CUniquePointer<SDRMCommitThreadRequest>> takeOwnerRequests(uint64_t ownerID);
+
+        Hyprutils::Memory::CUniquePointer<IDRMCommitSubmitter>                  m_submitter;
+        Hyprutils::OS::CFileDescriptor                                          m_completionFD;
+        std::thread                                                             m_thread;
+        std::mutex                                                              m_stopMutex;
+
+        mutable std::mutex                                                      m_queueMutex;
+        std::condition_variable                                                 m_queueCondition;
+        std::vector<SQueuedRequest>                                             m_queue;
+        std::unordered_map<uint64_t, SBlocker>                                  m_blockedQueues;
+        std::unordered_set<uint64_t>                                            m_pausedQueues;
+        std::unordered_set<uint64_t>                                            m_cancelledOwners;
+        std::optional<SActiveRequest>                                           m_activeRequest;
+        uint64_t                                                                m_lastCommitID = 0;
+        uint64_t                                                                m_lastSequence = 0;
+        bool                                                                    m_stopping     = false;
+
+        std::mutex                                                              m_resultMutex;
+        std::vector<SResult>                                                    m_results;
+    };
+}

--- a/src/backend/drm/CommitThread.hpp
+++ b/src/backend/drm/CommitThread.hpp
@@ -73,8 +73,10 @@ namespace Aquamarine {
 
         ~CDRMCommitThread();
 
-        std::optional<uint64_t> enqueue(Hyprutils::Memory::CUniquePointer<SDRMCommitThreadRequest> request);
+        std::optional<uint64_t> enqueue(Hyprutils::Memory::CUniquePointer<SDRMCommitThreadRequest>&& request);
         size_t                  cancelOwner(uint64_t ownerID);
+        bool                    pauseQueue(uint64_t queueKey);
+        bool                    resumeQueue(uint64_t queueKey);
         bool                    releaseQueue(uint64_t queueKey, uint64_t commitID);
         std::vector<SResult>    stopAndDrain();
 
@@ -119,7 +121,8 @@ namespace Aquamarine {
         std::condition_variable                                                 m_queueCondition;
         std::vector<SQueuedRequest>                                             m_queue;
         std::unordered_map<uint64_t, SBlocker>                                  m_blockedQueues;
-        std::unordered_set<uint64_t>                                            m_pausedQueues;
+        std::unordered_map<uint64_t, size_t>                                    m_pausedQueues;
+        std::unordered_set<uint64_t>                                            m_cancellingQueues;
         std::unordered_set<uint64_t>                                            m_cancelledOwners;
         std::optional<SActiveRequest>                                           m_activeRequest;
         uint64_t                                                                m_lastCommitID = 0;

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <format>
 #include <hyprutils/math/Mat3x3.hpp>
+#include <hyprutils/memory/Atomic.hpp>
 #include <hyprutils/string/VarList.hpp>
 #include <chrono>
 #include <thread>
@@ -16,6 +17,7 @@
 #include <cstring>
 #include <filesystem>
 #include <system_error>
+#include <utility>
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -36,6 +38,7 @@ extern "C" {
 #include "hwdata.hpp"
 #include "Renderer.hpp"
 #include "OutputTiming.hpp"
+#include "AsyncCommit.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 using Hyprutils::Utils::CScopeGuard;
@@ -63,7 +66,12 @@ Aquamarine::CDRMBackend::CDRMBackend(SP<CBackend> backend_) : backend(backend_) 
         if (backend->session->active) {
             // session got activated, we need to restore
             restoreAfterVT();
-        }
+        } else
+            for (const auto& connector : connectors) {
+                if (connector->output)
+                    cancelAsyncOutput(connector->output.get(), true);
+                connector->invalidateFrame();
+            }
     });
 }
 
@@ -372,6 +380,8 @@ std::vector<SP<CDRMBackend>> Aquamarine::CDRMBackend::attempt(SP<CBackend> backe
 }
 
 Aquamarine::CDRMBackend::~CDRMBackend() {
+    stopCommitThread();
+
     for (auto& conn : connectors) {
         conn->disconnect();
         conn.reset();
@@ -382,6 +392,197 @@ Aquamarine::CDRMBackend::~CDRMBackend() {
 
     rendererState.renderer.reset();
     rendererState.allocator.reset();
+}
+
+bool Aquamarine::CDRMBackend::initCommitThread() {
+    if (commitThread)
+        return true;
+
+    commitThread = CDRMCommitThread::create(makeDRMCommitSubmitter(gpu->fd));
+    return !!commitThread;
+}
+
+void Aquamarine::CDRMBackend::stopCommitThread() {
+    if (!commitThread)
+        return;
+
+    flushAsyncCommitEvents();
+    auto RESULTS = commitThread->stopAndDrain();
+    for (auto& result : RESULTS) {
+        auto* DATA        = dynamic_cast<CDRMAsyncCommitData*>(result.request->data.get());
+        auto* ATOMIC_IMPL = dynamic_cast<CDRMAtomicImpl*>(impl.get());
+        if (!DATA || !DATA->request || !ATOMIC_IMPL)
+            continue;
+
+        const bool SUBMITTED = result.status == CDRMCommitThread::AQ_DRM_COMMIT_THREAD_SUBMITTED;
+        if (SUBMITTED)
+            DATA->mgpuAcquired = false;
+        ATOMIC_IMPL->finalizeAsync(*DATA->request, DATA->connector, DATA->commitData, SUBMITTED);
+
+        if (SUBMITTED && DATA->connector && DATA->output && DATA->connector->output == DATA->output) {
+            DATA->output->state->internalState.drmFormat = DATA->commitData.outputState.drmFormat;
+            DATA->connector->applyCommit(DATA->commitData);
+            for (const auto& fb : DATA->commitData.retiredFBs)
+                DATA->connector->releaseFBBuffer(fb);
+        }
+
+        if (!SUBMITTED)
+            DATA->rollbackMgpu();
+        DATA->releasePins();
+        if (!SUBMITTED && DATA->output && DATA->snapshot)
+            DATA->output->state->rearm(*DATA->snapshot);
+        if (DATA->output && DATA->output->pendingAsyncCommit == result.request->id) {
+            if (!SUBMITTED)
+                DATA->output->pendingAsyncCommit = 0;
+            DATA->output->events.commitResult.emit(IOutput::SCommitResult{
+                .id           = result.request->id,
+                .status       = SUBMITTED ? IOutput::AQ_OUTPUT_COMMIT_SUBMITTED :
+                                            (result.status == CDRMCommitThread::AQ_DRM_COMMIT_THREAD_CANCELLED ? IOutput::AQ_OUTPUT_COMMIT_CANCELLED : IOutput::AQ_OUTPUT_COMMIT_FAILED),
+                .error        = result.error,
+                .missedTarget = result.missedTarget,
+            });
+        }
+    }
+
+    commitThread.reset();
+}
+
+uint64_t Aquamarine::CDRMBackend::nextAsyncOwnerID() {
+    if (++m_lastAsyncOwnerID == 0)
+        ++m_lastAsyncOwnerID;
+    return m_lastAsyncOwnerID;
+}
+
+bool Aquamarine::CDRMBackend::pauseCommitQueue(uint64_t queueKey) {
+    if (!commitThread)
+        return true;
+
+    if (!commitThread->pauseQueue(queueKey))
+        return false;
+
+    dispatchCommitResults();
+    return true;
+}
+
+void Aquamarine::CDRMBackend::resumeCommitQueue(uint64_t queueKey) {
+    if (commitThread)
+        commitThread->resumeQueue(queueKey);
+}
+
+void Aquamarine::CDRMBackend::cancelAsyncOutput(CDRMOutput* output, bool renewOwner) {
+    if (!output || !output->asyncOwnerID)
+        return;
+
+    flushAsyncCommitEvents();
+    if (commitThread)
+        commitThread->cancelOwner(output->asyncOwnerID);
+    dispatchCommitResults();
+
+    if (renewOwner)
+        output->asyncOwnerID = nextAsyncOwnerID();
+}
+
+void Aquamarine::CDRMBackend::emitAsyncCommitEvent(SP<CDRMOutput> output) {
+    if (!output || !output->asyncCommitEventPending)
+        return;
+
+    output->asyncCommitEventPending = false;
+    if (m_pendingAsyncCommitEvents > 0)
+        --m_pendingAsyncCommitEvents;
+    output->events.commit.emit();
+
+    if (m_pendingAsyncCommitEvents == 0)
+        dispatchCommitResults();
+}
+
+void Aquamarine::CDRMBackend::flushAsyncCommitEvents() {
+    for (const auto& connector : connectors) {
+        if (connector->output && connector->output->asyncCommitEventPending)
+            emitAsyncCommitEvent(connector->output);
+    }
+}
+
+void Aquamarine::CDRMBackend::dispatchCommitResults() {
+    if (!commitThread || m_pendingAsyncCommitEvents > 0)
+        return;
+
+    auto* atomicImpl = dynamic_cast<CDRMAtomicImpl*>(impl.get());
+    auto  results    = commitThread->drainResults();
+    for (auto& result : results) {
+        auto* data = dynamic_cast<CDRMAsyncCommitData*>(result.request->data.get());
+        if (!data || !data->request || !atomicImpl)
+            continue;
+
+        const bool SUBMITTED = result.status == CDRMCommitThread::AQ_DRM_COMMIT_THREAD_SUBMITTED;
+        if (SUBMITTED)
+            data->mgpuAcquired = false;
+        atomicImpl->finalizeAsync(*data->request, data->connector, data->commitData, SUBMITTED);
+
+        const auto OUTPUT    = data->output;
+        const auto CONNECTOR = data->connector;
+        const auto CRTC      = CONNECTOR ? CONNECTOR->crtc : nullptr;
+
+        if (SUBMITTED && CONNECTOR && OUTPUT && CONNECTOR->output == OUTPUT) {
+            OUTPUT->state->internalState.drmFormat = data->commitData.outputState.drmFormat;
+            if (data->commitData.committed & COutputState::AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE)
+                OUTPUT->state->internalState.explicitOutFence = data->commitData.outputState.explicitOutFence;
+            CONNECTOR->applyCommit(data->commitData);
+            for (const auto& fb : data->commitData.retiredFBs)
+                CONNECTOR->releaseFBBuffer(fb);
+        }
+
+        if (!SUBMITTED)
+            data->rollbackMgpu();
+        data->releasePins();
+
+        const bool CURRENT = OUTPUT && result.request->ownerID == OUTPUT->asyncOwnerID && OUTPUT->pendingAsyncCommit == result.request->id;
+        if (!CURRENT) {
+            if (!SUBMITTED && CRTC) {
+                commitThread->releaseQueue(CRTC->id, result.request->id);
+                if (CRTC->pendingFlip.commitID == result.request->id)
+                    CRTC->disarmPageFlip();
+            }
+            continue;
+        }
+
+        IOutput::SCommitResult commitResult{
+            .id           = result.request->id,
+            .status       = SUBMITTED ? IOutput::AQ_OUTPUT_COMMIT_SUBMITTED :
+                                        (result.status == CDRMCommitThread::AQ_DRM_COMMIT_THREAD_CANCELLED ? IOutput::AQ_OUTPUT_COMMIT_CANCELLED : IOutput::AQ_OUTPUT_COMMIT_FAILED),
+            .error        = result.error,
+            .missedTarget = result.missedTarget,
+        };
+
+        if (!SUBMITTED) {
+            OUTPUT->pendingAsyncCommit = 0;
+            if (data->snapshot)
+                OUTPUT->state->rearm(*data->snapshot);
+            if (CRTC) {
+                commitThread->releaseQueue(CRTC->id, result.request->id);
+                if (CRTC->pendingFlip.commitID == result.request->id)
+                    CRTC->disarmPageFlip();
+            }
+            if (CONNECTOR)
+                CONNECTOR->sched.onFrameComplete();
+            OUTPUT->events.commitResult.emit(commitResult);
+            OUTPUT->scheduleFrame(IOutput::AQ_SCHEDULE_NEEDS_FRAME);
+            continue;
+        }
+
+        if (!CRTC || CRTC->pendingFlip.commitID != result.request->id) {
+            OUTPUT->pendingAsyncCommit = 0;
+            OUTPUT->events.commitResult.emit(commitResult);
+            continue;
+        }
+
+        CRTC->pendingFlip.resultReady = true;
+        const auto EARLY              = CRTC->pendingFlip.early;
+        const auto FLIP_ID            = *CRTC->pendingFlip.id;
+        OUTPUT->events.commitResult.emit(commitResult);
+
+        if (EARLY.valid)
+            handlePageFlip(FLIP_ID, EARLY.seq, EARLY.sec, EARLY.usec, CRTC->id);
+    }
 }
 
 void Aquamarine::CDRMBackend::log(eBackendLogLevel l, const std::string& s) {
@@ -556,6 +757,8 @@ bool Aquamarine::CDRMBackend::checkFeatures() {
         impl                         = makeShared<CDRMAtomicImpl>(self.lock());
         drmProps.supportsAsyncCommit = drmGetCap(gpu->fd, DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP, &cap) == 0 && cap == 1;
         atomic                       = true;
+        if (!initCommitThread())
+            backend->log(AQ_LOG_WARNING, "drm: Failed to create the asynchronous commit worker");
     }
 
     backend->log(AQ_LOG_DEBUG, std::format("drm: drmProps.supportsAsyncCommit: {}", drmProps.supportsAsyncCommit));
@@ -1162,7 +1365,10 @@ bool Aquamarine::CDRMBackend::start() {
 }
 
 std::vector<Hyprutils::Memory::CSharedPointer<SPollFD>> Aquamarine::CDRMBackend::pollFDs() {
-    return {makeShared<SPollFD>(gpu->fd, [this]() { dispatchEvents(); })};
+    std::vector<SP<SPollFD>> fds = {makeShared<SPollFD>(gpu->fd, [this]() { dispatchEvents(); })};
+    if (commitThread)
+        fds.emplace_back(makeShared<SPollFD>(commitThread->completionFD(), [this]() { dispatchCommitResults(); }));
+    return fds;
 }
 
 int Aquamarine::CDRMBackend::drmFD() {
@@ -1186,7 +1392,7 @@ SP<SDRMCRTC> Aquamarine::CDRMBackend::crtcByID(uint32_t id) {
     return it == crtcs.end() ? nullptr : *it;
 }
 
-uintptr_t Aquamarine::SDRMCRTC::armPageFlip(CWeakPointer<SDRMConnector> connector, bool async) {
+uintptr_t Aquamarine::SDRMCRTC::armPageFlip(CWeakPointer<SDRMConnector> connector, bool async, std::optional<uintptr_t> requestedID, uint64_t commitID, bool resultReady) {
     if (pendingFlip.id && !(pendingFlip.connector == connector)) {
         if (const auto PREV = pendingFlip.connector.lock()) {
             backend->log(AQ_LOG_ERROR, std::format("drm: crtc {} page-flip slot taken from {}, dropping its frame", id, PREV->szName));
@@ -1194,9 +1400,12 @@ uintptr_t Aquamarine::SDRMCRTC::armPageFlip(CWeakPointer<SDRMConnector> connecto
         }
     }
 
-    pendingFlip.id        = backend->nextPageFlipID();
-    pendingFlip.connector = connector;
-    pendingFlip.async     = async;
+    pendingFlip.id          = requestedID.value_or(backend->nextPageFlipID());
+    pendingFlip.connector   = connector;
+    pendingFlip.async       = async;
+    pendingFlip.commitID    = commitID;
+    pendingFlip.resultReady = resultReady;
+    pendingFlip.early.valid = false;
 
     return pendingFlip.id.value();
 }
@@ -1204,7 +1413,10 @@ uintptr_t Aquamarine::SDRMCRTC::armPageFlip(CWeakPointer<SDRMConnector> connecto
 void Aquamarine::SDRMCRTC::disarmPageFlip() {
     pendingFlip.id.reset();
     pendingFlip.connector.reset();
-    pendingFlip.async = false;
+    pendingFlip.async       = false;
+    pendingFlip.commitID    = 0;
+    pendingFlip.resultReady = true;
+    pendingFlip.early.valid = false;
 }
 
 static CWeakPointer<CDRMBackend> gDispatchingBackend;
@@ -1214,66 +1426,81 @@ static void                      handlePF(int fd, unsigned seq, unsigned tv_sec,
     if (!BACKEND || BACKEND->drmFD() != fd)
         return;
 
-    const auto FLIPID = rc<uintptr_t>(data);
-    const auto CRTC   = BACKEND->crtcByID(crtc_id);
+    BACKEND->handlePageFlip(rc<uintptr_t>(data), seq, tv_sec, tv_usec, crtc_id);
+}
 
-    if (!CRTC || !FLIPID || CRTC->pendingFlip.id != FLIPID) {
-        BACKEND->log(AQ_LOG_DEBUG, std::format("drm: Ignoring a stale pf event, flip {} on crtc {}", FLIPID, crtc_id));
+void Aquamarine::CDRMBackend::handlePageFlip(uintptr_t flipID, unsigned int seq, unsigned int sec, unsigned int usec, uint32_t crtcID) {
+    const auto CRTC = crtcByID(crtcID);
+    if (!CRTC || !flipID || CRTC->pendingFlip.id != flipID) {
+        log(AQ_LOG_DEBUG, std::format("drm: Ignoring a stale pf event, flip {} on crtc {}", flipID, crtcID));
+        return;
+    }
+
+    if (!CRTC->pendingFlip.resultReady) {
+        CRTC->pendingFlip.early = {
+            .valid = true,
+            .seq   = seq,
+            .sec   = sec,
+            .usec  = usec,
+        };
         return;
     }
 
     const auto CONNECTOR = CRTC->pendingFlip.connector.lock();
     const auto ASYNC     = CRTC->pendingFlip.async;
+    const auto COMMIT_ID = CRTC->pendingFlip.commitID;
     CRTC->disarmPageFlip();
 
+    if (commitThread && COMMIT_ID)
+        commitThread->releaseQueue(crtcID, COMMIT_ID);
+
     if (!CONNECTOR) {
-        BACKEND->log(AQ_LOG_DEBUG, "drm: Ignoring a pf event whose connector is gone");
+        log(AQ_LOG_DEBUG, "drm: Ignoring a pf event whose connector is gone");
         return;
     }
 
-    TRACE(BACKEND->log(AQ_LOG_TRACE, std::format("drm: pf event seq {} sec {} usec {} crtc {}", seq, tv_sec, tv_usec, crtc_id)));
+    if (CONNECTOR->output && CONNECTOR->output->pendingAsyncCommit == COMMIT_ID)
+        CONNECTOR->output->pendingAsyncCommit = 0;
+
+    TRACE(log(AQ_LOG_TRACE, std::format("drm: pf event seq {} sec {} usec {} crtc {}", seq, sec, usec, crtcID)));
 
     if (!CONNECTOR->sched.frameInFlight()) {
-        BACKEND->log(AQ_LOG_DEBUG, std::format("drm: Ignoring pf event on {}, no frame in flight?", CONNECTOR->szName));
+        log(AQ_LOG_DEBUG, std::format("drm: Ignoring pf event on {}, no frame in flight?", CONNECTOR->szName));
         return;
     }
 
     CONNECTOR->sched.onFrameComplete();
 
     if (CONNECTOR->status != DRM_MODE_CONNECTED || !CONNECTOR->crtc || !CONNECTOR->output) {
-        BACKEND->log(AQ_LOG_DEBUG, "drm: Ignoring a pf event from a disabled crtc / connector");
+        log(AQ_LOG_DEBUG, "drm: Ignoring a pf event from a disabled crtc / connector");
         return;
     }
 
-    // hold isFrameRunning around the emit (RAII pair, so reentrant enable/disable
-    // can't strand it).
     CFrameRunningGuard frameRunning(CONNECTOR->sched);
 
-    // a tearing commit already emitted present and rotated the FBs synchronously
-    if (!ASYNC) {
+    if (!ASYNC || COMMIT_ID) {
         CONNECTOR->onPresent();
 
-        uint32_t flags = IOutput::AQ_OUTPUT_PRESENT_VSYNC | IOutput::AQ_OUTPUT_PRESENT_HW_CLOCK | IOutput::AQ_OUTPUT_PRESENT_HW_COMPLETION | IOutput::AQ_OUTPUT_PRESENT_ZEROCOPY;
+        uint32_t flags = IOutput::AQ_OUTPUT_PRESENT_HW_CLOCK | IOutput::AQ_OUTPUT_PRESENT_HW_COMPLETION | IOutput::AQ_OUTPUT_PRESENT_ZEROCOPY;
+        if (!ASYNC)
+            flags |= IOutput::AQ_OUTPUT_PRESENT_VSYNC;
 
-        timespec presented = {.tv_sec = (time_t)tv_sec, .tv_nsec = (long)(tv_usec * 1000)};
+        timespec presented = {.tv_sec = sc<time_t>(sec), .tv_nsec = sc<long>(usec * 1000)};
 
-        // nvidia-drm registers no vblank counter, unless module options 'nvidia_drm vblank=1' is set.
-        // kernel checks for vblank support and fallbacks to setting seq 0 and the timestamp is a plain ktime_get()
-        // this is not a HW clock, its just a plain software clock fetched from whenever the event was called.
-        if (BACKEND->gpuDriver() == AQ_BACKEND_GPU_DRIVER_NVIDIA && seq == 0)
+        if (gpuDriver() == AQ_BACKEND_GPU_DRIVER_NVIDIA && seq == 0)
             flags &= ~IOutput::AQ_OUTPUT_PRESENT_HW_CLOCK;
 
         CONNECTOR->output->events.present.emit(IOutput::SPresentEvent{
-            .presented = BACKEND->sessionActive(),
+            .presented = sessionActive(),
             .when      = &presented,
             .seq       = seq,
-            .refresh   = (int)(CONNECTOR->refresh ? (1000000000000LL / CONNECTOR->refresh) : 0),
+            .refresh   = sc<int>(CONNECTOR->refresh ? (1000000000000LL / CONNECTOR->refresh) : 0),
             .flags     = flags,
+            .commitID  = COMMIT_ID,
         });
     }
 
-    // Skip if an idle frame is already queued: it emits events.frame itself, and #325 forbids double-firing.
-    if (BACKEND->sessionActive() && CONNECTOR->output->enabledState && !CONNECTOR->sched.frameScheduled())
+    if (sessionActive() && CONNECTOR->output->enabledState && !CONNECTOR->sched.frameScheduled())
         CONNECTOR->sched.frameReady.emit();
 }
 
@@ -1903,6 +2130,7 @@ void Aquamarine::SDRMConnector::disconnect() {
         return;
     }
 
+    backend->cancelAsyncOutput(output.get());
     invalidateFrame();
 
     status = DRM_MODE_DISCONNECTED;
@@ -2021,14 +2249,32 @@ void Aquamarine::SDRMConnector::applyCommit(SDRMConnectorCommitData& data) {
 void Aquamarine::SDRMConnector::invalidateFrame() {
     sched.invalidate();
 
-    if (crtc && crtc->pendingFlip.connector == self)
+    if (crtc && crtc->pendingFlip.connector == self) {
+        const auto COMMIT_ID = crtc->pendingFlip.commitID;
+        if (backend->commitThread && COMMIT_ID)
+            backend->commitThread->releaseQueue(crtc->id, COMMIT_ID);
         crtc->disarmPageFlip();
+
+        if (output && COMMIT_ID && output->pendingAsyncCommit == COMMIT_ID) {
+            output->pendingAsyncCommit = 0;
+
+            timespec when = {};
+            clock_gettime(CLOCK_MONOTONIC, &when);
+            output->events.present.emit(IOutput::SPresentEvent{
+                .presented = false,
+                .when      = &when,
+                .commitID  = COMMIT_ID,
+            });
+        }
+    }
 }
 
 void Aquamarine::SDRMConnector::setCRTC(SP<SDRMCRTC> newCRTC) {
     if (crtc == newCRTC)
         return;
 
+    if (output)
+        backend->cancelAsyncOutput(output.get(), true);
     invalidateFrame();
 
     crtc = newCRTC;
@@ -2063,6 +2309,8 @@ void Aquamarine::SDRMConnector::onPresent(bool primary, bool cursor, DRMFBList* 
 }
 
 Aquamarine::CDRMOutput::~CDRMOutput() {
+    if (backend)
+        backend->cancelAsyncOutput(this);
     if (backend && backend->backend)
         backend->backend->removeIdleEvent(frameIdle);
     connector->sched.onFrameComplete();
@@ -2081,16 +2329,158 @@ void Aquamarine::CDRMOutput::releaseMgpuResources() {
 }
 
 bool Aquamarine::CDRMOutput::commit() {
+    if (!connector->crtc)
+        return commitState();
+
+    const auto QUEUE_KEY = connector->crtc->id;
+    if (pendingAsyncCommit)
+        backend->cancelAsyncOutput(this, true);
+    if (pendingAsyncCommit)
+        return false;
+    if (!backend->pauseCommitQueue(QUEUE_KEY))
+        return false;
+    CScopeGuard resume([this, QUEUE_KEY] { backend->resumeCommitQueue(QUEUE_KEY); });
     return commitState();
 }
 
 bool Aquamarine::CDRMOutput::test() {
+    if (!connector->crtc)
+        return commitState(true);
+
+    const auto QUEUE_KEY = connector->crtc->id;
+    if (pendingAsyncCommit)
+        backend->cancelAsyncOutput(this, true);
+    if (pendingAsyncCommit)
+        return false;
+    if (!backend->pauseCommitQueue(QUEUE_KEY))
+        return false;
+    CScopeGuard resume([this, QUEUE_KEY] { backend->resumeCommitQueue(QUEUE_KEY); });
     return commitState(true);
 }
 
 void Aquamarine::CDRMOutput::setCursorVisible(bool visible) {
     cursorVisible = visible;
     scheduleFrame(AQ_SCHEDULE_CURSOR_VISIBLE);
+}
+
+bool Aquamarine::CDRMOutput::prepareAsyncCommitData(const COutputState::CSnapshot& snapshot, SDRMConnectorCommitData& data, Hyprutils::OS::CFileDescriptor& mgpuFence,
+                                                    bool& mgpuAcquired, bool& requiresSync) {
+    const auto& STATE = snapshot.state();
+
+    data.outputState   = STATE;
+    data.cursorPos     = cursorPos;
+    data.cursorHotspot = cursorHotspot;
+    data.cursorVisible = cursorVisible;
+
+    SP<CDRMFB> drmFB;
+    if (backend->shouldBlit()) {
+        if (!backend->rendererState.renderer) {
+            backend->log(AQ_LOG_DEBUG, "drm: No renderer attached to backend when required for asynchronous blitting, initializing");
+            if (!backend->initMgpu() || !backend->rendererState.renderer || !backend->rendererState.allocator) {
+                backend->log(AQ_LOG_ERROR, "drm: Failed to initialize renderer backend for asynchronous blitting");
+                return false;
+            }
+        }
+
+        if (!mgpu.swapchain)
+            mgpu.swapchain = CSwapchain::create(backend->rendererState.allocator, backend.lock());
+
+        auto       options = swapchain ? swapchain->currentOptions() : mgpu.swapchain->currentOptions();
+        const auto ATTRS   = snapshot.state().buffer->dmabuf();
+        options.size       = STATE.buffer->size;
+        if (options.format == DRM_FORMAT_INVALID)
+            options.format = ATTRS.format;
+        options.multigpu = false;
+        options.cursor   = false;
+        options.scanout  = true;
+        if (options.length == 0)
+            options.length = 2;
+
+        const auto& CURRENT = mgpu.swapchain->currentOptions();
+        if (CURRENT.length > 0 &&
+            (CURRENT.length != options.length || CURRENT.size != options.size || CURRENT.format != options.format || CURRENT.multigpu != options.multigpu ||
+             CURRENT.cursor != options.cursor || CURRENT.scanout != options.scanout)) {
+            requiresSync = true;
+            return false;
+        }
+
+        if (!mgpu.swapchain->reconfigure(options)) {
+            backend->log(AQ_LOG_ERROR, "drm: Asynchronous commit requires blit, but the mGPU swapchain failed reconfiguring");
+            return false;
+        }
+
+        const auto NEW_BUFFER = mgpu.swapchain->next(nullptr);
+        if (!NEW_BUFFER) {
+            backend->log(AQ_LOG_ERROR, "drm: Asynchronous commit requires blit, but the mGPU swapchain has no buffer");
+            return false;
+        }
+        mgpuAcquired = true;
+
+        SP<CDRMRenderer> primaryRenderer;
+        if (backend->primary)
+            primaryRenderer = backend->primary->rendererState.renderer;
+        const auto BLIT = backend->rendererState.renderer->blit(STATE.buffer, NEW_BUFFER, primaryRenderer,
+                                                                (STATE.committed & COutputState::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE) ? STATE.explicitInFence : -1);
+        if (!BLIT.success) {
+            backend->log(AQ_LOG_ERROR, "drm: Asynchronous commit requires blit, but blitting failed");
+            return false;
+        }
+
+        static const bool NO_EXPLICIT = envEnabled("AQ_MGPU_NO_EXPLICIT");
+        if (!BLIT.syncFD || NO_EXPLICIT || !supportsExplicit) {
+            requiresSync = true;
+            return false;
+        }
+
+        const int DUPLICATED_FENCE = fcntl(*BLIT.syncFD, F_DUPFD_CLOEXEC, 0);
+        if (DUPLICATED_FENCE < 0) {
+            backend->log(AQ_LOG_ERROR, std::format("drm: Failed to duplicate asynchronous mGPU fence: {}", strerror(errno)));
+            return false;
+        }
+
+        mgpuFence                        = Hyprutils::OS::CFileDescriptor{DUPLICATED_FENCE};
+        data.outputState.explicitInFence = mgpuFence.get();
+
+        drmFB = CDRMFB::create(NEW_BUFFER, backend, nullptr);
+    } else
+        drmFB = CDRMFB::create(STATE.buffer, backend, nullptr);
+
+    if (!drmFB || drmFB->dead) {
+        backend->log(AQ_LOG_ERROR, "drm: Asynchronous commit buffer failed to import to KMS");
+        return false;
+    }
+
+    data.mainFB = drmFB;
+    if (connector->crtc->pendingCursor)
+        data.cursorFB = connector->crtc->pendingCursor;
+    else if (connector->crtc->cursor)
+        data.cursorFB = connector->crtc->cursor->front;
+
+    if (data.cursorFB && (data.cursorFB->dead || data.cursorFB->buffer->dmabuf().modifier == DRM_FORMAT_MOD_INVALID))
+        data.cursorFB.reset();
+
+    const auto MODE = STATE.mode ? STATE.mode : STATE.customMode;
+    if (!MODE)
+        return false;
+
+    data.blocking  = false;
+    data.modeset   = false;
+    data.test      = false;
+    data.enabled   = true;
+    data.committed = STATE.committed;
+    if (mgpuFence.isValid())
+        data.committed |= COutputState::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE;
+    data.flags = DRM_MODE_PAGE_FLIP_EVENT;
+    if (STATE.presentationMode == AQ_OUTPUT_PRESENTATION_IMMEDIATE)
+        data.flags |= DRM_MODE_PAGE_FLIP_ASYNC;
+    if (STATE.committed & COutputState::AQ_OUTPUT_STATE_DAMAGE)
+        data.damage = STATE.damage.copy();
+    if (MODE->modeInfo)
+        data.modeInfo = *MODE->modeInfo;
+    else
+        data.calculateMode(connector);
+
+    return true;
 }
 
 bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
@@ -2517,6 +2907,8 @@ bool Aquamarine::CDRMOutput::setCursor(SP<IBuffer> buffer, const Vector2D& hotsp
         }
 
         cursorHotspot = hotspot;
+        if (cursorMailbox)
+            cursorMailbox->store(cursorPos);
 
         backend->backend->log(AQ_LOG_DEBUG, std::format("drm: Cursor buffer imported into KMS with id {}", fb->id));
 
@@ -2531,6 +2923,8 @@ bool Aquamarine::CDRMOutput::setCursor(SP<IBuffer> buffer, const Vector2D& hotsp
 
 void Aquamarine::CDRMOutput::moveCursor(const Vector2D& coord, bool skipSchedule) {
     cursorPos = coord;
+    if (cursorMailbox)
+        cursorMailbox->store(coord);
     // cursorVisible = true;
     // if (!skipSchedule)
     state->markCommitted(COutputState::AQ_OUTPUT_STATE_CURSOR_POS);
@@ -2633,6 +3027,142 @@ std::optional<std::chrono::steady_clock::time_point> Aquamarine::CDRMOutput::nex
     return std::nullopt;
 }
 
+uint32_t Aquamarine::CDRMOutput::commitCapabilities() const {
+    if (!backend || !backend->commitThread || !backend->atomic)
+        return 0;
+
+    uint32_t capabilities = AQ_OUTPUT_COMMIT_CAPABILITY_QUEUED | AQ_OUTPUT_COMMIT_CAPABILITY_TIMED;
+    if (connector->canDoVrr)
+        capabilities |= AQ_OUTPUT_COMMIT_CAPABILITY_VRR;
+    if (backend->drmProps.supportsAsyncCommit)
+        capabilities |= AQ_OUTPUT_COMMIT_CAPABILITY_TEARING;
+    if (connector->crtc && connector->crtc->cursor)
+        capabilities |= AQ_OUTPUT_COMMIT_CAPABILITY_LATE_CURSOR;
+    return capabilities;
+}
+
+Aquamarine::IOutput::SCommitSubmission Aquamarine::CDRMOutput::commitAsync(const SCommitOptions& options) {
+    const auto CAPABILITIES = commitCapabilities();
+    if (!(CAPABILITIES & AQ_OUTPUT_COMMIT_CAPABILITY_QUEUED))
+        return {.error = ENOTSUP};
+    if (options.targetPresentation && !(CAPABILITIES & AQ_OUTPUT_COMMIT_CAPABILITY_TIMED))
+        return {.error = ENOTSUP};
+    if (options.lateCursor && !(CAPABILITIES & AQ_OUTPUT_COMMIT_CAPABILITY_LATE_CURSOR))
+        return {.error = ENOTSUP};
+
+    if (!backend->sessionActive() || connector->status != DRM_MODE_CONNECTED || connector->output != self.lock() || !connector->crtc)
+        return {.error = ENODEV};
+
+    auto SNAPSHOT = state->snapshot();
+    if (SNAPSHOT.error())
+        return {.error = SNAPSHOT.error()};
+
+    const auto&        STATE     = SNAPSHOT.state();
+    const auto         COMMITTED = STATE.committed;
+    constexpr uint32_t ASYNC_PROPERTIES =
+        COutputState::AQ_OUTPUT_STATE_BUFFER | COutputState::AQ_OUTPUT_STATE_DAMAGE | COutputState::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE | COutputState::AQ_OUTPUT_STATE_CURSOR_POS;
+
+    if (!(COMMITTED & COutputState::AQ_OUTPUT_STATE_BUFFER) || (COMMITTED & ~ASYNC_PROPERTIES) || SNAPSHOT.needsReconfig() || lastCommitNoBuffer)
+        return {.error = ENOTSUP};
+    if (!STATE.buffer || !STATE.enabled || STATE.drmFormat == DRM_FORMAT_INVALID)
+        return {.error = EINVAL};
+    if (STATE.buffer->attachments.has<CDRMBufferUnimportable>())
+        return {.error = EINVAL};
+    if (STATE.adaptiveSync && !(CAPABILITIES & AQ_OUTPUT_COMMIT_CAPABILITY_VRR))
+        return {.error = ENOTSUP};
+    if (STATE.presentationMode == AQ_OUTPUT_PRESENTATION_IMMEDIATE && !(CAPABILITIES & AQ_OUTPUT_COMMIT_CAPABILITY_TEARING))
+        return {.error = ENOTSUP};
+    if (pendingAsyncCommit || connector->sched.frameInFlight())
+        return {.error = EBUSY};
+
+    SDRMConnectorCommitData        data;
+    Hyprutils::OS::CFileDescriptor mgpuFence;
+    bool                           mgpuAcquired = false, requiresSync = false;
+    CScopeGuard                    rollbackMgpu([this, &mgpuAcquired] {
+        if (mgpuAcquired && mgpu.swapchain)
+            mgpu.swapchain->rollback();
+    });
+    if (!prepareAsyncCommitData(SNAPSHOT, data, mgpuFence, mgpuAcquired, requiresSync))
+        return {.error = requiresSync ? ENOTSUP : EINVAL};
+
+    const auto MAIN_BUFFER = data.mainFB ? data.mainFB->buffer.lock() : nullptr;
+    const auto ATTRS       = MAIN_BUFFER ? MAIN_BUFFER->dmabuf() : SDMABUFAttrs{};
+    if (ATTRS.success && ATTRS.format != STATE.drmFormat)
+        return {.error = ENOTSUP};
+
+    if (options.lateCursor && cursorVisible && connector->crtc->cursor)
+        data.committed |= COutputState::AQ_OUTPUT_STATE_CURSOR_POS;
+
+    auto* atomicImpl = dynamic_cast<CDRMAtomicImpl*>(backend->impl.get());
+    if (!atomicImpl)
+        return {.error = ENOTSUP};
+
+    uint32_t atomicFlags   = 0;
+    auto     atomicRequest = atomicImpl->prepareAsync(connector, data, atomicFlags);
+    if (!atomicRequest)
+        return {.error = EINVAL};
+
+    auto asyncData           = makeUnique<CDRMAsyncCommitData>(std::move(SNAPSHOT));
+    asyncData->output        = self.lock();
+    asyncData->connector     = connector;
+    asyncData->commitData    = std::move(data);
+    asyncData->request       = std::move(atomicRequest);
+    asyncData->mainBuffer    = asyncData->commitData.mainFB ? asyncData->commitData.mainFB->buffer.lock() : nullptr;
+    asyncData->cursorBuffer  = asyncData->commitData.cursorFB ? asyncData->commitData.cursorFB->buffer.lock() : nullptr;
+    asyncData->flags         = atomicFlags;
+    asyncData->flipID        = backend->nextPageFlipID();
+    asyncData->tearing       = asyncData->commitData.flags & DRM_MODE_PAGE_FLIP_ASYNC;
+    asyncData->lateCursor    = options.lateCursor;
+    asyncData->mgpuFence     = std::move(mgpuFence);
+    asyncData->mgpuSwapchain = mgpuAcquired ? mgpu.swapchain : nullptr;
+    asyncData->mgpuAcquired  = std::exchange(mgpuAcquired, false);
+    asyncData->pinBuffers();
+
+    if (options.lateCursor && cursorVisible && connector->crtc->cursor) {
+        asyncData->cursorMailbox = cursorMailbox;
+        asyncData->cursorPlaneID = connector->crtc->cursor->id;
+        asyncData->cursorXProp   = connector->crtc->cursor->props.values.crtc_x;
+        asyncData->cursorYProp   = connector->crtc->cursor->props.values.crtc_y;
+        asyncData->cursorHotspot = cursorHotspot;
+    }
+
+    auto* asyncDataPtr          = asyncData.get();
+    auto  request               = makeUnique<SDRMCommitThreadRequest>();
+    request->ownerID            = asyncOwnerID;
+    request->queueKey           = connector->crtc->id;
+    request->targetPresentation = options.targetPresentation;
+    if (options.targetPresentation)
+        request->submitAt = *options.targetPresentation - backend->commitLeadTime;
+    request->data = std::move(asyncData);
+
+    const auto COMMIT_ID = backend->commitThread->enqueue(std::move(request));
+    if (!COMMIT_ID) {
+        auto* failedData = dynamic_cast<CDRMAsyncCommitData*>(request->data.get());
+        if (failedData) {
+            atomicImpl->finalizeAsync(*failedData->request, connector, failedData->commitData, false);
+            failedData->rollbackMgpu();
+            failedData->releasePins();
+        }
+        return {.error = ECANCELED};
+    }
+    const bool TEARING = asyncDataPtr->commitData.flags & DRM_MODE_PAGE_FLIP_ASYNC;
+    connector->crtc->armPageFlip(connector, TEARING, asyncDataPtr->flipID, *COMMIT_ID, false);
+    pendingAsyncCommit = *COMMIT_ID;
+    connector->sched.onFrameSubmitted();
+    state->consume(*asyncDataPtr->snapshot);
+    lastCommitNoBuffer = false;
+    needsFrame         = false;
+
+    asyncCommitEventPending = true;
+    ++backend->m_pendingAsyncCommitEvents;
+    backend->backend->addIdleEvent(makeShared<std::function<void(void)>>([output = self, drmBackend = backend] {
+        if (const auto OUTPUT = output.lock(); OUTPUT && drmBackend)
+            drmBackend->emitAsyncCommitEvent(OUTPUT);
+    }));
+
+    return {.id = *COMMIT_ID};
+}
+
 size_t Aquamarine::CDRMOutput::getGammaSize() {
     if (!backend->atomic) {
         backend->log(AQ_LOG_ERROR, "No support for gamma on the legacy iface");
@@ -2695,7 +3225,10 @@ int Aquamarine::CDRMOutput::getConnectorID() {
 
 Aquamarine::CDRMOutput::CDRMOutput(const std::string& name_, Hyprutils::Memory::CWeakPointer<CDRMBackend> backend_, SP<SDRMConnector> connector_) :
     backend(backend_), connector(connector_) {
-    name = name_;
+    name          = name_;
+    asyncOwnerID  = backend->nextAsyncOwnerID();
+    cursorMailbox = makeAtomicShared<CDRMCursorPositionMailbox>();
+    cursorMailbox->store(cursorPos);
 
     // The scheduler's frameReady signal drives the public events.frame on this output.
     frameReadyListener = connector->sched.frameReady.listen([this]() { events.frame.emit(); });

--- a/src/backend/drm/DRM.cpp
+++ b/src/backend/drm/DRM.cpp
@@ -427,14 +427,18 @@ void Aquamarine::CDRMBackend::restoreAfterVT() {
         auto&                   STATE = c->output->state->state();
 
         SDRMConnectorCommitData data = {
-            .mainFB      = nullptr,
-            .modeset     = true,
-            .blocking    = true,
-            .flags       = 0,
-            .test        = false,
-            .enabled     = STATE.enabled,
-            .committed   = STATE.committed,
-            .hdrMetadata = STATE.hdrMetadata,
+            .mainFB        = nullptr,
+            .outputState   = STATE,
+            .cursorPos     = c->output->cursorPos,
+            .cursorHotspot = c->output->cursorHotspot,
+            .cursorVisible = c->output->cursorVisible,
+            .modeset       = true,
+            .blocking      = true,
+            .flags         = 0,
+            .test          = false,
+            .enabled       = STATE.enabled,
+            .committed     = STATE.committed,
+            .hdrMetadata   = STATE.hdrMetadata,
         };
 
         auto& MODE = STATE.customMode ? STATE.customMode : STATE.mode;
@@ -682,7 +686,7 @@ bool Aquamarine::CDRMBackend::initMgpu() {
     return true;
 }
 
-bool Aquamarine::CDRMBackend::updateSecondaryRendererState() {
+bool Aquamarine::CDRMBackend::updateSecondaryRendererState(DRMFBList* deferred) {
     if (!backend->ready)
         return true;
 
@@ -693,8 +697,7 @@ bool Aquamarine::CDRMBackend::updateSecondaryRendererState() {
         return initMgpu();
     }
 
-    const bool hasEnabledOutputs =
-        std::ranges::any_of(connectors, [](const auto& c) { return c->status == DRM_MODE_CONNECTED && c->output && c->output->state && c->output->state->state().enabled; });
+    const bool hasEnabledOutputs = std::ranges::any_of(connectors, [](const auto& c) { return c->status == DRM_MODE_CONNECTED && c->output && c->output->enabledState; });
 
     if (hasEnabledOutputs) {
         if (rendererState.renderer && rendererState.allocator)
@@ -709,8 +712,9 @@ bool Aquamarine::CDRMBackend::updateSecondaryRendererState() {
 
     backend->log(AQ_LOG_DEBUG, std::format("drm: Deinitializing secondary renderer on {}, no enabled outputs", gpu->path));
 
+    DRMFBList retired;
     for (auto const& c : connectors) {
-        c->releaseFBReferences();
+        c->releaseFBReferences(&retired);
 
         if (c->output)
             c->output->releaseMgpuResources();
@@ -721,6 +725,16 @@ bool Aquamarine::CDRMBackend::updateSecondaryRendererState() {
 
     rendererState.renderer.reset();
     rendererState.allocator.reset();
+
+    if (deferred) {
+        for (auto& fb : retired)
+            deferred->emplace_back(std::move(fb));
+    } else {
+        for (const auto& fb : retired) {
+            if (auto buffer = fb->buffer.lock())
+                buffer->backendUnpin();
+        }
+    }
 
     return true;
 }
@@ -807,9 +821,12 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
                 continue;
 
             // deactivate old output
-            if (c->output && c->output->state && c->output->state->state().enabled) {
+            if (c->output && c->output->enabledState) {
                 c->output->state->setEnabled(false);
-                c->output->commit();
+                if (!c->output->commit()) {
+                    backend->log(AQ_LOG_ERROR, std::format("drm: Failed to disable {} before reassigning its CRTC", c->szName));
+                    continue;
+                }
             }
 
             backend->log(AQ_LOG_DEBUG,
@@ -841,6 +858,8 @@ void Aquamarine::CDRMBackend::recheckCRTCs() {
             if (!(c->possibleCrtcs & (1 << i)))
                 continue;
             if (c->status != DRM_MODE_CONNECTED)
+                continue;
+            if (c->output && c->output->enabledState)
                 continue;
 
             backend->log(AQ_LOG_DEBUG, std::format("drm: backup slot {} crtc {} assigned to disabled {}", i, crtcs.at(i)->id, c->szName));
@@ -1576,33 +1595,42 @@ void Aquamarine::SDRMConnector::releaseFBBuffer(const SP<CDRMFB> fb) {
     if (!fb)
         return;
 
-    if (auto buf = fb->buffer.lock(); buf && buf->lockedByBackend) {
-        buf->lockedByBackend = false;
-        buf->events.backendRelease.emit();
-    }
+    if (auto buf = fb->buffer.lock())
+        buf->backendUnpin();
 }
 
-void Aquamarine::SDRMConnector::releaseFBReferences() {
-    const auto releaseFB = [this](SP<CDRMFB>& fb) {
-        releaseFBBuffer(fb);
-        fb.reset();
+void Aquamarine::SDRMConnector::releaseFBReferences(DRMFBList* deferred) {
+    DRMFBList  retired;
+    const auto clearPlane = [&retired](SP<SDRMPlane> plane) {
+        if (!plane)
+            return;
+
+        const bool SAME_BUFFER = plane->front == plane->back;
+        if (plane->front)
+            retired.emplace_back(std::move(plane->front));
+        if (plane->back && !SAME_BUFFER)
+            retired.emplace_back(std::move(plane->back));
+
+        plane->front.reset();
+        plane->back.reset();
+        plane->last.reset();
+        plane->backSet = false;
     };
 
     if (crtc) {
-        if (crtc->primary) {
-            releaseFB(crtc->primary->front);
-            releaseFB(crtc->primary->back);
-            releaseFB(crtc->primary->last);
-        }
-
-        if (crtc->cursor) {
-            releaseFB(crtc->cursor->front);
-            releaseFB(crtc->cursor->back);
-            releaseFB(crtc->cursor->last);
-        }
-
-        releaseFB(crtc->pendingCursor);
+        clearPlane(crtc->primary);
+        clearPlane(crtc->cursor);
+        crtc->pendingCursor.reset();
     }
+
+    if (deferred) {
+        for (auto& fb : retired)
+            deferred->emplace_back(std::move(fb));
+        return;
+    }
+
+    for (const auto& fb : retired)
+        releaseFBBuffer(fb);
 }
 
 Aquamarine::SDRMConnector::~SDRMConnector() {
@@ -1885,33 +1913,75 @@ void Aquamarine::SDRMConnector::disconnect() {
 }
 
 bool Aquamarine::SDRMConnector::commitState(SDRMConnectorCommitData& data) {
+    if (status != DRM_MODE_CONNECTED || !output)
+        return false;
+
     const bool ok = backend->impl->commit(self.lock(), data);
 
-    if (ok && !data.test)
+    if (ok && !data.test) {
+        output->state->internalState.drmFormat = data.outputState.drmFormat;
+        if (data.committed & COutputState::AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE)
+            output->state->internalState.explicitOutFence = data.outputState.explicitOutFence;
+
         applyCommit(data);
+        if (!(data.flags & DRM_MODE_PAGE_FLIP_EVENT))
+            onPresent(data.primaryFBChanged, data.cursorFBChanged, &data.retiredFBs);
+
+        for (const auto& fb : data.retiredFBs)
+            releaseFBBuffer(fb);
+    }
 
     return ok;
 }
 
-void Aquamarine::SDRMConnector::applyCommit(const SDRMConnectorCommitData& data) {
-    const bool enable = data.enabled && data.mainFB;
+void Aquamarine::SDRMConnector::applyCommit(SDRMConnectorCommitData& data) {
+    const bool enable         = data.enabled && data.mainFB;
+    const bool updatesPrimary = data.modeset || (data.committed & COutputState::AQ_OUTPUT_STATE_BUFFER);
 
-    if (enable && data.mainFB != crtc->primary->front) {
+    const auto retireBack = [&data](const SP<SDRMPlane>& plane) {
+        if (plane->back && plane->back != plane->front)
+            data.retiredFBs.emplace_back(std::move(plane->back));
+        plane->back    = plane->front;
+        plane->backSet = false;
+    };
+
+    if (enable && data.modeset && data.mainFB == crtc->primary->front && crtc->primary->back != crtc->primary->front)
+        retireBack(crtc->primary);
+
+    if (enable && updatesPrimary && data.mainFB != crtc->primary->front) {
         if (crtc->primary->back != crtc->primary->front && crtc->primary->back != data.mainFB)
-            releaseFBBuffer(crtc->primary->back);
+            data.retiredFBs.emplace_back(std::move(crtc->primary->back));
 
-        crtc->primary->back                  = data.mainFB;
-        data.mainFB->buffer->lockedByBackend = true;
+        if (crtc->primary->back != data.mainFB) {
+            crtc->primary->back = data.mainFB;
+            data.mainFB->buffer->backendPin();
+        }
+        crtc->primary->backSet = true;
+        data.primaryFBChanged  = true;
     }
 
-    if (enable && crtc->cursor && data.cursorFB) {
-        if (data.cursorFB != crtc->cursor->front) {
-            if (crtc->cursor->back != crtc->cursor->front && crtc->cursor->back != data.cursorFB)
-                releaseFBBuffer(crtc->cursor->back);
+    if (enable && crtc->cursor) {
+        if (data.committed & COutputState::AQ_OUTPUT_STATE_CURSOR_SHAPE) {
+            const auto desired = data.cursorVisible ? data.cursorFB : nullptr;
 
-            crtc->cursor->back                     = data.cursorFB;
-            data.cursorFB->buffer->lockedByBackend = true;
-        }
+            if (desired == crtc->cursor->front) {
+                if (crtc->cursor->back != crtc->cursor->front)
+                    retireBack(crtc->cursor);
+            } else {
+                if (crtc->cursor->back != crtc->cursor->front && crtc->cursor->back != desired)
+                    data.retiredFBs.emplace_back(std::move(crtc->cursor->back));
+
+                if (crtc->cursor->back != desired) {
+                    crtc->cursor->back = desired;
+                    if (desired)
+                        desired->buffer->backendPin();
+                }
+
+                crtc->cursor->backSet = true;
+                data.cursorFBChanged  = true;
+            }
+        } else if (data.modeset && data.cursorFB == crtc->cursor->front && crtc->cursor->back != crtc->cursor->front)
+            retireBack(crtc->cursor);
 
         if (crtc->pendingCursor == data.cursorFB)
             crtc->pendingCursor.reset();
@@ -1923,12 +1993,10 @@ void Aquamarine::SDRMConnector::applyCommit(const SDRMConnectorCommitData& data)
     const bool wasEnabled = output->enabledState;
     output->enabledState  = data.enabled;
 
-    if (!output->enabledState) {
-        releaseFBReferences();
+    if (!output->enabledState)
         invalidateFrame();
-    }
 
-    if (!backend->updateSecondaryRendererState())
+    if (!backend->updateSecondaryRendererState(&data.retiredFBs))
         backend->backend->log(AQ_LOG_ERROR, std::format("drm: Failed to update renderer state for {} on applyCommit", szName));
 
     if (wasEnabled != output->enabledState) {
@@ -1942,6 +2010,11 @@ void Aquamarine::SDRMConnector::applyCommit(const SDRMConnectorCommitData& data)
                     b->recheckOutputs();
             }));
         }
+    }
+
+    if (!output->enabledState) {
+        releaseFBReferences(&data.retiredFBs);
+        return;
     }
 }
 
@@ -1961,24 +2034,32 @@ void Aquamarine::SDRMConnector::setCRTC(SP<SDRMCRTC> newCRTC) {
     crtc = newCRTC;
 }
 
-void Aquamarine::SDRMConnector::onPresent() {
-    if (crtc->primary->back && crtc->primary->back != crtc->primary->front) {
-        crtc->primary->last  = crtc->primary->front;
-        crtc->primary->front = crtc->primary->back;
-        if (crtc->primary->last && crtc->primary->last->buffer) {
-            crtc->primary->last->buffer->lockedByBackend = false;
-            crtc->primary->last->buffer->events.backendRelease.emit();
-        }
+void Aquamarine::SDRMConnector::onPresent(bool primary, bool cursor, DRMFBList* deferred) {
+    DRMFBList  retired;
+    const auto presentPlane = [&retired](const SP<SDRMPlane>& plane) {
+        if (!plane || !plane->backSet)
+            return;
+
+        if (plane->front && plane->front != plane->back)
+            retired.emplace_back(std::move(plane->front));
+        plane->front   = plane->back;
+        plane->backSet = false;
+        plane->last.reset();
+    };
+
+    if (primary)
+        presentPlane(crtc->primary);
+    if (cursor)
+        presentPlane(crtc->cursor);
+
+    if (deferred) {
+        for (auto& fb : retired)
+            deferred->emplace_back(std::move(fb));
+        return;
     }
 
-    if (crtc->cursor && crtc->cursor->back && crtc->cursor->back != crtc->cursor->front) {
-        crtc->cursor->last  = crtc->cursor->front;
-        crtc->cursor->front = crtc->cursor->back;
-        if (crtc->cursor->last && crtc->cursor->last->buffer) {
-            crtc->cursor->last->buffer->lockedByBackend = false;
-            crtc->cursor->last->buffer->events.backendRelease.emit();
-        }
-    }
+    for (const auto& fb : retired)
+        releaseFBBuffer(fb);
 }
 
 Aquamarine::CDRMOutput::~CDRMOutput() {
@@ -2023,8 +2104,19 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
         return false;
     }
 
-    const auto&    STATE     = state->state();
+    if (connector->status != DRM_MODE_CONNECTED || connector->output != self.lock()) {
+        backend->backend->log(AQ_LOG_ERROR, "drm: Cannot commit a disconnected output");
+        return false;
+    }
+
+    const auto     SNAPSHOT  = state->snapshot();
+    const auto&    STATE     = SNAPSHOT.state();
     const uint32_t COMMITTED = STATE.committed;
+
+    if (SNAPSHOT.error()) {
+        backend->backend->log(AQ_LOG_ERROR, std::format("drm: Failed to duplicate explicit input fence: {}", strerror(SNAPSHOT.error())));
+        return false;
+    }
 
     if ((COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_ENABLED) && STATE.enabled) {
         if (!STATE.mode && !STATE.customMode) {
@@ -2076,7 +2168,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
 
     // If we are changing the rendering format, we may need to reconfigure the output (aka modeset)
     // which may result in some glitches
-    const bool NEEDS_RECONFIG = state->needsReconfig();
+    const bool NEEDS_RECONFIG = SNAPSHOT.needsReconfig();
 
     const bool BLOCKING = NEEDS_RECONFIG || !(COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_BUFFER);
 
@@ -2120,6 +2212,10 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
         return true;
 
     SDRMConnectorCommitData data;
+    data.outputState   = STATE;
+    data.cursorPos     = cursorPos;
+    data.cursorHotspot = cursorHotspot;
+    data.cursorVisible = cursorVisible;
 
     // A commit that carries no new buffer has nothing to blit: STATE.buffer is the one we already copied
     SP<CDRMFB> blittedFB;
@@ -2187,9 +2283,9 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
             // if the commit doesn't have an explicit fence, don't use the one we created, just fallback to implicit
             static auto NO_EXPLICIT = envEnabled("AQ_MGPU_NO_EXPLICIT");
             if (blitResult.syncFD.has_value() && !NO_EXPLICIT && (COMMITTED & COutputState::eOutputStateProperties::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE))
-                state->setExplicitInFence(blitResult.syncFD.value());
+                data.outputState.explicitInFence = blitResult.syncFD.value();
             else
-                state->setExplicitInFence(-1);
+                data.outputState.explicitInFence = -1;
 
             drmFB = CDRMFB::create(NEWAQBUF, backend, nullptr); // will return attachment if present
         } else
@@ -2216,8 +2312,8 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
             backend->backend->log(AQ_LOG_WARNING,
                                   std::format("drm: Formats mismatch in commit, buffer is {} but output is set to {}. Modesetting to {}", fourccToName(params.format),
                                               fourccToName(STATE.drmFormat), fourccToName(params.format)));
-            state->setFormat(params.format);
-            formatMismatch = true;
+            data.outputState.drmFormat = params.format;
+            formatMismatch             = true;
             // TODO: reject if tearing? We will miss a frame event!
             flags &= ~DRM_MODE_PAGE_FLIP_ASYNC; // we cannot modeset with async pf
         }
@@ -2300,7 +2396,7 @@ bool Aquamarine::CDRMOutput::commitState(bool onlyTest) {
         return ok;
 
     events.commit.emit();
-    state->onCommit();
+    state->consume(SNAPSHOT);
 
     lastCommitNoBuffer = !data.mainFB;
     needsFrame         = false;
@@ -2345,7 +2441,7 @@ bool Aquamarine::CDRMOutput::setCursor(SP<IBuffer> buffer, const Vector2D& hotsp
     if (!buffer && !cursorVisible)
         return true;
 
-    state->internalState.committed |= COutputState::AQ_OUTPUT_STATE_CURSOR_SHAPE;
+    state->markCommitted(COutputState::AQ_OUTPUT_STATE_CURSOR_SHAPE);
     if (!buffer)
         setCursorVisible(false);
     else {
@@ -2437,7 +2533,7 @@ void Aquamarine::CDRMOutput::moveCursor(const Vector2D& coord, bool skipSchedule
     cursorPos = coord;
     // cursorVisible = true;
     // if (!skipSchedule)
-    state->internalState.committed |= COutputState::AQ_OUTPUT_STATE_CURSOR_POS;
+    state->markCommitted(COutputState::AQ_OUTPUT_STATE_CURSOR_POS);
 
     backend->impl->moveCursor(connector, skipSchedule);
 }
@@ -2789,10 +2885,10 @@ uint32_t Aquamarine::CDRMFB::submitBuffer() {
 }
 
 void Aquamarine::SDRMConnectorCommitData::calculateMode(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector) {
-    if (!connector || !connector->output || !connector->output->state)
+    if (!connector)
         return;
 
-    const auto& STATE = connector->output->state->state();
+    const auto& STATE = outputState;
     const auto  MODE  = STATE.mode ? STATE.mode : STATE.customMode;
 
     if (!MODE) {

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -1,4 +1,5 @@
 #include <aquamarine/backend/drm/Atomic.hpp>
+#include <cerrno>
 #include <cstdint>
 #include <cstring>
 #include <drm_mode.h>
@@ -145,6 +146,24 @@ void Aquamarine::CDRMAtomicRequest::add(uint32_t id, uint32_t prop, uint64_t val
         backend->log(AQ_LOG_ERROR, "atomic drm request: failed to add prop");
         failed = true;
     }
+}
+
+bool Aquamarine::CDRMAtomicRequest::addRaw(uint32_t id, uint32_t prop, uint64_t val) noexcept {
+    if (!req || !id || !prop)
+        return false;
+
+    return drmModeAtomicAddProperty(req, id, prop, val) >= 0;
+}
+
+CDRMAtomicRequest::SAsyncResult Aquamarine::CDRMAtomicRequest::submitAsync(int drmFD, uint32_t flags, uint64_t commitID) noexcept {
+    if (!req || failed || drmFD < 0 || !commitID)
+        return {.submitted = false, .error = EINVAL};
+
+    const auto RET = drmModeAtomicCommit(drmFD, req, flags, rc<void*>(commitID));
+    if (RET)
+        return {.submitted = false, .error = RET == -1 ? errno : -RET};
+
+    return {.submitted = true, .error = 0};
 }
 
 void Aquamarine::CDRMAtomicRequest::planeProps(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane, Hyprutils::Memory::CSharedPointer<CDRMFB> fb, uint32_t crtc,
@@ -445,6 +464,41 @@ void Aquamarine::CDRMAtomicRequest::apply(SDRMConnectorCommitData& data) {
 
 Aquamarine::CDRMAtomicImpl::CDRMAtomicImpl(Hyprutils::Memory::CSharedPointer<CDRMBackend> backend_) : backend(backend_) {
     ;
+}
+
+CUniquePointer<CDRMAtomicRequest> Aquamarine::CDRMAtomicImpl::prepareAsync(SP<SDRMConnector> connector, SDRMConnectorCommitData& data, uint32_t& flags) {
+    if (!prepareConnector(connector, data))
+        return nullptr;
+
+    auto request = makeUnique<CDRMAtomicRequest>(backend);
+    request->addConnector(connector, data);
+
+    flags = data.flags | DRM_MODE_ATOMIC_NONBLOCK;
+    if (request->failed) {
+        request->rollback(data);
+        return nullptr;
+    }
+
+    return request;
+}
+
+void Aquamarine::CDRMAtomicImpl::finalizeAsync(CDRMAtomicRequest& request, SP<SDRMConnector> connector, SDRMConnectorCommitData& data, bool success) {
+    if (!success) {
+        request.rollback(data);
+        return;
+    }
+
+    request.apply(data);
+    connector->atomic.maxBpc      = data.atomic.maxBpc;
+    connector->atomic.colorspace  = data.atomic.colorspace;
+    connector->atomic.contentType = data.atomic.contentType;
+    connector->atomic.crtcID      = data.atomic.crtcID;
+    connector->atomic.propsCached = true;
+    connector->atomic.colorRange  = data.outputState.colorRange;
+    connector->atomic.vrrEnabled  = data.outputState.adaptiveSync;
+    connector->output->vrrActive  = data.outputState.adaptiveSync;
+    if (data.atomic.ctmd)
+        connector->crtc->atomic.ctmStateKnown = true;
 }
 
 bool Aquamarine::CDRMAtomicImpl::prepareConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data) {

--- a/src/backend/drm/impl/Atomic.cpp
+++ b/src/backend/drm/impl/Atomic.cpp
@@ -87,7 +87,7 @@ bool Aquamarine::CDRMAtomicRequest::restateConnectors(SP<SDRMConnector> self) {
         if (c == self || !c->crtc || !c->output)
             continue;
 
-        if (!c->output->state->state().enabled)
+        if (!c->output->enabledState)
             continue;
 
         drmModeModeInfo* current = c->getCurrentMode();
@@ -120,7 +120,7 @@ bool Aquamarine::CDRMAtomicRequest::restateConnectors(SP<SDRMConnector> self) {
             // head we are restating rather than ours.
             const auto saved = conn;
             conn             = c;
-            planeProps(c->crtc->primary, c->crtc->primary->front, c->crtc->id, {});
+            planeProps(c->crtc->primary, c->crtc->primary->front, c->crtc->id, {}, c->atomic.colorRange);
             conn = saved;
         }
 
@@ -148,7 +148,7 @@ void Aquamarine::CDRMAtomicRequest::add(uint32_t id, uint32_t prop, uint64_t val
 }
 
 void Aquamarine::CDRMAtomicRequest::planeProps(Hyprutils::Memory::CSharedPointer<SDRMPlane> plane, Hyprutils::Memory::CSharedPointer<CDRMFB> fb, uint32_t crtc,
-                                               Hyprutils::Math::Vector2D pos) {
+                                               Hyprutils::Math::Vector2D pos, eOutputColorRange colorRange) {
 
     if (failed)
         return;
@@ -179,7 +179,6 @@ void Aquamarine::CDRMAtomicRequest::planeProps(Hyprutils::Memory::CSharedPointer
     add(plane->id, plane->props.values.crtc_id, crtc);
 
     if (plane->props.values.color_range) {
-        const auto              colorRange = conn && conn->output ? conn->output->state->state().colorRange : AQ_OUTPUT_COLOR_RANGE_AUTO;
         std::optional<uint32_t> rangeVal;
         switch (colorRange) {
             case AQ_OUTPUT_COLOR_RANGE_FULL: rangeVal = plane->colorRange.values.Full_YCbCr; break;
@@ -213,7 +212,7 @@ void Aquamarine::CDRMAtomicRequest::setConnector(Hyprutils::Memory::CSharedPoint
 }
 
 void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data) {
-    const auto& STATE  = connector->output->state->state();
+    const auto& STATE  = data.outputState;
     const bool  enable = data.enabled && data.mainFB;
 
     TRACE(backend->log(AQ_LOG_TRACE,
@@ -288,7 +287,7 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
 
     if (enable) {
         if (connector->output->supportsExplicit && data.committed & COutputState::AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE)
-            add(connector->crtc->id, connector->crtc->props.values.out_fence_ptr, (uintptr_t)&STATE.explicitOutFence);
+            add(connector->crtc->id, connector->crtc->props.values.out_fence_ptr, (uintptr_t)&data.outputState.explicitOutFence);
 
         if (connector->crtc->props.values.gamma_lut && data.atomic.gammad)
             add(connector->crtc->id, connector->crtc->props.values.gamma_lut, data.atomic.gammaLut);
@@ -302,9 +301,9 @@ void Aquamarine::CDRMAtomicRequest::addConnector(Hyprutils::Memory::CSharedPoint
         if (connector->crtc->props.values.vrr_enabled)
             add(connector->crtc->id, connector->crtc->props.values.vrr_enabled, (uint64_t)STATE.adaptiveSync);
 
-        planeProps(connector->crtc->primary, data.mainFB, connector->crtc->id, {});
+        planeProps(connector->crtc->primary, data.mainFB, connector->crtc->id, {}, STATE.colorRange);
 
-        if (connector->output->supportsExplicit && STATE.explicitInFence >= 0)
+        if (connector->output->supportsExplicit && (data.committed & COutputState::AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE) && STATE.explicitInFence >= 0)
             add(connector->crtc->primary->id, connector->crtc->primary->props.values.in_fence_fd, STATE.explicitInFence);
 
         if (connector->crtc->primary->props.values.fb_damage_clips)
@@ -340,12 +339,12 @@ void Aquamarine::CDRMAtomicRequest::addConnectorCursor(Hyprutils::Memory::CShare
         if (data.committed & COutputState::AQ_OUTPUT_STATE_CURSOR_SHAPE || data.committed & COutputState::AQ_OUTPUT_STATE_CURSOR_POS) {
             TRACE(backend->log(AQ_LOG_TRACE, data.committed & COutputState::AQ_OUTPUT_STATE_CURSOR_SHAPE ? "atomic addConnector cursor shape" : "atomic addConnector cursor pos"));
             if (data.committed & COutputState::AQ_OUTPUT_STATE_CURSOR_SHAPE) {
-                if (!connector->output->cursorVisible)
+                if (!data.cursorVisible)
                     planeProps(connector->crtc->cursor, nullptr, 0, {});
                 else
-                    planeProps(connector->crtc->cursor, data.cursorFB, connector->crtc->id, connector->output->cursorPos - connector->output->cursorHotspot);
-            } else if (connector->output->cursorVisible)
-                planePropsPos(connector->crtc->cursor, connector->output->cursorPos - connector->output->cursorHotspot);
+                    planeProps(connector->crtc->cursor, data.cursorFB, connector->crtc->id, data.cursorPos - data.cursorHotspot);
+            } else if (data.cursorVisible)
+                planePropsPos(connector->crtc->cursor, data.cursorPos - data.cursorHotspot);
         }
     } else
         planeProps(connector->crtc->cursor, nullptr, 0, {});
@@ -449,7 +448,7 @@ Aquamarine::CDRMAtomicImpl::CDRMAtomicImpl(Hyprutils::Memory::CSharedPointer<CDR
 }
 
 bool Aquamarine::CDRMAtomicImpl::prepareConnector(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data) {
-    const auto& STATE  = connector->output->state->state();
+    const auto& STATE  = data.outputState;
     const bool  enable = data.enabled;
     const auto& MODE   = STATE.mode ? STATE.mode : STATE.customMode;
 
@@ -621,6 +620,7 @@ bool Aquamarine::CDRMAtomicImpl::commit(Hyprutils::Memory::CSharedPointer<SDRMCo
                 connector->atomic.contentType = data.atomic.contentType;
                 connector->atomic.crtcID      = data.atomic.crtcID;
                 connector->atomic.propsCached = true;
+                connector->atomic.colorRange  = data.outputState.colorRange;
                 if (data.atomic.ctmd)
                     connector->crtc->atomic.ctmStateKnown = true;
 
@@ -669,6 +669,7 @@ bool Aquamarine::CDRMAtomicImpl::commit(Hyprutils::Memory::CSharedPointer<SDRMCo
             connector->atomic.contentType = data.atomic.contentType;
             connector->atomic.crtcID      = data.atomic.crtcID;
             connector->atomic.propsCached = true;
+            connector->atomic.colorRange  = data.outputState.colorRange;
             if (data.atomic.ctmd)
                 connector->crtc->atomic.ctmStateKnown = true;
         }

--- a/src/backend/drm/impl/Legacy.cpp
+++ b/src/backend/drm/impl/Legacy.cpp
@@ -25,7 +25,7 @@ bool Aquamarine::CDRMLegacyImpl::moveCursor(Hyprutils::Memory::CSharedPointer<SD
 }
 
 bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointer<SDRMConnector> connector, SDRMConnectorCommitData& data) {
-    const auto& STATE = connector->output->state->state();
+    const auto& STATE = data.outputState;
     SP<CDRMFB>  mainFB;
     bool        enable = data.enabled;
 
@@ -86,7 +86,7 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
 
     // TODO: gamma
 
-    if (data.cursorFB && connector->crtc->cursor && connector->output->cursorVisible && enable &&
+    if (data.cursorFB && connector->crtc->cursor && data.cursorVisible && enable &&
         (data.committed & COutputState::AQ_OUTPUT_STATE_CURSOR_SHAPE || data.committed & COutputState::AQ_OUTPUT_STATE_CURSOR_POS)) {
         uint32_t boHandle = 0;
         auto     attrs    = data.cursorFB->buffer->dmabuf();
@@ -100,18 +100,16 @@ bool Aquamarine::CDRMLegacyImpl::commitInternal(Hyprutils::Memory::CSharedPointe
                                          std::format("legacy drm: cursor fb: {} with bo handle {} from fd {}, size {}", connector->backend->gpu->fd, boHandle,
                                                      data.cursorFB->buffer->dmabuf().fds.at(0), data.cursorFB->buffer->size));
 
-        Vector2D                cursorPos = connector->output->cursorPos;
-
         struct drm_mode_cursor2 request = {
             .flags   = DRM_MODE_CURSOR_BO | DRM_MODE_CURSOR_MOVE,
             .crtc_id = connector->crtc->id,
-            .x       = (int32_t)cursorPos.x,
-            .y       = (int32_t)cursorPos.y,
+            .x       = (int32_t)data.cursorPos.x,
+            .y       = (int32_t)data.cursorPos.y,
             .width   = (uint32_t)data.cursorFB->buffer->size.x,
             .height  = (uint32_t)data.cursorFB->buffer->size.y,
             .handle  = boHandle,
-            .hot_x   = (int32_t)connector->output->cursorHotspot.x,
-            .hot_y   = (int32_t)connector->output->cursorHotspot.y,
+            .hot_x   = (int32_t)data.cursorHotspot.x,
+            .hot_y   = (int32_t)data.cursorHotspot.y,
         };
 
         int ret = drmIoctl(connector->backend->gpu->fd, DRM_IOCTL_MODE_CURSOR2, &request);

--- a/src/buffer/Buffer.cpp
+++ b/src/buffer/Buffer.cpp
@@ -39,3 +39,26 @@ void Aquamarine::IBuffer::unlock() {
 bool Aquamarine::IBuffer::locked() {
     return locks;
 }
+
+void Aquamarine::IBuffer::backendPin() {
+    backendPins++;
+    lockedByBackend = true;
+}
+
+void Aquamarine::IBuffer::backendUnpin() {
+    ASSERT(backendPins > 0);
+
+    if (backendPins == 0)
+        return;
+
+    backendPins--;
+    if (backendPins > 0)
+        return;
+
+    lockedByBackend = false;
+    events.backendRelease.emit();
+}
+
+uint32_t Aquamarine::IBuffer::backendPinCount() const {
+    return backendPins;
+}

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -1,5 +1,7 @@
 #include <aquamarine/output/Output.hpp>
 
+#include <cerrno>
+
 using namespace Aquamarine;
 
 Aquamarine::IOutput::~IOutput() {
@@ -13,6 +15,16 @@ Hyprutils::Memory::CSharedPointer<SOutputMode> Aquamarine::IOutput::preferredMod
     }
 
     return nullptr;
+}
+
+uint32_t Aquamarine::IOutput::commitCapabilities() const {
+    return 0;
+}
+
+Aquamarine::IOutput::SCommitSubmission Aquamarine::IOutput::commitAsync(const SCommitOptions& options) {
+    return {
+        .error = ENOTSUP,
+    };
 }
 
 void Aquamarine::IOutput::moveCursor(const Hyprutils::Math::Vector2D& coord, bool skipSchedule) {

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -1,6 +1,9 @@
 #include <aquamarine/output/Output.hpp>
+#include "Shared.hpp"
 
+#include <bit>
 #include <cerrno>
+#include <fcntl.h>
 
 using namespace Aquamarine;
 
@@ -67,8 +70,65 @@ bool Aquamarine::IOutput::destroy() {
     return false;
 }
 
+Aquamarine::COutputState::CSnapshot::CSnapshot(const COutputState* owner, const SInternalState& state, const std::array<uint64_t, 16>& generations) :
+    m_owner(owner), m_state(state), m_generations(generations) {
+    if (!(m_state.committed & AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE) || m_state.explicitInFence < 0)
+        return;
+
+    const int DUPLICATED_FD = fcntl(m_state.explicitInFence, F_DUPFD_CLOEXEC, 0);
+    if (DUPLICATED_FD < 0) {
+        m_error                 = errno;
+        m_state.explicitInFence = -1;
+        return;
+    }
+
+    m_explicitInFence       = Hyprutils::OS::CFileDescriptor{DUPLICATED_FD};
+    m_state.explicitInFence = m_explicitInFence.get();
+}
+
+const Aquamarine::COutputState::SInternalState& Aquamarine::COutputState::CSnapshot::state() const {
+    return m_state;
+}
+
+bool Aquamarine::COutputState::CSnapshot::needsReconfig() const {
+    return m_state.committed & (AQ_OUTPUT_STATE_ENABLED | AQ_OUTPUT_STATE_FORMAT | AQ_OUTPUT_STATE_MODE | AQ_OUTPUT_STATE_HDR | AQ_OUTPUT_STATE_WCG);
+}
+
+int Aquamarine::COutputState::CSnapshot::error() const {
+    return m_error;
+}
+
 const Aquamarine::COutputState::SInternalState& Aquamarine::COutputState::state() {
     return internalState;
+}
+
+const Aquamarine::COutputState::SInternalState& Aquamarine::COutputState::state() const {
+    return internalState;
+}
+
+Aquamarine::COutputState::CSnapshot Aquamarine::COutputState::snapshot() const {
+    return CSnapshot{this, internalState, propertyGenerations};
+}
+
+void Aquamarine::COutputState::consume(const CSnapshot& snapshot) {
+    ASSERT(snapshot.m_owner == this);
+    if (snapshot.m_owner != this)
+        return;
+
+    uint32_t properties = snapshot.m_state.committed;
+
+    while (properties) {
+        const uint32_t property = 1U << std::countr_zero(properties);
+        const size_t   index    = std::countr_zero(property);
+        properties &= ~property;
+
+        if (!(internalState.committed & property) || propertyGenerations.at(index) != snapshot.m_generations.at(index))
+            continue;
+
+        internalState.committed &= ~property;
+        if (property == AQ_OUTPUT_STATE_DAMAGE)
+            internalState.damage.clear();
+    }
 }
 
 bool Aquamarine::COutputState::needsReconfig() const {
@@ -77,68 +137,68 @@ bool Aquamarine::COutputState::needsReconfig() const {
 
 void Aquamarine::COutputState::addDamage(const Hyprutils::Math::CRegion& region) {
     internalState.damage.add(region);
-    internalState.committed |= AQ_OUTPUT_STATE_DAMAGE;
+    markCommitted(AQ_OUTPUT_STATE_DAMAGE);
 }
 
 void Aquamarine::COutputState::clearDamage() {
     internalState.damage.clear();
-    internalState.committed |= AQ_OUTPUT_STATE_DAMAGE;
+    markCommitted(AQ_OUTPUT_STATE_DAMAGE);
 }
 
 void Aquamarine::COutputState::setEnabled(bool enabled) {
     internalState.enabled = enabled;
-    internalState.committed |= AQ_OUTPUT_STATE_ENABLED;
+    markCommitted(AQ_OUTPUT_STATE_ENABLED);
 }
 
 void Aquamarine::COutputState::setAdaptiveSync(bool enabled) {
     internalState.adaptiveSync = enabled;
-    internalState.committed |= AQ_OUTPUT_STATE_ADAPTIVE_SYNC;
+    markCommitted(AQ_OUTPUT_STATE_ADAPTIVE_SYNC);
 }
 
 void Aquamarine::COutputState::setPresentationMode(eOutputPresentationMode mode) {
     internalState.presentationMode = mode;
-    internalState.committed |= AQ_OUTPUT_STATE_PRESENTATION_MODE;
+    markCommitted(AQ_OUTPUT_STATE_PRESENTATION_MODE);
 }
 
 void Aquamarine::COutputState::setGammaLut(const std::vector<uint16_t>& lut) {
     internalState.gammaLut = lut;
-    internalState.committed |= AQ_OUTPUT_STATE_GAMMA_LUT;
+    markCommitted(AQ_OUTPUT_STATE_GAMMA_LUT);
 }
 
 void Aquamarine::COutputState::setDeGammaLut(const std::vector<uint16_t>& lut) {
     internalState.degammaLut = lut;
-    internalState.committed |= AQ_OUTPUT_STATE_DEGAMMA_LUT;
+    markCommitted(AQ_OUTPUT_STATE_DEGAMMA_LUT);
 }
 
 void Aquamarine::COutputState::setMode(Hyprutils::Memory::CSharedPointer<SOutputMode> mode) {
     internalState.mode       = mode;
     internalState.customMode = nullptr;
-    internalState.committed |= AQ_OUTPUT_STATE_MODE;
+    markCommitted(AQ_OUTPUT_STATE_MODE);
 }
 
 void Aquamarine::COutputState::setCustomMode(Hyprutils::Memory::CSharedPointer<SOutputMode> mode) {
     internalState.mode.reset();
     internalState.customMode = mode;
-    internalState.committed |= AQ_OUTPUT_STATE_MODE;
+    markCommitted(AQ_OUTPUT_STATE_MODE);
 }
 
 void Aquamarine::COutputState::setFormat(uint32_t drmFormat) {
     internalState.drmFormat = drmFormat;
-    internalState.committed |= AQ_OUTPUT_STATE_FORMAT;
+    markCommitted(AQ_OUTPUT_STATE_FORMAT);
 }
 
 void Aquamarine::COutputState::setBuffer(Hyprutils::Memory::CSharedPointer<IBuffer> buffer) {
     internalState.buffer = buffer;
-    internalState.committed |= AQ_OUTPUT_STATE_BUFFER;
+    markCommitted(AQ_OUTPUT_STATE_BUFFER);
 }
 
 void Aquamarine::COutputState::setExplicitInFence(int32_t fenceFD) {
     internalState.explicitInFence = fenceFD;
-    internalState.committed |= AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE;
+    markCommitted(AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE);
 }
 
 void Aquamarine::COutputState::enableExplicitOutFenceForNextCommit() {
-    internalState.committed |= AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE;
+    markCommitted(AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE);
 }
 
 void Aquamarine::COutputState::resetExplicitFences() {
@@ -149,17 +209,17 @@ void Aquamarine::COutputState::resetExplicitFences() {
 
 void Aquamarine::COutputState::setCTM(const Hyprutils::Math::Mat3x3& ctm) {
     internalState.ctm = ctm;
-    internalState.committed |= AQ_OUTPUT_STATE_CTM;
+    markCommitted(AQ_OUTPUT_STATE_CTM);
 }
 
 void Aquamarine::COutputState::setWideColorGamut(bool wcg) {
     internalState.wideColorGamut = wcg;
-    internalState.committed |= AQ_OUTPUT_STATE_WCG;
+    markCommitted(AQ_OUTPUT_STATE_WCG);
 }
 
 void Aquamarine::COutputState::setHDRMetadata(const hdr_output_metadata& metadata) {
     internalState.hdrMetadata = metadata;
-    internalState.committed |= AQ_OUTPUT_STATE_HDR;
+    markCommitted(AQ_OUTPUT_STATE_HDR);
 }
 
 void Aquamarine::COutputState::setContentType(const uint16_t drmContentType) {
@@ -170,7 +230,12 @@ void Aquamarine::COutputState::setColorRange(eOutputColorRange range) {
     internalState.colorRange = range;
 }
 
-void Aquamarine::COutputState::onCommit() {
-    internalState.committed = 0;
-    internalState.damage.clear();
+void Aquamarine::COutputState::markCommitted(uint32_t properties) {
+    internalState.committed |= properties;
+
+    while (properties) {
+        const uint32_t property = 1U << std::countr_zero(properties);
+        properties &= ~property;
+        propertyGenerations.at(std::countr_zero(property)) = ++nextGeneration;
+    }
 }

--- a/src/output/Output.cpp
+++ b/src/output/Output.cpp
@@ -131,6 +131,26 @@ void Aquamarine::COutputState::consume(const CSnapshot& snapshot) {
     }
 }
 
+void Aquamarine::COutputState::rearm(const CSnapshot& snapshot) {
+    ASSERT(snapshot.m_owner == this);
+    if (snapshot.m_owner != this)
+        return;
+
+    uint32_t properties = snapshot.m_state.committed & ~(AQ_OUTPUT_STATE_EXPLICIT_IN_FENCE | AQ_OUTPUT_STATE_EXPLICIT_OUT_FENCE);
+    while (properties) {
+        const uint32_t property = 1U << std::countr_zero(properties);
+        const size_t   index    = std::countr_zero(property);
+        properties &= ~property;
+
+        if (propertyGenerations.at(index) != snapshot.m_generations.at(index))
+            continue;
+
+        internalState.committed |= property;
+        if (property == AQ_OUTPUT_STATE_DAMAGE)
+            internalState.damage.add(snapshot.m_state.damage);
+    }
+}
+
 bool Aquamarine::COutputState::needsReconfig() const {
     return internalState.committed & (AQ_OUTPUT_STATE_ENABLED | AQ_OUTPUT_STATE_FORMAT | AQ_OUTPUT_STATE_MODE | AQ_OUTPUT_STATE_HDR | AQ_OUTPUT_STATE_WCG);
 }

--- a/tests/CommitThread.cpp
+++ b/tests/CommitThread.cpp
@@ -1,0 +1,314 @@
+#include "CommitThread.hpp"
+#include "shared.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <poll.h>
+#include <vector>
+
+using namespace Aquamarine;
+using namespace Hyprutils::Memory;
+using namespace std::chrono_literals;
+#define UP CUniquePointer
+
+class CTestCommitData : public IDRMCommitThreadData {
+  public:
+    explicit CTestCommitData(int value_) : value(value_) {
+        ;
+    }
+
+    const int value = 0;
+};
+
+class CFakeCommitSubmitter : public IDRMCommitSubmitter {
+  public:
+    SResult submit(uint64_t commitID, const IDRMCommitThreadData& data) noexcept override {
+        std::unique_lock<std::mutex> lock(m_mutex);
+
+        const auto&                  COMMIT_DATA = *sc<const CTestCommitData*>(&data);
+
+        m_submittedIDs.emplace_back(commitID);
+        m_submittedValues.emplace_back(COMMIT_DATA.value);
+
+        SResult result{.submitted = true};
+        if (!m_results.empty()) {
+            result = m_results.front();
+            m_results.erase(m_results.begin());
+        }
+
+        m_condition.notify_all();
+        m_condition.wait(lock, [this] { return !m_blocked; });
+        return result;
+    }
+
+    void addResult(const SResult& result) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_results.emplace_back(result);
+    }
+
+    bool waitForSubmissions(size_t count, std::chrono::milliseconds timeout = 2s) {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_condition.wait_for(lock, timeout, [this, count] { return m_submittedIDs.size() >= count; });
+    }
+
+    void block() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_blocked = true;
+    }
+
+    void unblock() {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_blocked = false;
+        }
+        m_condition.notify_all();
+    }
+
+    std::vector<uint64_t> submittedIDs() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_submittedIDs;
+    }
+
+    std::vector<int> submittedValues() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_submittedValues;
+    }
+
+  private:
+    std::mutex              m_mutex;
+    std::condition_variable m_condition;
+    std::vector<SResult>    m_results;
+    std::vector<uint64_t>   m_submittedIDs;
+    std::vector<int>        m_submittedValues;
+    bool                    m_blocked = false;
+};
+
+static UP<SDRMCommitThreadRequest> makeRequest(uint64_t ownerID, uint64_t queueKey, int value) {
+    auto request      = makeUnique<SDRMCommitThreadRequest>();
+    request->ownerID  = ownerID;
+    request->queueKey = queueKey;
+    request->data     = makeUnique<CTestCommitData>(value);
+    return request;
+}
+
+static uint64_t enqueue(CDRMCommitThread& thread, UP<SDRMCommitThreadRequest> request) {
+    return thread.enqueue(std::move(request)).value_or(0);
+}
+
+static bool waitForResults(int fd) {
+    pollfd descriptor{
+        .fd     = fd,
+        .events = POLLIN,
+    };
+
+    return poll(&descriptor, 1, 2000) == 1 && descriptor.revents & POLLIN;
+}
+
+static const CDRMCommitThread::SResult* resultFor(const std::vector<CDRMCommitThread::SResult>& results, uint64_t id) {
+    const auto IT = std::ranges::find_if(results, [id](const auto& result) { return result.request->id == id; });
+    return IT == results.end() ? nullptr : &*IT;
+}
+
+int main() {
+    int  ret = 0;
+
+    auto submitter    = makeUnique<CFakeCommitSubmitter>();
+    auto submitterPtr = submitter.get();
+    auto thread       = CDRMCommitThread::create(std::move(submitter));
+
+    EXPECT(!!thread, true);
+    if (!thread)
+        return 1;
+
+    EXPECT(thread->completionFD() >= 0, true);
+    EXPECT(thread->accepting(), true);
+
+    const auto FIRST  = enqueue(*thread, makeRequest(1, 10, 100));
+    const auto SECOND = enqueue(*thread, makeRequest(2, 10, 200));
+
+    EXPECT(FIRST != 0, true);
+    EXPECT(SECOND > FIRST, true);
+    EXPECT(submitterPtr->waitForSubmissions(1), true);
+    EXPECT(waitForResults(thread->completionFD()), true);
+
+    auto results = thread->drainResults();
+    EXPECT(results.size(), 1U);
+    EXPECT(resultFor(results, FIRST) != nullptr, true);
+    EXPECT(resultFor(results, FIRST)->status, CDRMCommitThread::AQ_DRM_COMMIT_THREAD_SUBMITTED);
+    EXPECT(thread->cancelOwner(2), 1U);
+    EXPECT(waitForResults(thread->completionFD()), true);
+    results = thread->drainResults();
+    EXPECT(results.size(), 1U);
+    EXPECT(resultFor(results, SECOND) != nullptr, true);
+    EXPECT(resultFor(results, SECOND)->status, CDRMCommitThread::AQ_DRM_COMMIT_THREAD_CANCELLED);
+    EXPECT(resultFor(results, SECOND)->error, ECANCELED);
+
+    const auto INDEPENDENT = enqueue(*thread, makeRequest(3, 20, 300));
+    EXPECT(INDEPENDENT != 0, true);
+    EXPECT(submitterPtr->waitForSubmissions(2), true);
+    EXPECT(waitForResults(thread->completionFD()), true);
+    results = thread->drainResults();
+    EXPECT(resultFor(results, INDEPENDENT) != nullptr, true);
+
+    const auto BLOCKED = enqueue(*thread, makeRequest(4, 10, 400));
+    EXPECT(BLOCKED != 0, true);
+    EXPECT(thread->cancelOwner(4), 1U);
+    EXPECT(waitForResults(thread->completionFD()), true);
+    results = thread->drainResults();
+    EXPECT(resultFor(results, BLOCKED) != nullptr, true);
+    EXPECT(resultFor(results, BLOCKED)->status, CDRMCommitThread::AQ_DRM_COMMIT_THREAD_CANCELLED);
+
+    EXPECT(thread->releaseQueue(10, FIRST), true);
+    EXPECT(thread->releaseQueue(10, FIRST), false);
+    const auto RELEASED = enqueue(*thread, makeRequest(5, 10, 500));
+    EXPECT(RELEASED != 0, true);
+    EXPECT(submitterPtr->waitForSubmissions(3), true);
+    EXPECT(waitForResults(thread->completionFD()), true);
+    results = thread->drainResults();
+    EXPECT(resultFor(results, RELEASED) != nullptr, true);
+
+    submitterPtr->addResult({.submitted = false, .error = EINVAL});
+    EXPECT(thread->releaseQueue(20, INDEPENDENT), true);
+    const auto FAILING = enqueue(*thread, makeRequest(6, 20, 600));
+    EXPECT(FAILING != 0, true);
+    EXPECT(submitterPtr->waitForSubmissions(4), true);
+    EXPECT(waitForResults(thread->completionFD()), true);
+    results = thread->drainResults();
+    EXPECT(resultFor(results, FAILING) != nullptr, true);
+    EXPECT(resultFor(results, FAILING)->status, CDRMCommitThread::AQ_DRM_COMMIT_THREAD_FAILED);
+    EXPECT(resultFor(results, FAILING)->error, EINVAL);
+
+    auto late                = makeRequest(7, 30, 700);
+    late->targetPresentation = std::chrono::steady_clock::now() - 1ms;
+    late->blocksQueue        = false;
+    const auto LATE          = enqueue(*thread, std::move(late));
+    EXPECT(LATE != 0, true);
+    EXPECT(submitterPtr->waitForSubmissions(5), true);
+    EXPECT(waitForResults(thread->completionFD()), true);
+    results = thread->drainResults();
+    EXPECT(resultFor(results, LATE) != nullptr, true);
+    EXPECT(resultFor(results, LATE)->missedTarget, true);
+
+    submitterPtr->block();
+    auto active         = makeRequest(9, 50, 900);
+    active->blocksQueue = false;
+    const auto ACTIVE   = enqueue(*thread, std::move(active));
+    EXPECT(ACTIVE != 0, true);
+    EXPECT(submitterPtr->waitForSubmissions(6), true);
+
+    auto activeFollower         = makeRequest(9, 50, 901);
+    activeFollower->blocksQueue = false;
+    const auto ACTIVE_FOLLOWER  = enqueue(*thread, std::move(activeFollower));
+    EXPECT(ACTIVE_FOLLOWER != 0, true);
+
+    auto cancellation = std::async(std::launch::async, [&thread] { return thread->cancelOwner(9); });
+    EXPECT(cancellation.wait_for(20ms) == std::future_status::timeout, true);
+    submitterPtr->unblock();
+    EXPECT(cancellation.wait_for(2s) == std::future_status::ready, true);
+    EXPECT(cancellation.get(), 1U);
+    EXPECT(waitForResults(thread->completionFD()), true);
+    results = thread->drainResults();
+    EXPECT(results.size(), 2U);
+    EXPECT(results.at(0).request->id, ACTIVE);
+    EXPECT(results.at(1).request->id, ACTIVE_FOLLOWER);
+    EXPECT(resultFor(results, ACTIVE) != nullptr, true);
+    EXPECT(resultFor(results, ACTIVE)->status, CDRMCommitThread::AQ_DRM_COMMIT_THREAD_SUBMITTED);
+    EXPECT(resultFor(results, ACTIVE_FOLLOWER)->status, CDRMCommitThread::AQ_DRM_COMMIT_THREAD_CANCELLED);
+
+    auto cancelledOwner = makeRequest(9, 50, 901);
+    EXPECT(thread->enqueue(std::move(cancelledOwner)).has_value(), false);
+
+    auto future       = makeRequest(8, 40, 800);
+    future->submitAt  = std::chrono::steady_clock::now() + 1h;
+    const auto FUTURE = enqueue(*thread, std::move(future));
+    EXPECT(FUTURE != 0, true);
+    results = thread->stopAndDrain();
+    EXPECT(thread->accepting(), false);
+    EXPECT(resultFor(results, FUTURE) != nullptr, true);
+    EXPECT(resultFor(results, FUTURE)->status, CDRMCommitThread::AQ_DRM_COMMIT_THREAD_CANCELLED);
+
+    const auto IDS    = submitterPtr->submittedIDs();
+    const auto VALUES = submitterPtr->submittedValues();
+    EXPECT(IDS.size(), 6U);
+    EXPECT(VALUES.size(), 6U);
+    EXPECT(VALUES.at(0), 100);
+    EXPECT(VALUES.at(1), 300);
+    EXPECT(VALUES.at(2), 500);
+    EXPECT(VALUES.at(3), 600);
+    EXPECT(VALUES.at(4), 700);
+    EXPECT(VALUES.at(5), 900);
+
+    auto rejected = makeRequest(10, 50, 1000);
+    EXPECT(thread->enqueue(std::move(rejected)).has_value(), false);
+
+    auto deadlineSubmitter    = makeUnique<CFakeCommitSubmitter>();
+    auto deadlineSubmitterPtr = deadlineSubmitter.get();
+    auto deadlineThread       = CDRMCommitThread::create(std::move(deadlineSubmitter));
+    EXPECT(!!deadlineThread, true);
+
+    deadlineSubmitterPtr->block();
+    auto gate         = makeRequest(11, 60, 1100);
+    gate->blocksQueue = false;
+    EXPECT(enqueue(*deadlineThread, std::move(gate)) != 0, true);
+    EXPECT(deadlineSubmitterPtr->waitForSubmissions(1), true);
+
+    auto laterDeadline                  = makeRequest(12, 70, 1200);
+    laterDeadline->blocksQueue          = false;
+    laterDeadline->targetPresentation   = std::chrono::steady_clock::now() + 2s;
+    auto earlierDeadline                = makeRequest(13, 80, 1300);
+    earlierDeadline->blocksQueue        = false;
+    earlierDeadline->targetPresentation = std::chrono::steady_clock::now() + 1s;
+    EXPECT(enqueue(*deadlineThread, std::move(laterDeadline)) != 0, true);
+    EXPECT(enqueue(*deadlineThread, std::move(earlierDeadline)) != 0, true);
+
+    deadlineSubmitterPtr->unblock();
+    EXPECT(deadlineSubmitterPtr->waitForSubmissions(3), true);
+    auto deadlineValues = deadlineSubmitterPtr->submittedValues();
+    EXPECT(deadlineValues.at(0), 1100);
+    EXPECT(deadlineValues.at(1), 1300);
+    EXPECT(deadlineValues.at(2), 1200);
+    EXPECT(waitForResults(deadlineThread->completionFD()), true);
+    deadlineThread->drainResults();
+
+    auto sleeping         = makeRequest(14, 90, 1400);
+    sleeping->blocksQueue = false;
+    sleeping->submitAt    = std::chrono::steady_clock::now() + 1h;
+    const auto SLEEPING   = enqueue(*deadlineThread, std::move(sleeping));
+    EXPECT(SLEEPING != 0, true);
+    EXPECT(deadlineSubmitterPtr->waitForSubmissions(4, 20ms), false);
+
+    auto wake         = makeRequest(15, 100, 1500);
+    wake->blocksQueue = false;
+    EXPECT(enqueue(*deadlineThread, std::move(wake)) != 0, true);
+    EXPECT(deadlineSubmitterPtr->waitForSubmissions(4), true);
+    deadlineValues = deadlineSubmitterPtr->submittedValues();
+    EXPECT(deadlineValues.at(3), 1500);
+
+    const auto DEADLINE_RESULTS = deadlineThread->stopAndDrain();
+    EXPECT(resultFor(DEADLINE_RESULTS, SLEEPING)->status, CDRMCommitThread::AQ_DRM_COMMIT_THREAD_CANCELLED);
+
+    auto stopSubmitter    = makeUnique<CFakeCommitSubmitter>();
+    auto stopSubmitterPtr = stopSubmitter.get();
+    auto stopThread       = CDRMCommitThread::create(std::move(stopSubmitter));
+    EXPECT(!!stopThread, true);
+
+    stopSubmitterPtr->block();
+    auto activeStop         = makeRequest(16, 110, 1600);
+    activeStop->blocksQueue = false;
+    const auto ACTIVE_STOP  = enqueue(*stopThread, std::move(activeStop));
+    EXPECT(ACTIVE_STOP != 0, true);
+    EXPECT(stopSubmitterPtr->waitForSubmissions(1), true);
+
+    auto stopping = std::async(std::launch::async, [&stopThread] { return stopThread->stopAndDrain(); });
+    EXPECT(stopping.wait_for(20ms) == std::future_status::timeout, true);
+    stopSubmitterPtr->unblock();
+    EXPECT(stopping.wait_for(2s) == std::future_status::ready, true);
+    const auto STOP_RESULTS = stopping.get();
+    EXPECT(resultFor(STOP_RESULTS, ACTIVE_STOP)->status, CDRMCommitThread::AQ_DRM_COMMIT_THREAD_SUBMITTED);
+
+    return ret;
+}

--- a/tests/CommitThread.cpp
+++ b/tests/CommitThread.cpp
@@ -221,6 +221,7 @@ int main() {
 
     auto cancelledOwner = makeRequest(9, 50, 901);
     EXPECT(thread->enqueue(std::move(cancelledOwner)).has_value(), false);
+    EXPECT(!!cancelledOwner, true);
 
     auto future       = makeRequest(8, 40, 800);
     future->submitAt  = std::chrono::steady_clock::now() + 1h;
@@ -244,6 +245,7 @@ int main() {
 
     auto rejected = makeRequest(10, 50, 1000);
     EXPECT(thread->enqueue(std::move(rejected)).has_value(), false);
+    EXPECT(!!rejected, true);
 
     auto deadlineSubmitter    = makeUnique<CFakeCommitSubmitter>();
     auto deadlineSubmitterPtr = deadlineSubmitter.get();
@@ -309,6 +311,49 @@ int main() {
     EXPECT(stopping.wait_for(2s) == std::future_status::ready, true);
     const auto STOP_RESULTS = stopping.get();
     EXPECT(resultFor(STOP_RESULTS, ACTIVE_STOP)->status, CDRMCommitThread::AQ_DRM_COMMIT_THREAD_SUBMITTED);
+
+    auto barrierSubmitter    = makeUnique<CFakeCommitSubmitter>();
+    auto barrierSubmitterPtr = barrierSubmitter.get();
+    auto barrierThread       = CDRMCommitThread::create(std::move(barrierSubmitter));
+    EXPECT(!!barrierThread, true);
+
+    EXPECT(barrierThread->pauseQueue(0), false);
+    EXPECT(barrierThread->resumeQueue(0), false);
+    EXPECT(barrierThread->pauseQueue(120), true);
+    EXPECT(barrierThread->pauseQueue(120), true);
+
+    auto paused           = makeRequest(17, 120, 1700);
+    paused->blocksQueue   = false;
+    const auto PAUSED     = enqueue(*barrierThread, std::move(paused));
+    auto       unpaused   = makeRequest(18, 130, 1800);
+    unpaused->blocksQueue = false;
+    const auto UNPAUSED   = enqueue(*barrierThread, std::move(unpaused));
+    EXPECT(PAUSED != 0, true);
+    EXPECT(UNPAUSED != 0, true);
+    EXPECT(barrierSubmitterPtr->waitForSubmissions(1), true);
+    EXPECT(barrierSubmitterPtr->submittedIDs().at(0), UNPAUSED);
+    EXPECT(barrierSubmitterPtr->waitForSubmissions(2, 20ms), false);
+
+    EXPECT(barrierThread->resumeQueue(120), true);
+    EXPECT(barrierSubmitterPtr->waitForSubmissions(2, 20ms), false);
+    EXPECT(barrierThread->resumeQueue(120), true);
+    EXPECT(barrierSubmitterPtr->waitForSubmissions(2), true);
+    EXPECT(barrierSubmitterPtr->submittedIDs().at(1), PAUSED);
+    EXPECT(barrierThread->resumeQueue(120), false);
+
+    barrierSubmitterPtr->block();
+    auto activeBarrier         = makeRequest(19, 140, 1900);
+    activeBarrier->blocksQueue = false;
+    EXPECT(enqueue(*barrierThread, std::move(activeBarrier)) != 0, true);
+    EXPECT(barrierSubmitterPtr->waitForSubmissions(3), true);
+
+    auto pausing = std::async(std::launch::async, [&barrierThread] { return barrierThread->pauseQueue(140); });
+    EXPECT(pausing.wait_for(20ms) == std::future_status::timeout, true);
+    barrierSubmitterPtr->unblock();
+    EXPECT(pausing.wait_for(2s) == std::future_status::ready, true);
+    EXPECT(pausing.get(), true);
+    EXPECT(barrierThread->resumeQueue(140), true);
+    barrierThread->stopAndDrain();
 
     return ret;
 }

--- a/tests/Output.cpp
+++ b/tests/Output.cpp
@@ -1,6 +1,7 @@
 #include <aquamarine/output/Output.hpp>
 #include <aquamarine/backend/Backend.hpp>
 #include <hyprutils/memory/SharedPtr.hpp>
+#include <cerrno>
 #include "OutputTiming.hpp"
 #include "shared.hpp"
 
@@ -40,6 +41,46 @@ int main() {
 
     EXPECT(output.hasCursorPlane(), false);
     EXPECT(output.nextVBlank().has_value(), false);
+    EXPECT(output.commitCapabilities(), 0U);
+
+    const IOutput::SCommitOptions DEFAULT_OPTIONS;
+    EXPECT(DEFAULT_OPTIONS.targetPresentation.has_value(), false);
+    EXPECT(DEFAULT_OPTIONS.lateCursor, false);
+
+    bool                         resultFired        = false;
+    uint64_t                     resultID           = 0;
+    IOutput::eOutputCommitStatus resultStatus       = IOutput::AQ_OUTPUT_COMMIT_FAILED;
+    int                          resultError        = 0;
+    bool                         resultMissedTarget = false;
+    auto                         resultListener     = output.events.commitResult.listen([&](const IOutput::SCommitResult& event) {
+        resultFired        = true;
+        resultID           = event.id;
+        resultStatus       = event.status;
+        resultError        = event.error;
+        resultMissedTarget = event.missedTarget;
+    });
+
+    const auto                   SUBMISSION = output.commitAsync({});
+    EXPECT(SUBMISSION.id, 0U);
+    EXPECT(SUBMISSION.error, ENOTSUP);
+    EXPECT(resultFired, false);
+
+    output.events.commitResult.emit({
+        .id           = 42,
+        .status       = IOutput::AQ_OUTPUT_COMMIT_SUBMITTED,
+        .missedTarget = true,
+    });
+
+    EXPECT(resultFired, true);
+    EXPECT(resultID, 42U);
+    EXPECT(resultStatus, IOutput::AQ_OUTPUT_COMMIT_SUBMITTED);
+    EXPECT(resultError, 0);
+    EXPECT(resultMissedTarget, true);
+
+    const IOutput::SPresentEvent PRESENT_EVENT{
+        .commitID = 42,
+    };
+    EXPECT(PRESENT_EVENT.commitID, 42U);
 
     using namespace std::chrono_literals;
 

--- a/tests/Output.cpp
+++ b/tests/Output.cpp
@@ -2,6 +2,8 @@
 #include <aquamarine/backend/Backend.hpp>
 #include <hyprutils/memory/SharedPtr.hpp>
 #include <cerrno>
+#include <fcntl.h>
+#include <unistd.h>
 #include "OutputTiming.hpp"
 #include "shared.hpp"
 
@@ -15,7 +17,7 @@ class CTestOutput : public IOutput {
     }
 
     virtual bool test() {
-        return false;
+        return true;
     }
 
     virtual CSharedPointer<IBackendImplementation> getBackend() {
@@ -35,9 +37,98 @@ class CTestOutput : public IOutput {
     }
 };
 
+class CTestBuffer : public IBuffer {
+  public:
+    virtual eBufferCapability caps() {
+        return BUFFER_CAPABILITY_NONE;
+    }
+
+    virtual eBufferType type() {
+        return BUFFER_TYPE_MISC;
+    }
+
+    virtual void update(const Hyprutils::Math::CRegion& damage) {
+        ;
+    }
+
+    virtual bool isSynchronous() {
+        return true;
+    }
+
+    virtual bool good() {
+        return true;
+    }
+};
+
 int main() {
     int         ret = 0;
     CTestOutput output;
+
+    CTestBuffer buffer;
+    int         backendReleases = 0;
+    auto        releaseListener = buffer.events.backendRelease.listen([&] { backendReleases++; });
+
+    buffer.backendPin();
+    buffer.backendPin();
+    EXPECT(buffer.backendPinCount(), 2U);
+    EXPECT(buffer.lockedByBackend, true);
+    buffer.backendUnpin();
+    EXPECT(buffer.backendPinCount(), 1U);
+    EXPECT(buffer.lockedByBackend, true);
+    EXPECT(backendReleases, 0);
+    buffer.backendUnpin();
+    EXPECT(buffer.backendPinCount(), 0U);
+    EXPECT(buffer.lockedByBackend, false);
+    EXPECT(backendReleases, 1);
+    buffer.backendPin();
+    buffer.backendUnpin();
+    EXPECT(backendReleases, 2);
+
+    COutputState outputState;
+    outputState.setEnabled(true);
+    outputState.addDamage(Hyprutils::Math::CRegion{0, 0, 10, 10});
+    const auto FIRST_SNAPSHOT = outputState.snapshot();
+
+    outputState.setEnabled(false);
+    outputState.addDamage(Hyprutils::Math::CRegion{20, 20, 10, 10});
+    EXPECT(FIRST_SNAPSHOT.state().enabled, true);
+    EXPECT(FIRST_SNAPSHOT.state().damage.empty(), false);
+
+    outputState.consume(FIRST_SNAPSHOT);
+    EXPECT(outputState.state().enabled, false);
+    EXPECT(!!(outputState.state().committed & COutputState::AQ_OUTPUT_STATE_ENABLED), true);
+    EXPECT(!!(outputState.state().committed & COutputState::AQ_OUTPUT_STATE_DAMAGE), true);
+    EXPECT(outputState.state().damage.empty(), false);
+
+    const auto SECOND_SNAPSHOT = outputState.snapshot();
+    outputState.consume(SECOND_SNAPSHOT);
+    EXPECT(outputState.state().committed, 0U);
+    EXPECT(outputState.state().damage.empty(), true);
+
+    outputState.setFormat(DRM_FORMAT_XRGB8888);
+    outputState.setAdaptiveSync(true);
+    const auto PARTIAL_SNAPSHOT = outputState.snapshot();
+    outputState.setAdaptiveSync(false);
+    outputState.consume(PARTIAL_SNAPSHOT);
+    EXPECT(!!(outputState.state().committed & COutputState::AQ_OUTPUT_STATE_FORMAT), false);
+    EXPECT(!!(outputState.state().committed & COutputState::AQ_OUTPUT_STATE_ADAPTIVE_SYNC), true);
+
+    int pipeFDs[2] = {-1, -1};
+    EXPECT(pipe(pipeFDs), 0);
+    if (pipeFDs[0] >= 0) {
+        COutputState fenceState;
+        fenceState.setExplicitInFence(pipeFDs[0]);
+        const auto FENCE_SNAPSHOT = fenceState.snapshot();
+        EXPECT(FENCE_SNAPSHOT.error(), 0);
+        EXPECT(FENCE_SNAPSHOT.state().explicitInFence == pipeFDs[0], false);
+        close(pipeFDs[0]);
+        close(pipeFDs[1]);
+        EXPECT(fcntl(FENCE_SNAPSHOT.state().explicitInFence, F_GETFD) >= 0, true);
+    }
+
+    output.state->setEnabled(true);
+    EXPECT(output.test(), true);
+    EXPECT(!!(output.state->state().committed & COutputState::AQ_OUTPUT_STATE_ENABLED), true);
 
     EXPECT(output.hasCursorPlane(), false);
     EXPECT(output.nextVBlank().has_value(), false);

--- a/tests/Output.cpp
+++ b/tests/Output.cpp
@@ -105,6 +105,23 @@ int main() {
     EXPECT(outputState.state().committed, 0U);
     EXPECT(outputState.state().damage.empty(), true);
 
+    COutputState retryState;
+    retryState.setFormat(DRM_FORMAT_XRGB8888);
+    retryState.addDamage(Hyprutils::Math::CRegion{0, 0, 20, 20});
+    const auto RETRY_SNAPSHOT = retryState.snapshot();
+    retryState.consume(RETRY_SNAPSHOT);
+    EXPECT(retryState.state().committed, 0U);
+    retryState.rearm(RETRY_SNAPSHOT);
+    EXPECT(!!(retryState.state().committed & COutputState::AQ_OUTPUT_STATE_FORMAT), true);
+    EXPECT(!!(retryState.state().committed & COutputState::AQ_OUTPUT_STATE_DAMAGE), true);
+    EXPECT(retryState.state().damage.empty(), false);
+
+    const auto STALE_RETRY_SNAPSHOT = retryState.snapshot();
+    retryState.consume(STALE_RETRY_SNAPSHOT);
+    retryState.setFormat(DRM_FORMAT_ARGB8888);
+    retryState.rearm(STALE_RETRY_SNAPSHOT);
+    EXPECT(retryState.state().drmFormat, DRM_FORMAT_ARGB8888);
+
     outputState.setFormat(DRM_FORMAT_XRGB8888);
     outputState.setAdaptiveSync(true);
     const auto PARTIAL_SNAPSHOT = outputState.snapshot();


### PR DESCRIPTION
This adds infrastructure for async commits via a worker. Essentially, it's similar to KDE's approach, where we hold the commit until just before the deadline, then commit. It lets us update the cursor pos continuously before submitting, reducing input lag, esp on low hz screens.

Codex was used to assist with writing the code. It's not overly complex.